### PR TITLE
Remove duplicate README.md and fix typo for Broadcast Chat

### DIFF
--- a/Projects/CoX/CMakeLists.txt
+++ b/Projects/CoX/CMakeLists.txt
@@ -7,7 +7,7 @@ ADD_SUBDIRECTORY(Servers)
 ADD_SUBDIRECTORY(Clients)
 
 # Add README, settings.cfg, and Starter Databases
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/README.md ${EXECUTABLE_OUTPUT_PATH}/default_dbs/README.md COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/README.md ${EXECUTABLE_OUTPUT_PATH}/README.md COPYONLY)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Data/settings.cfg ${EXECUTABLE_OUTPUT_PATH}/default_dbs/settings.cfg COPYONLY)
 if(NOT EXISTS ${EXECUTABLE_OUTPUT_PATH}/settings.cfg)

--- a/Projects/CoX/CMakeLists.txt
+++ b/Projects/CoX/CMakeLists.txt
@@ -8,9 +8,6 @@ ADD_SUBDIRECTORY(Clients)
 
 # Add README, settings.cfg, and Starter Databases
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/README.md ${EXECUTABLE_OUTPUT_PATH}/default_dbs/README.md COPYONLY)
-if(NOT EXISTS ${EXECUTABLE_OUTPUT_PATH}/README.md)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/README.md ${EXECUTABLE_OUTPUT_PATH}/README.md COPYONLY)
-endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Data/settings.cfg ${EXECUTABLE_OUTPUT_PATH}/default_dbs/settings.cfg COPYONLY)
 if(NOT EXISTS ${EXECUTABLE_OUTPUT_PATH}/settings.cfg)

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -424,7 +424,7 @@ static ChatMessage::eChatTypes getKindOfChatMessage(const QStringRef &msg)
     if(msg.startsWith("l ") || msg.startsWith("local "))
         return ChatMessage::CHAT_Local;
     if(msg.startsWith("b ") || msg.startsWith("broadcast "))
-        return ChatMessage::CHAT_Local;
+        return ChatMessage::CHAT_Broadcast;
     // unknown chat types are processed as local chat
     return ChatMessage::CHAT_Local;
 }


### PR DESCRIPTION
Removes the duplicate copy of the new README from the default_dbs folder