### PR TITLE
[WIP] Calculate Hitpoints Base and Cap from Archetype

### DIFF
--- a/Projects/CoX/Common/GameData/CMakeLists.txt
+++ b/Projects/CoX/Common/GameData/CMakeLists.txt
@@ -20,6 +20,7 @@ set(GAMEDATA_SRC
     keybind_serializers.cpp
     keybind_serializers.h
     keybind_definitions.h
+    hitpoints_definitions.h
     #particlesys_serializers.cpp
     #particlesys_serializers.h
     costume_serializers.cpp

--- a/Projects/CoX/Common/GameData/hitpoints_definitions.h
+++ b/Projects/CoX/Common/GameData/hitpoints_definitions.h
@@ -1,0 +1,112 @@
+#pragma once
+#include <QtCore/QString>
+
+struct hp_base_values {
+    hp_base_values() : mod(), base() {}
+    hp_base_values(float m, float b)
+            : mod(m), base(b) {}
+    
+    float mod;
+    float base;
+};
+
+struct hp_archetype_values {
+    hp_archetype_values() : mod(), cap() {}
+    hp_archetype_values(float m, float c)
+            : mod(m), cap(c) {}
+    
+    float mod;
+    float cap;
+};
+
+QMap<int level, hp_base_values> hp_base_table = {
+    {1, {0.2, 100.0000}},
+    {2, {0.21, 110.5000}},
+    {3, {0.23, 121.7997}},
+    {4, {0.25, 133.9275}},
+    {5, {0.27, 146.9091}},
+    {6, {0.3, 160.7676}},
+    {7, {0.35, 175.5225}},
+    {8, {0.4, 191.1898}},
+    {9, {0.45, 207.7812}},
+    {10, {0.5, 225.3041}},
+    {11, {0.55, 243.7607}},
+    {12, {0.6, 263.1478}},
+    {13, {0.65, 283.4566}},
+    {14, {0.7, 304.6722}},
+    {15, {0.75, 326.7734}},
+    {16, {0.8, 349.7323}},
+    {17, {0.85, 373.5140}},
+    {18, {0.9, 398.0770}},
+    {19, {0.95, 423.3724}},
+    {20, {1, 449.3441}},
+    {21, {1, 475.9290}},
+    {22, {1, 503.0570}},
+    {23, {1, 530.6509}},
+    {24, {1, 558.6270}},
+    {25, {1, 586.8953}},
+    {26, {1, 615.3598}},
+    {27, {1, 643.9188}},
+    {28, {1, 672.4658}},
+    {29, {1, 700.8901}},
+    {30, {1, 729.0768}},
+    {31, {1, 756.9086}},
+    {32, {1, 784.2654}},
+    {33, {1, 811.0261}},
+    {34, {1, 837.0691}},
+    {35, {1, 862.2729}},
+    {36, {1, 886.5175}},
+    {37, {1, 909.6852}},
+    {38, {1, 931.6613}},
+    {39, {1, 952.3353}},
+    {40, {1, 971.6017}},
+    {41, {1, 989.3612}},
+    {42, {1, 1005.5210}},
+    {43, {1, 1019.9950}},
+    {44, {1, 1032.7080}},
+    {45, {1, 1043.5910}},
+    {46, {1, 1052.5850}},
+    {47, {1, 1059.6440}},
+    {48, {1, 1064.7290}},
+    {49, {1, 1067.8130}},
+    {50, {1, 1070.8970}},
+};
+
+QMap<QString m_archetype, hp_archetype_values> hp_archetype_table = {
+    {"Blaster", {1.125, 1}},
+    {"Controller", {0.95, 1}},
+    {"Defender", {0.95, 1}},
+    {"Scrapper", {1.25, 1.5}},
+    {"Tanker", {1.75, 2.2}},
+    {"Peacebringer", {1, 1.5}},
+    {"Warshade", {1, 1.5}},
+    {"Corruptor", {1, 1}},
+    {"Dominator", {0.95, 1}},
+    {"Mastermind", {0.75, 1}},
+    {"Brute", {1.4, 2}},
+    {"Stalker", {1.125, 1.3}},
+    {"Arachnos Soldier", {1, 1.5}},
+    {"Arachnos Widow", {1, 1.5}},
+};
+
+inline float get_HP_base(const Entity &src)
+{
+    // ( ( (Base HP Archetype Modifier - 1) * Level Modifier) + 1) * Level HP
+    float hp;
+    hp_archetype_values a_val = hp_archetype_table[QString(src.m_class_name)].value;
+    hp_base_values b_val = hp_base_table[src.m_level].value;
+    hp = (((a_val.mod - 1) * b_val.mod) + 1) * b_val.base;
+    
+    return hp;
+}
+
+inline float get_HP_cap(const Entity &src)
+{
+    // ( ( (Max HP Cap Archetype Modifier - 1) * Level Modifier) + 1) * 1.5 * Level HP
+    float hp;
+    hp_archetype_values a_val = hp_archetype_table[QString(src.m_class_name)].value;
+    hp_base_values b_val = hp_base_table[src.m_level].value;
+    hp = (((a_val.cap - 1) * b_val.mod) + 1) * 1.5 * b_val.base;
+    
+    return hp;
+}

--- a/Projects/CoX/Common/GameData/hitpoints_definitions.h
+++ b/Projects/CoX/Common/GameData/hitpoints_definitions.h
@@ -1,111 +1,119 @@
 #pragma once
+#include "Character.h"
 #include <QtCore/QString>
+#include <QtCore/QMap>
 
-struct hp_base_values {
-    hp_base_values() : mod(), base() {}
-    hp_base_values(float m, float b)
+struct HPBaseValues {
+    HPBaseValues() : mod(), base() {}
+    HPBaseValues(float m, float b)
             : mod(m), base(b) {}
     
     float mod;
     float base;
-};
+} hp_base_table[50];
 
-struct hp_archetype_values {
-    hp_archetype_values() : mod(), cap() {}
-    hp_archetype_values(float m, float c)
+struct HPArchetypeValues {
+    HPArchetypeValues() : mod(), cap() {}
+    HPArchetypeValues(float m, float c)
             : mod(m), cap(c) {}
     
     float mod;
     float cap;
 };
 
-QMap<int level, hp_base_values> hp_base_table = {
-    {1, {0.2, 100.0000}},
-    {2, {0.21, 110.5000}},
-    {3, {0.23, 121.7997}},
-    {4, {0.25, 133.9275}},
-    {5, {0.27, 146.9091}},
-    {6, {0.3, 160.7676}},
-    {7, {0.35, 175.5225}},
-    {8, {0.4, 191.1898}},
-    {9, {0.45, 207.7812}},
-    {10, {0.5, 225.3041}},
-    {11, {0.55, 243.7607}},
-    {12, {0.6, 263.1478}},
-    {13, {0.65, 283.4566}},
-    {14, {0.7, 304.6722}},
-    {15, {0.75, 326.7734}},
-    {16, {0.8, 349.7323}},
-    {17, {0.85, 373.5140}},
-    {18, {0.9, 398.0770}},
-    {19, {0.95, 423.3724}},
-    {20, {1, 449.3441}},
-    {21, {1, 475.9290}},
-    {22, {1, 503.0570}},
-    {23, {1, 530.6509}},
-    {24, {1, 558.6270}},
-    {25, {1, 586.8953}},
-    {26, {1, 615.3598}},
-    {27, {1, 643.9188}},
-    {28, {1, 672.4658}},
-    {29, {1, 700.8901}},
-    {30, {1, 729.0768}},
-    {31, {1, 756.9086}},
-    {32, {1, 784.2654}},
-    {33, {1, 811.0261}},
-    {34, {1, 837.0691}},
-    {35, {1, 862.2729}},
-    {36, {1, 886.5175}},
-    {37, {1, 909.6852}},
-    {38, {1, 931.6613}},
-    {39, {1, 952.3353}},
-    {40, {1, 971.6017}},
-    {41, {1, 989.3612}},
-    {42, {1, 1005.5210}},
-    {43, {1, 1019.9950}},
-    {44, {1, 1032.7080}},
-    {45, {1, 1043.5910}},
-    {46, {1, 1052.5850}},
-    {47, {1, 1059.6440}},
-    {48, {1, 1064.7290}},
-    {49, {1, 1067.8130}},
-    {50, {1, 1070.8970}},
-};
+inline void getBaseHP()
+{
+    hp_base_table[1] = HPBaseValues(0.2,100.0000);
+    hp_base_table[2] = HPBaseValues(0.21, 110.5000);
+    hp_base_table[3] = HPBaseValues(0.23, 121.7997);
+    hp_base_table[4] = HPBaseValues(0.25, 133.9275);
+    hp_base_table[5] = HPBaseValues(0.27, 146.9091);
+    hp_base_table[6] = HPBaseValues(0.3, 160.7676);
+    hp_base_table[7] = HPBaseValues(0.35, 175.5225);
+    hp_base_table[8] = HPBaseValues(0.4, 191.1898);
+    hp_base_table[9] = HPBaseValues(0.45, 207.7812);
+    hp_base_table[10] = HPBaseValues(0.5, 225.3041);
+    hp_base_table[11] = HPBaseValues(0.55, 243.7607);
+    hp_base_table[12] = HPBaseValues(0.6, 263.1478);
+    hp_base_table[13] = HPBaseValues(0.65, 283.4566);
+    hp_base_table[14] = HPBaseValues(0.7, 304.6722);
+    hp_base_table[15] = HPBaseValues(0.75, 326.7734);
+    hp_base_table[16] = HPBaseValues(0.8, 349.7323);
+    hp_base_table[17] = HPBaseValues(0.85, 373.5140);
+    hp_base_table[18] = HPBaseValues(0.9, 398.0770);
+    hp_base_table[19] = HPBaseValues(0.95, 423.3724);
+    hp_base_table[20] = HPBaseValues(1, 449.3441);
+    hp_base_table[21] = HPBaseValues(1, 475.9290);
+    hp_base_table[22] = HPBaseValues(1, 503.0570);
+    hp_base_table[23] = HPBaseValues(1, 530.6509);
+    hp_base_table[24] = HPBaseValues(1, 558.6270);
+    hp_base_table[25] = HPBaseValues(1, 586.8953);
+    hp_base_table[26] = HPBaseValues(1, 615.3598);
+    hp_base_table[27] = HPBaseValues(1, 643.9188);
+    hp_base_table[28] = HPBaseValues(1, 672.4658);
+    hp_base_table[29] = HPBaseValues(1, 700.8901);
+    hp_base_table[30] = HPBaseValues(1, 729.0768);
+    hp_base_table[31] = HPBaseValues(1, 756.9086);
+    hp_base_table[32] = HPBaseValues(1, 784.2654);
+    hp_base_table[33] = HPBaseValues(1, 811.0261);
+    hp_base_table[34] = HPBaseValues(1, 837.0691);
+    hp_base_table[35] = HPBaseValues(1, 862.2729);
+    hp_base_table[36] = HPBaseValues(1, 886.5175);
+    hp_base_table[37] = HPBaseValues(1, 909.6852);
+    hp_base_table[38] = HPBaseValues(1, 931.6613);
+    hp_base_table[39] = HPBaseValues(1, 952.3353);
+    hp_base_table[40] = HPBaseValues(1, 971.6017);
+    hp_base_table[41] = HPBaseValues(1, 989.3612);
+    hp_base_table[42] = HPBaseValues(1, 1005.5210);
+    hp_base_table[43] = HPBaseValues(1, 1019.9950);
+    hp_base_table[44] = HPBaseValues(1, 1032.7080);
+    hp_base_table[45] = HPBaseValues(1, 1043.5910);
+    hp_base_table[46] = HPBaseValues(1, 1052.5850);
+    hp_base_table[47] = HPBaseValues(1, 1059.6440);
+    hp_base_table[48] = HPBaseValues(1, 1064.7290);
+    hp_base_table[49] = HPBaseValues(1, 1067.8130);
+    hp_base_table[50] = HPBaseValues(1, 1070.8970);
+}
 
-QMap<QString m_archetype, hp_archetype_values> hp_archetype_table = {
-    {"Blaster", {1.125, 1}},
-    {"Controller", {0.95, 1}},
-    {"Defender", {0.95, 1}},
-    {"Scrapper", {1.25, 1.5}},
-    {"Tanker", {1.75, 2.2}},
-    {"Peacebringer", {1, 1.5}},
-    {"Warshade", {1, 1.5}},
-    {"Corruptor", {1, 1}},
-    {"Dominator", {0.95, 1}},
-    {"Mastermind", {0.75, 1}},
-    {"Brute", {1.4, 2}},
-    {"Stalker", {1.125, 1.3}},
-    {"Arachnos Soldier", {1, 1.5}},
-    {"Arachnos Widow", {1, 1.5}},
-};
+static QMap<QString, HPArchetypeValues> hp_archetype_table;
 
-inline float get_HP_base(const Entity &src)
+inline void getArchetypeHPMod()
+{
+    hp_archetype_table["Blaster"] = HPArchetypeValues(1.125, 1);
+    hp_archetype_table["Controller"] = HPArchetypeValues(0.95, 1);
+    hp_archetype_table["Defender"] = HPArchetypeValues(0.95, 1);
+    hp_archetype_table["Scrapper"] = HPArchetypeValues(1.25, 1.5);
+    hp_archetype_table["Tanker"] = HPArchetypeValues(1.75, 2.2);
+    hp_archetype_table["Peacebringer"] = HPArchetypeValues(1, 1.5);
+    hp_archetype_table["Warshade"] = HPArchetypeValues(1, 1.5);
+    hp_archetype_table["Corruptor"] = HPArchetypeValues(1, 1);
+    hp_archetype_table["Dominator"] = HPArchetypeValues(0.95, 1);
+    hp_archetype_table["Mastermind"] = HPArchetypeValues(0.75, 1);
+    hp_archetype_table["Brute"] = HPArchetypeValues(1.4, 2);
+    hp_archetype_table["Stalker"] = HPArchetypeValues(1.125, 1.3);
+    hp_archetype_table["Arachnos Soldier"] = HPArchetypeValues(1, 1.5);
+    hp_archetype_table["Arachnos Widow"] = HPArchetypeValues(1, 1.5);
+}
+
+inline float setHPBase(const Character *src)
 {
     // ( ( (Base HP Archetype Modifier - 1) * Level Modifier) + 1) * Level HP
     float hp;
-    hp_archetype_values a_val = hp_archetype_table[QString(src.m_class_name)].value;
-    hp_base_values b_val = hp_base_table[src.m_level].value;
+    QString m_class_name = src->getClass();
+    HPArchetypeValues a_val = hp_archetype_table[m_class_name];
+    HPBaseValues b_val = hp_base_table[src->getLevel()];
     hp = (((a_val.mod - 1) * b_val.mod) + 1) * b_val.base;
     
     return hp;
 }
 
-inline float get_HP_cap(const Entity &src)
+inline float setArchetypeHPMod(const Character *src)
 {
     // ( ( (Max HP Cap Archetype Modifier - 1) * Level Modifier) + 1) * 1.5 * Level HP
     float hp;
-    hp_archetype_values a_val = hp_archetype_table[QString(src.m_class_name)].value;
-    hp_base_values b_val = hp_base_table[src.m_level].value;
+    QString m_class_name = src->getClass();
+    HPArchetypeValues a_val = hp_archetype_table[m_class_name];
+    HPBaseValues b_val = hp_base_table[src->getLevel()];
     hp = (((a_val.cap - 1) * b_val.mod) + 1) * 1.5 * b_val.base;
     
     return hp;

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -10,6 +10,7 @@
 #include "BitStream.h"
 #include "Costume.h"
 #include "GameData/keybind_definitions.h"
+#include "GameData/hitpoints_definitions.h"
 #include <QtCore/QString>
 #include <QtCore/QDebug>
 
@@ -67,6 +68,9 @@ void Character::serializefrom( BitStream &src)
     src.GetString(m_origin_name);
     m_unkn1 =src.GetFloat();
     m_unkn2 =src.GetFloat();
+    qDebug() << m_unkn1;
+    qDebug() << m_unkn2;
+    
     src.GetString(m_mapName);
     /*uint32_t unkn3 =*/ src.GetPackedBits(1);
     //uint32_t unkn4 = src.GetBits(32);
@@ -85,6 +89,7 @@ void Character::serializeto( BitStream &tgt) const
     //tgt.StorePackedBits(1,m_villain);
     tgt.StoreString(m_mapName);
     tgt.StorePackedBits(1,m_unkn3);
+    qDebug() << m_unkn3;
     //tgt.StorePackedBits(32,m_unkn4); // if != 0 UpdateCharacter is called
 }
 void Character::sendWindow(BitStream &bs) const

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -29,7 +29,7 @@ Character::Character()
     m_supergroup_costume=false;
     m_sg_costume=nullptr;
     m_using_sg_costume=false;
-    m_current_attribs.m_HitPoints = 25;
+    m_current_attribs.m_HitPoints = 45; // setHPBase(self)
     m_max_attribs.m_HitPoints = 50;
     m_current_attribs.m_Endurance = 33;
     m_max_attribs.m_Endurance = 43;

--- a/Projects/CoX/Common/NetStructures/Entity.cpp
+++ b/Projects/CoX/Common/NetStructures/Entity.cpp
@@ -35,6 +35,9 @@ void Entity::fillFromCharacter(Character *f)
 {
     m_char = *f;
     m_hasname = true;
+    m_class_name = f->getClass();
+    m_origin_name = f->getOrigin();
+    m_level = f->getLevel();
     //TODO: map class/origin name to Entity's class/orign indices.
 }
 /**

--- a/Projects/CoX/Common/NetStructures/Entity.h
+++ b/Projects/CoX/Common/NetStructures/Entity.h
@@ -184,6 +184,9 @@ public:
         size_t              m_update_idx=0;
         std::vector<PosUpdate> interpResults;
         bool                m_has_the_prefix=false;
+        QString             m_class_name;
+        QString             m_origin_name;
+        uint8_t             m_level=0;
         QString             m_battle_cry;
         QString             m_character_description;
         bool                var_B4=0;


### PR DESCRIPTION
Based upon the data at https://paragonwiki.com/wiki/Hit_Points

This PR aims to configure the default values for HP and HP cap based upon archetype. As far as I can tell this information isn't stored client-side, so we need to define it server-side.

**Marking this [WIP] because while it compiles cleanly, I can't figure out how to feed the character entity to my `setHPBase()` class in Character.cpp:**
https://github.com/broxen/Segs/blob/16a70841f482a168ac4b473f0da3f79898f3c4c1/Projects/CoX/Common/NetStructures/Character.cpp#L32

- [X] Add hitpoints_definitions.h
- [X] Shared class, level and origin with Entity (because comments mentioned it)
- [X] Add Hitpoint Mod and Cap Values
- [X] Added debug output for `m_unkn1 m_unkn2 m_unkn3` because I suspect these have to do with HP/Endurance
- [ ] Reference these values when first creating a character
- [ ] Eventually pull this data from a lua table in hitpoints.lua

I know that my feeble attempts at coding are probably more annoyance than actual help, but I'm trying to do what I can. Please know that I'm completely open to learning a better way to do what I'm trying to achieve here, or focusing on specific tasks that you feel need attention.

On that note, I know you're super busy Nem, but whenever you have a little bit of spare time, if you can point me in the right direction with the final piece of this, I'd appreciate it. I'll keep researching in the meantime and will update here if I discover my own solution.