### PR TITLE
Fixed issue with broadcast channel not working

### DIFF
--- a/Projects/CoX/Servers/AdminServer/CharacterDatabase.cpp
+++ b/Projects/CoX/Servers/AdminServer/CharacterDatabase.cpp
@@ -143,7 +143,7 @@ bool CharacterDatabase::fill( Character *c)
     CharacterCostume *main_costume = new CharacterCostume;
     // appearance related.
     main_costume->m_body_type = m_prepared_char_select.value("bodytype").toUInt(); // 0
-    c->setMapName("Some map name"); // "V_City_00_01.txt" STR_OR_EMPTY(r.getColString("current_map"))
+    c->setMapName(STR_OR_EMPTY(m_prepared_char_select.value("current_map").toString()));
     c->setLastCostumeId(m_prepared_char_select.value("last_costume_id").toUInt());
     main_costume->setSlotIndex(0);
     main_costume->setCharacterId(m_prepared_char_select.value("id").toULongLong());

--- a/Projects/CoX/Servers/MapServer/Events/ChatMessage.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/ChatMessage.cpp
@@ -13,7 +13,7 @@ void ChatMessage::do_serialize(BitStream &bs) const
     bs.StorePackedBits(1,20);
     bs.StorePackedBits(10,m_source_player_id);
     bs.StorePackedBits(3,m_channel_type);
-    bs.StoreString(m_msg);
+    bs.StoreString(" " + m_msg);
     bs.StorePackedBits(1,0); // no messages follow
 }
 
@@ -36,7 +36,7 @@ ChatMessage *ChatMessage::adminMessage(const QString &msg)
 ChatMessage *ChatMessage::localMessage(const QString &msg, Entity *src)
 {
     ChatMessage * res = new ChatMessage;
-    res->m_channel_type = CHAT_Local; // Still broadcasts because we have no way to determine local radius
+    res->m_channel_type = CHAT_Local;
     res->m_source_player_id=src->getIdx();
     res->m_msg = msg;
     return res;

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -23,8 +23,7 @@
 #include "InternalEvents.h"
 
 #include <QtCore/QDebug>
-#include <glm/glm.hpp>
-#include <glm/gtc/type_ptr.hpp>
+
 
 namespace {
 enum {
@@ -411,11 +410,11 @@ static bool isChatMessage(const QString &msg)
     return msg.startsWith("l ") || msg.startsWith("local ") ||
             msg.startsWith("b ") || msg.startsWith("broadcast ");
 }
-static ChatMessage::eChatTypes getKindOfChatMessage(const QStringRef &msg)
+static ChatMessage::eChatTypes getKindOfChatMessage(const QString &msg)
 {
-    if(msg.startsWith("l") || msg.startsWith("local"))
+    if(msg.startsWith("l ") || msg.startsWith("local "))
         return ChatMessage::CHAT_Local;
-    if(msg.startsWith("b") || msg.startsWith("broadcast"))
+    if(msg.startsWith("b ") || msg.startsWith("broadcast "))
         return ChatMessage::CHAT_Broadcast;
     // unknown chat types are processed as local chat
     return ChatMessage::CHAT_Local;
@@ -424,9 +423,9 @@ static ChatMessage::eChatTypes getKindOfChatMessage(const QStringRef &msg)
 void MapInstance::process_chat(MapClient *sender,const QString &msg_text)
 {
     int first_space = msg_text.indexOf(' ');
-    QStringRef cmd_str(msg_text.midRef(0,first_space));
+    //QStringRef cmd_str(msg_text.midRef(0,first_space));
     QStringRef msg_content(msg_text.midRef(first_space+1,-1));
-    ChatMessage::eChatTypes kind = getKindOfChatMessage(cmd_str);
+    ChatMessage::eChatTypes kind = getKindOfChatMessage(msg_text);
     std::vector<MapClient *> recipients;
     switch(kind)
     {

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -411,9 +411,9 @@ static bool isChatMessage(const QString &msg)
 }
 static ChatMessage::eChatTypes getKindOfChatMessage(const QStringRef &msg)
 {
-    if(msg.startsWith("l ") || msg.startsWith("local "))
+    if(msg.startsWith("l") || msg.startsWith("local"))
         return ChatMessage::CHAT_Local;
-    if(msg.startsWith("b ") || msg.startsWith("broadcast "))
+    if(msg.startsWith("b") || msg.startsWith("broadcast"))
         return ChatMessage::CHAT_Broadcast;
     // unknown chat types are processed as local chat
     return ChatMessage::CHAT_Local;


### PR DESCRIPTION
Removed superfluous space from check for chat commands. Fixes error with `/b` not working

Addresses #66 
