### PR TITLE
Add experience per level and debt to MapServerData

### DIFF
--- a/Projects/CoX/Common/GameData/def_serializers.cpp
+++ b/Projects/CoX/Common/GameData/def_serializers.cpp
@@ -109,12 +109,12 @@ bool loadFrom(BinStore *s,Parse_Origin *target) {
     return ok;
 }
 }
-bool loadFrom(BinStore *s,LevelExpAndDebt * target)
+bool loadFrom(BinStore *s, LevelExpAndDebt & target)
 {
     s->prepare();
     bool ok = true;
-    ok &= s->read(target->m_ExperienceRequired);
-    ok &= s->read(target->m_DefeatPenalty);
+    ok &= s->read(target.m_ExperienceRequired);
+    ok &= s->read(target.m_DefeatPenalty);
     ok &= s->prepare_nested(); // will update the file size left
     assert(ok);
     return ok;

--- a/Projects/CoX/Common/GameData/def_serializers.h
+++ b/Projects/CoX/Common/GameData/def_serializers.h
@@ -11,7 +11,7 @@ struct Parse_PI_Schedule;
 typedef std::vector<struct Parse_Origin> Parse_AllOrigins;
 
 constexpr const static uint32_t levelsdebts_i0_requiredCrc = 0x8F0D1A87;
-bool loadFrom(BinStore *s,LevelExpAndDebt *target);
+bool loadFrom(BinStore *s,LevelExpAndDebt &target);
 void saveTo(const LevelExpAndDebt & target, const QString &baseName, bool text_format=false);
 
 constexpr const static uint32_t combining_i0_requiredCrc = 0x7F06A6D1;

--- a/Projects/CoX/Servers/MapServer/MapServerData.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServerData.cpp
@@ -206,6 +206,8 @@ bool MapServerData::read_runtime_data(const QString &directory_path)
         return false;
     if (!read_classes(directory_path))
         return false;
+    if(!read_exp_and_debt(directory_path))
+        return false;
     qWarning().noquote() << " All map data read";
     {
         QDebug warnLine = qWarning().noquote();
@@ -214,6 +216,18 @@ bool MapServerData::read_runtime_data(const QString &directory_path)
         warnLine << "Hashes filled";
     }
     return true;
+}
+
+int MapServerData::expForLevel(int lev) const
+{
+    assert(lev>0 && lev<m_experience_and_debt_per_level.m_ExperienceRequired.size());
+    return m_experience_and_debt_per_level.m_ExperienceRequired.at(lev - 1);
+}
+
+int MapServerData::expDebtForLevel(int lev) const
+{
+    assert(lev>0 && lev<m_experience_and_debt_per_level.m_DefeatPenalty.size());
+    return m_experience_and_debt_per_level.m_DefeatPenalty.at(lev - 1);
 }
 
 bool MapServerData::read_costumes(const QString &directory_path)
@@ -277,6 +291,15 @@ bool MapServerData::read_classes(const QString &directory_path)
     if(!read_data_to<Parse_AllCharClasses,charclass_i0_requiredCrc>(directory_path,"classes.bin",m_player_classes))
         return false;
     if(!read_data_to<Parse_AllCharClasses,charclass_i0_requiredCrc>(directory_path,"villain_classes.bin",m_other_classes))
+        return false;
+    return true;
+}
+
+bool MapServerData::read_exp_and_debt(const QString &directory_path)
+{
+    qDebug() << "Loading classes:";
+    if (!read_data_to<LevelExpAndDebt, levelsdebts_i0_requiredCrc>(directory_path, "classes.bin",
+                                                                   m_experience_and_debt_per_level))
         return false;
     return true;
 }

--- a/Projects/CoX/Servers/MapServer/MapServerData.h
+++ b/Projects/CoX/Servers/MapServer/MapServerData.h
@@ -4,24 +4,32 @@
 #include "Common/GameData/costume_definitions.h"
 #include "Common/GameData/origin_definitions.h"
 #include "Common/GameData/charclass_definitions.h"
