### PR TITLE
Added Smilex slash command which loads smlx folder from ./scripts/

### DIFF
--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -573,17 +573,17 @@ void MapInstance::on_console_command(ConsoleCommand * ev)
         src->addCommandToSendNextUpdate(std::unique_ptr<InfoMessageCmd>(info));
     }
     else if(ev->contents.startsWith("smilex ")) {
-        int first_space = ev->contents.indexOf(' ');
-        int second_space = ev->contents.indexOf(' ',first_space+1);
-        QString fileName(ev->contents.mid(second_space+1));
-        QFile file("./scripts/"+fileName);
-        if(QFileInfo::exists(fileName))
+        int space = ev->contents.indexOf(' ');
+        QString fileName("scripts/" + ev->contents.mid(space+1));
+        QFile file(fileName);
+        if(QFileInfo::exists(fileName) && file.open(QIODevice::ReadOnly | QIODevice::Text))
         {
-            StandardDialogCmd *dlg = new StandardDialogCmd(file.readAll());
+            QString contents(file.readAll());
+            StandardDialogCmd *dlg = new StandardDialogCmd(contents);
             src->addCommandToSendNextUpdate(std::unique_ptr<StandardDialogCmd>(dlg));
         }
         else {
-            QString errormsg = "Failed to load smilex file. File not found.";
+            QString errormsg = "Failed to load smilex file. \'" + file.fileName() + "\' not found.";
             qDebug() << errormsg;
             src->addCommandToSendNextUpdate(std::unique_ptr<ChatMessage>(ChatMessage::adminMessage(errormsg)));
         }

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -572,6 +572,22 @@ void MapInstance::on_console_command(ConsoleCommand * ev)
         }
         src->addCommandToSendNextUpdate(std::unique_ptr<InfoMessageCmd>(info));
     }
+    else if(ev->contents.startsWith("smilex ")) {
+        int first_space = ev->contents.indexOf(' ');
+        int second_space = ev->contents.indexOf(' ',first_space+1);
+        QString fileName(ev->contents.mid(second_space+1));
+        QFile file("./scripts/"+fileName);
+        if(QFileInfo::exists(fileName))
+        {
+            StandardDialogCmd *dlg = new StandardDialogCmd(file.readAll());
+            src->addCommandToSendNextUpdate(std::unique_ptr<StandardDialogCmd>(dlg));
+        }
+        else {
+            QString errormsg = "Failed to load smilex file. File not found.";
+            qDebug() << errormsg;
+            src->addCommandToSendNextUpdate(std::unique_ptr<ChatMessage>(ChatMessage::adminMessage(errormsg)));
+        }
+    }
 }
 void MapInstance::on_command_chat_divider_moved(ChatDividerMoved *ev)
 {

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -575,6 +575,8 @@ void MapInstance::on_console_command(ConsoleCommand * ev)
     else if(ev->contents.startsWith("smilex ")) {
         int space = ev->contents.indexOf(' ');
         QString fileName("scripts/" + ev->contents.mid(space+1));
+        if(!fileName.endsWith(".smlx"))
+                fileName.append(".smlx");
         QFile file(fileName);
         if(QFileInfo::exists(fileName) && file.open(QIODevice::ReadOnly | QIODevice::Text))
         {


### PR DESCRIPTION
First run at #155

Additions/modifications proposed in this pull request:
- add handler for /smilex {filename} command
- load contents of {filename} into dlg
- error msg if none found

ToDo:
- Parse smlx file?? Not sure the end goal with /smilex, is it just for testing only?