+#include "Common/GameData/other_definitions.h"
+
 class ColorAndPartPacker;
 class QString;
 class MapServerData
 {
         ColorAndPartPacker *packer_instance;
+        LevelExpAndDebt m_experience_and_debt_per_level;
+
         bool            read_costumes(const QString &directory_path);
         bool            read_colors(const QString &src_filename);
         bool            read_origins(const QString &src_filename);
         bool            read_classes(const QString &src_filename);
+        bool            read_exp_and_debt(const QString &src_filename);
 public:
                         MapServerData();
                         ~MapServerData();
         bool            read_runtime_data(const QString &directory_path);
         ColorAndPartPacker *getPacker() { return packer_instance; }
-        Pallette_Data   m_supergroup_colors;
-        CostumeSet_Data m_costume_store;
-        Parse_AllOrigins m_player_origins;
-        Parse_AllOrigins m_other_origins;
+        int             expForLevel(int lev) const;
+        int             expDebtForLevel(int lev) const;
+
+        Pallette_Data        m_supergroup_colors;
+        CostumeSet_Data      m_costume_store;
+        Parse_AllOrigins     m_player_origins;
+        Parse_AllOrigins     m_other_origins;
         Parse_AllCharClasses m_player_classes;
         Parse_AllCharClasses m_other_classes;
 };

--- a/Projects/CoX/Utilities/BinConverter/binConverter.cpp
+++ b/Projects/CoX/Utilities/BinConverter/binConverter.cpp
@@ -16,6 +16,7 @@
 #include "Common/GameData/charclass_serializers.h"
 //#include "Common/GameData/seq_serializers.h"
 #include "Common/GameData/def_serializers.h"
+#include "Common/GameData/other_definitions.h"
 #include "Common/GameData/origin_definitions.h"
 //#include "Common/GameData/particlesys_serializers.h"
 
@@ -49,7 +50,7 @@ enum BinType {
     eTrickDefinitions,
 };
 const QHash<uint32_t,BinType> knownSerializers = {
-//    {levelsdebts_i0_requiredCrc         , eLevelsDebts},
+    {levelsdebts_i0_requiredCrc         , eLevelsDebts},
 //    {combining_i0_requiredCrc           , eCombineChances},
 //    {boosteffectiveness_i0_requiredCrc  , eBoostEffectiveness},
 //    {particlesystems_i0_requiredCrc     , eParticleSystems},
@@ -113,6 +114,7 @@ bool doConvert(T *src_struct,const QString &fname,bool text_format=false)
 void showSupportedBinTypes()
 {
     qDebug()<<"Currently supported file types ";
+    qDebug()<<"   I0<"<<QString::number(levelsdebts_i0_requiredCrc,16)<<"> Experience data - 'experience.bin'";
     qDebug()<<"   I0<"<<QString::number(shoplist_i0_requiredCrc,16)<<"> Shops data - 'stores.bin'";
     qDebug()<<"   I0<"<<QString::number(shopitems_i0_requiredCrc,16)<<"> Shops items- 'items.bin'";
     qDebug()<<"   I0<"<<QString::number(shopdepts_i0_requiredCrc,16)<<"> Shop department names data - 'depts.bin'";
@@ -152,10 +154,10 @@ int main(int argc,char **argv)
         json_output = app.arguments()[2].toInt()!=0;
 
     switch(bin_type) {
-//        case eLevelsDebts:    doConvert(doLoad<LevelExpAndDebt>(binfile),target_basename,json_output); break;
-//        case eCombineChances: doConvert(doLoad<Parse_Combining>(binfile),target_basename,json_output); break;
-//        case eBoostEffectiveness: doConvert(doLoad<Parse_Effectiveness>(binfile),target_basename,json_output); break;
-//        case eParticleSystems:doConvert(doLoad<Parse_AllPSystems>(binfile),target_basename,json_output); break;
+        case eLevelsDebts:    doConvert(doLoadRef<LevelExpAndDebt>(&binfile),target_basename,json_output); break;
+//        case eCombineChances: doConvert(doLoad<Parse_Combining>(&binfile),target_basename,json_output); break;
+//        case eBoostEffectiveness: doConvert(doLoad<Parse_Effectiveness>(&binfile),target_basename,json_output); break;
+//        case eParticleSystems:doConvert(doLoad<Parse_AllPSystems>(&binfile),target_basename,json_output); break;
         case eShops:        doConvert(doLoadRef<AllShops_Data>(&binfile),target_basename,json_output); break;
         case eShopItems:    doConvert(doLoad<AllShopItems_Data>(&binfile),target_basename,json_output); break;
         case eShopDepts:    doConvert(doLoad<AllShopDepts_Data>(&binfile),target_basename,json_output); break;


### PR DESCRIPTION
Closes #176 .

Additions/modifications proposed in this pull request:
- experience.bin is handled by binConverter
- experience and debt data is available from MapServerData

