### PR TITLE
Qsettings wrapper Settings

### DIFF
--- a/Components/CMakeLists.txt
+++ b/Components/CMakeLists.txt
@@ -9,6 +9,7 @@ SET(target_CPP
     EventProcessor.cpp
     SEGSTimer.cpp
     FixedPointValue.cpp
+    Settings.cpp
 )
 SET(target_INCLUDE
     BitStream.h
@@ -19,6 +20,7 @@ SET(target_INCLUDE
     LinkLevelEvent.h
     SEGSTimer.h
     FixedPointValue.h
+    Settings.h
 )
 
 SET(target_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -1,0 +1,119 @@
+/*
+ * Super Entity Game Server
+ * http://github.com/Segs
+ * Copyright (c) 2006 - 2018 Super Entity Game Server Team (see Authors.txt)
+ * This software is licensed! (See License.txt for details)
+ *
+ */
+ 
+#include "Settings.h"
+
+Settings * Settings::m_settings = NULL;
+
+bool fileExists(QString path) {
+    QFileInfo check_file(path);
+    // check if file exists and if yes: Is it really a file and no directory?
+    return check_file.exists() && check_file.isFile();
+}
+
+Settings::Settings()
+{
+    if (!fileExists(m_settings_path))
+        createSettingsFile();
+
+    if(!m_settings)
+        m_settings = QSettings m_settings(m_settings_path,QSettings::IniFormat);
+}
+
+Settings *Settings::getSettings()
+{
+    if (!m_settings)
+        m_settings =  new Settings();
+
+    return m_settings;
+}
+
+void Settings::createSettingsFile()
+{
+    if (!fileExists(m_settings_path))
+    {
+        qCritical() << "Settings file" << m_settings_path <<"does not exist. Creating it now...";
+        m_settings_file = new QFile(m_settings_path);
+        if(!m_settings_file->open(QIODevice::WriteOnly))
+        {
+            qDebug() << "Unable to create" << m_settings_path << "Check folder permissions.";
+            return;
+        }
+        m_settings_file->close();
+        
+        if(!m_settings)
+            m_settings = QSettings m_settings(m_settings_path,QSettings::IniFormat);
+        
+        setDefaultSettings();
+        
+        return;
+    }
+    else
+    {
+        qDebug() << "Settings file already exists at" << m_settings_path;
+        return;
+    }
+}
+
+void Settings::setDefaultSettings()
+{
+    m_settings.beginGroup("AdminServer");
+        m_settings.beginGroup("AccountDatabase");
+            m_settings.setValue("db_driver","QSQLITE");
+            m_settings.value("db_host","127.0.0.1").toString();
+            m_settings.value("db_port","5432").toString();
+            m_settings.value("db_name","segs").toString();
+            m_settings.value("db_user","none").toString();
+            m_settings.value("db_pass","none").toString();
+        m_settings.endGroup();
+        m_settings.beginGroup("CharacterDatabase");
+            m_settings.setValue("db_driver","QSQLITE");
+            m_settings.value("db_host","127.0.0.1").toString();
+            m_settings.value("db_port","5432").toString();
+            m_settings.value("db_name","segs_game").toString();
+            m_settings.value("db_user","none").toString();
+            m_settings.value("db_pass","none").toString();
+        m_settings.endGroup();
+    m_settings.endGroup();
+    m_settings.beginGroup("AuthServer");
+        m_settings.value("listen_addr","127.0.0.1:2106").toString();
+    m_settings.endGroup();
+    m_settings.beginGroup("GameServer");
+        m_settings.value("server_name","SEGS Server").toString();
+        m_settings.value("listen_addr","127.0.0.1:7002").toString();
+        m_settings.value("location_addr","127.0.0.1:7002").toString();
+        m_settings.value("max_players","200").toInt();
+        m_settings.value("max_account_slots","8").toInt();
+    m_settings.endGroup();
+    m_settings.beginGroup("MapServer");
+        m_settings.value("listen_addr","127.0.0.1:7003").toString();
+        m_settings.value("location_addr","127.0.0.1:7003").toString();
+    m_settings.endGroup();
+    
+    m_settings.sync(); // sync changes
+}
+
+void Settings::dump()
+{
+    QString output;
+    QSettings* settings = Settings::getSettings();
+    foreach (const QString &group, settings->childGroups()) {
+        QString groupString = QString("===== %1 =====\n").arg(group);
+        settings->beginGroup(group);
+    
+        foreach (const QString &key, settings->childKeys()) {
+            groupString.append(QString("  %1\t %2\n").arg(key, settings->value(key).toString()));
+        }
+        
+        settings->endGroup();
+        groupString.append("\n");
+    
+        output.append(groupString);
+    }
+    qDebug() << output;
+}

--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -8,8 +8,6 @@
  
 #include "Settings.h"
 
-Settings * Settings::m_settings = NULL;
-
 bool fileExists(QString path) {
     QFileInfo check_file(path);
     // check if file exists and if yes: Is it really a file and no directory?
@@ -22,10 +20,10 @@ Settings::Settings()
         createSettingsFile();
 
     if(!m_settings)
-        m_settings = QSettings m_settings(m_settings_path,QSettings::IniFormat);
+        QSettings m_settings(m_settings_path,QSettings::IniFormat);
 }
 
-Settings *Settings::getSettings()
+QSettings *Settings::getSettings()
 {
     if (!m_settings)
         m_settings =  new Settings();
@@ -38,16 +36,16 @@ void Settings::createSettingsFile()
     if (!fileExists(m_settings_path))
     {
         qCritical() << "Settings file" << m_settings_path <<"does not exist. Creating it now...";
-        m_settings_file = new QFile(m_settings_path);
-        if(!m_settings_file->open(QIODevice::WriteOnly))
+        QFile m_settings_file(m_settings_path);
+        if(!m_settings_file.open(QIODevice::WriteOnly))
         {
             qDebug() << "Unable to create" << m_settings_path << "Check folder permissions.";
             return;
         }
-        m_settings_file->close();
+        m_settings_file.close();
         
         if(!m_settings)
-            m_settings = QSettings m_settings(m_settings_path,QSettings::IniFormat);
+            QSettings m_settings(m_settings_path,QSettings::IniFormat);
         
         setDefaultSettings();
         
@@ -62,46 +60,46 @@ void Settings::createSettingsFile()
 
 void Settings::setDefaultSettings()
 {
-    m_settings.beginGroup("AdminServer");
-        m_settings.beginGroup("AccountDatabase");
-            m_settings.setValue("db_driver","QSQLITE");
-            m_settings.value("db_host","127.0.0.1").toString();
-            m_settings.value("db_port","5432").toString();
-            m_settings.value("db_name","segs").toString();
-            m_settings.value("db_user","none").toString();
-            m_settings.value("db_pass","none").toString();
-        m_settings.endGroup();
-        m_settings.beginGroup("CharacterDatabase");
-            m_settings.setValue("db_driver","QSQLITE");
-            m_settings.value("db_host","127.0.0.1").toString();
-            m_settings.value("db_port","5432").toString();
-            m_settings.value("db_name","segs_game").toString();
-            m_settings.value("db_user","none").toString();
-            m_settings.value("db_pass","none").toString();
-        m_settings.endGroup();
-    m_settings.endGroup();
-    m_settings.beginGroup("AuthServer");
-        m_settings.value("listen_addr","127.0.0.1:2106").toString();
-    m_settings.endGroup();
-    m_settings.beginGroup("GameServer");
-        m_settings.value("server_name","SEGS Server").toString();
-        m_settings.value("listen_addr","127.0.0.1:7002").toString();
-        m_settings.value("location_addr","127.0.0.1:7002").toString();
-        m_settings.value("max_players","200").toInt();
-        m_settings.value("max_account_slots","8").toInt();
-    m_settings.endGroup();
-    m_settings.beginGroup("MapServer");
-        m_settings.value("listen_addr","127.0.0.1:7003").toString();
-        m_settings.value("location_addr","127.0.0.1:7003").toString();
-    m_settings.endGroup();
+    m_settings->beginGroup("AdminServer");
+        m_settings->beginGroup("AccountDatabase");
+            m_settings->setValue("db_driver","QSQLITE");
+            m_settings->value("db_host","127.0.0.1").toString();
+            m_settings->value("db_port","5432").toString();
+            m_settings->value("db_name","segs").toString();
+            m_settings->value("db_user","none").toString();
+            m_settings->value("db_pass","none").toString();
+        m_settings->endGroup();
+        m_settings->beginGroup("CharacterDatabase");
+            m_settings->setValue("db_driver","QSQLITE");
+            m_settings->value("db_host","127.0.0.1").toString();
+            m_settings->value("db_port","5432").toString();
+            m_settings->value("db_name","segs_game").toString();
+            m_settings->value("db_user","none").toString();
+            m_settings->value("db_pass","none").toString();
+        m_settings->endGroup();
+    m_settings->endGroup();
+    m_settings->beginGroup("AuthServer");
+        m_settings->value("listen_addr","127.0.0.1:2106").toString();
+    m_settings->endGroup();
+    m_settings->beginGroup("GameServer");
+        m_settings->value("server_name","SEGS Server").toString();
+        m_settings->value("listen_addr","127.0.0.1:7002").toString();
+        m_settings->value("location_addr","127.0.0.1:7002").toString();
+        m_settings->value("max_players","200").toInt();
+        m_settings->value("max_account_slots","8").toInt();
+    m_settings->endGroup();
+    m_settings->beginGroup("MapServer");
+        m_settings->value("listen_addr","127.0.0.1:7003").toString();
+        m_settings->value("location_addr","127.0.0.1:7003").toString();
+    m_settings->endGroup();
     
-    m_settings.sync(); // sync changes
+    m_settings->sync(); // sync changes
 }
 
 void Settings::dump()
 {
     QString output;
-    QSettings* settings = Settings::getSettings();
+    QSettings* settings = getSettings();
     foreach (const QString &group, settings->childGroups()) {
         QString groupString = QString("===== %1 =====\n").arg(group);
         settings->beginGroup(group);

--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -26,7 +26,12 @@ QSettings *Settings::getSettings()
         s.createSettingsFile();
 
     static QSettings m_settings(s.getSettingsPath(),QSettings::IniFormat);
+    //if(!s.m_settings.contains("AuthServer/location_addr"))
+    //{
+    //    s.m_settings.setPath(QSettings::IniFormat,QSettings::SystemScope,s.getSettingsPath());
+    //}
 
+    settingsDump(&m_settings); // Settings are correct
     return &m_settings;
 }
 
@@ -99,48 +104,53 @@ void Settings::createSettingsFile()
 // TODO: Any time you set settings values it deletes all file comments. There is no known workaround.
 void Settings::setDefaultSettings()
 {
-    QSettings *s = getSettings();
+    QSettings s(getSettings());
 
-    s->beginGroup("AdminServer");
-        s->beginGroup("AccountDatabase");
-            s->setValue("db_driver","QSQLITE");
-            s->setValue("db_host","127.0.0.1");
-            s->setValue("db_port","5432");
-            s->setValue("db_name","segs");
-            s->setValue("db_user","segsadmin");
-            s->setValue("db_pass","segs123");
-        s->endGroup();
-        s->beginGroup("CharacterDatabase");
-            s->setValue("db_driver","QSQLITE");
-            s->setValue("db_host","127.0.0.1");
-            s->setValue("db_port","5432");
-            s->setValue("db_name","segs_game");
-            s->setValue("db_user","segsadmin");
-            s->setValue("db_pass","segs123");
-        s->endGroup();
-    s->endGroup();
-    s->beginGroup("AuthServer");
-        s->setValue("listen_addr","127.0.0.1:2106");
-    s->endGroup();
-    s->beginGroup("GameServer");
-        s->setValue("server_name","SEGS Server");
-        s->setValue("listen_addr","127.0.0.1:7002");
-        s->setValue("location_addr","127.0.0.1:7002");
-        s->setValue("max_players","200");
-        s->setValue("max_account_slots","8");
-    s->endGroup();
-    s->beginGroup("MapServer");
-        s->setValue("listen_addr","127.0.0.1:7003");
-        s->setValue("location_addr","127.0.0.1:7003");
-    s->endGroup();
+    s.beginGroup("AdminServer");
+        s.beginGroup("AccountDatabase");
+            s.setValue("db_driver","QSQLITE");
+            s.setValue("db_host","127.0.0.1");
+            s.setValue("db_port","5432");
+            s.setValue("db_name","segs");
+            s.setValue("db_user","segsadmin");
+            s.setValue("db_pass","segs123");
+        s.endGroup();
+        s.beginGroup("CharacterDatabase");
+            s.setValue("db_driver","QSQLITE");
+            s.setValue("db_host","127.0.0.1");
+            s.setValue("db_port","5432");
+            s.setValue("db_name","segs_game");
+            s.setValue("db_user","segsadmin");
+            s.setValue("db_pass","segs123");
+        s.endGroup();
+    s.endGroup();
+    s.beginGroup("AuthServer");
+        s.setValue("listen_addr","127.0.0.1:2106");
+    s.endGroup();
+    s.beginGroup("GameServer");
+        s.setValue("server_name","SEGS Server");
+        s.setValue("listen_addr","127.0.0.1:7002");
+        s.setValue("location_addr","127.0.0.1:7002");
+        s.setValue("max_players","200");
+        s.setValue("max_account_slots","8");
+    s.endGroup();
+    s.beginGroup("MapServer");
+        s.setValue("listen_addr","127.0.0.1:7003");
+        s.setValue("location_addr","127.0.0.1:7003");
+    s.endGroup();
     
-    s->sync(); // sync changes or they wont be saved to file.
+    s.sync(); // sync changes or they wont be saved to file.
 }
 
 void settingsDump()
 {
+    QSettings *s(Settings::getSettings());
+    settingsDump(s);
+}
+
+void settingsDump(QSettings *s)
+{
     QString output = "Settings File Dump\n";
-    QSettings* s = Settings::getSettings();
     foreach (const QString &group, s->childGroups()) {
         QString groupString = QString("===== %1 =====\n").arg(group);
         s->beginGroup(group);

--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -8,6 +8,9 @@
  
 #include "Settings.h"
 
+QSettings* Settings::m_settings = nullptr;
+QString Settings::m_settings_path = "settings.cfg"; // default path 'settings.cfg' from args
+
 bool fileExists(QString path) {
     QFileInfo check_file(path);
     // check if file exists and if yes: Is it really a file and not a directory?
@@ -16,23 +19,18 @@ bool fileExists(QString path) {
 
 Settings::Settings()
 {
+    if(!fileExists(getSettingsPath()))
+        createSettingsFile();
 }
 
 QSettings *Settings::getSettings()
 {
-    Settings s;
+    if(m_settings == nullptr)
+        m_settings = new QSettings(Settings::getSettingsPath(),QSettings::IniFormat,0);
 
-    if(!fileExists(s.getSettingsPath()))
-        s.createSettingsFile();
+    //settingsDump(m_settings); // Debugging
 
-    static QSettings m_settings(s.getSettingsPath(),QSettings::IniFormat);
-    //if(!s.m_settings.contains("AuthServer/location_addr"))
-    //{
-    //    s.m_settings.setPath(QSettings::IniFormat,QSettings::SystemScope,s.getSettingsPath());
-    //}
-
-    settingsDump(&m_settings); // Settings are correct
-    return &m_settings;
+    return m_settings;
 }
 
 void Settings::setSettingsPath(const QString path)
@@ -104,42 +102,42 @@ void Settings::createSettingsFile()
 // TODO: Any time you set settings values it deletes all file comments. There is no known workaround.
 void Settings::setDefaultSettings()
 {
-    QSettings s(getSettings());
+    QSettings *s(Settings::getSettings());
 
-    s.beginGroup("AdminServer");
-        s.beginGroup("AccountDatabase");
-            s.setValue("db_driver","QSQLITE");
-            s.setValue("db_host","127.0.0.1");
-            s.setValue("db_port","5432");
-            s.setValue("db_name","segs");
-            s.setValue("db_user","segsadmin");
-            s.setValue("db_pass","segs123");
-        s.endGroup();
-        s.beginGroup("CharacterDatabase");
-            s.setValue("db_driver","QSQLITE");
-            s.setValue("db_host","127.0.0.1");
-            s.setValue("db_port","5432");
-            s.setValue("db_name","segs_game");
-            s.setValue("db_user","segsadmin");
-            s.setValue("db_pass","segs123");
-        s.endGroup();
-    s.endGroup();
-    s.beginGroup("AuthServer");
-        s.setValue("listen_addr","127.0.0.1:2106");
-    s.endGroup();
-    s.beginGroup("GameServer");
-        s.setValue("server_name","SEGS Server");
-        s.setValue("listen_addr","127.0.0.1:7002");
-        s.setValue("location_addr","127.0.0.1:7002");
-        s.setValue("max_players","200");
-        s.setValue("max_account_slots","8");
-    s.endGroup();
-    s.beginGroup("MapServer");
-        s.setValue("listen_addr","127.0.0.1:7003");
-        s.setValue("location_addr","127.0.0.1:7003");
-    s.endGroup();
+    s->beginGroup("AdminServer");
+        s->beginGroup("AccountDatabase");
+            s->setValue("db_driver","QSQLITE");
+            s->setValue("db_host","127.0.0.1");
+            s->setValue("db_port","5432");
+            s->setValue("db_name","segs");
+            s->setValue("db_user","segsadmin");
+            s->setValue("db_pass","segs123");
+        s->endGroup();
+        s->beginGroup("CharacterDatabase");
+            s->setValue("db_driver","QSQLITE");
+            s->setValue("db_host","127.0.0.1");
+            s->setValue("db_port","5432");
+            s->setValue("db_name","segs_game");
+            s->setValue("db_user","segsadmin");
+            s->setValue("db_pass","segs123");
+        s->endGroup();
+    s->endGroup();
+    s->beginGroup("AuthServer");
+        s->setValue("listen_addr","127.0.0.1:2106");
+    s->endGroup();
+    s->beginGroup("GameServer");
+        s->setValue("server_name","SEGS Server");
+        s->setValue("listen_addr","127.0.0.1:7002");
+        s->setValue("location_addr","127.0.0.1:7002");
+        s->setValue("max_players","200");
+        s->setValue("max_character_slots","8");
+    s->endGroup();
+    s->beginGroup("MapServer");
+        s->setValue("listen_addr","127.0.0.1:7003");
+        s->setValue("location_addr","127.0.0.1:7003");
+    s->endGroup();
     
-    s.sync(); // sync changes or they wont be saved to file.
+    s->sync(); // sync changes or they wont be saved to file.
 }
 
 void settingsDump()

--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -22,52 +22,68 @@ QSettings *Settings::getSettings()
 {
     Settings s;
 
-    if(!fileExists(s.m_settings_path))
+    if(!fileExists(s.getSettingsPath()))
         s.createSettingsFile();
 
-    static QSettings m_settings(s.m_settings_path,QSettings::IniFormat);
+    static QSettings m_settings(s.getSettingsPath(),QSettings::IniFormat);
 
     return &m_settings;
 }
 
+void Settings::setSettingsPath(const QString path)
+{
+    if(path == NULL)
+        qCritical() << "Settings path not defined? This is unpossible!";
+
+    m_settings_path = path;
+}
+
+QString Settings::getSettingsPath()
+{
+    if(m_settings_path.isEmpty())
+        setSettingsPath("settings.cfg"); // set default path to "settings.cfg"
+
+    return m_settings_path;
+}
+
 void Settings::createSettingsFile()
 {
-    if (!fileExists(m_settings_path))
+    if (!fileExists(Settings::getSettingsPath()))
     {
-        qCritical() << "Settings file" << m_settings_path <<"does not exist. Creating it now...";
-        QFile m_settings_file(m_settings_path);
-        if(!m_settings_file.open(QIODevice::WriteOnly))
+        qCritical() << "Settings file" << Settings::getSettingsPath() <<"does not exist. Creating it now...";
+        QFile sfile(Settings::getSettingsPath());
+        if(!sfile.open(QIODevice::WriteOnly))
         {
-            qDebug() << "Unable to create" << m_settings_path << "Check folder permissions.";
+            qDebug() << "Unable to create" << Settings::getSettingsPath() << "Check folder permissions.";
             return;
         }
 
-        QTextStream header(&m_settings_file);
-        header << ";##############################################################"
-                 << "\n;#    SEGS configuration file."
-                 << "\n;#"
-                 << "\n;#    listen_addr values below should contain the IP the"
-                 << "\n;#      clients will connect to."
-                 << "\n;#"
-                 << "\n;#    location_addr values below should contain the IP the"
-                 << "\n;#      clients will receive data from."
-                 << "\n;#"
-                 << "\n;#    Both values are set to 127.0.0.1 by default but should"
-                 << "\n;#      be set to your local IP address on the network"
-                 << "\n;#      for example: 10.0.0.2"
-                 << "\n;#"
-                 << "\n;#    Default ports are listed below:"
-                 << "\n;#      AccountDatabase db_port:		5432"
-                 << "\n;#      CharacterDatabase db_port:	5432"
-                 << "\n;#      AuthServer listen_addr:		2106"
-                 << "\n;#      GameServer listen_addr:		7002"
-                 << "\n;#      GameServer location_addr:	7002"
-                 << "\n;#      MapServer listen_addr:		7003"
-                 << "\n;#      MapServer location_addr:		7003"
-                 << "\n;#"
-                 << "\n;##############################################################";
+        QTextStream header(&sfile);
+        header << "##############################################################"
+                 << "\n#    SEGS configuration file."
+                 << "\n#"
+                 << "\n#    listen_addr values below should contain the IP the"
+                 << "\n#      clients will connect to."
+                 << "\n#"
+                 << "\n#    location_addr values below should contain the IP the"
+                 << "\n#      clients will receive data from."
+                 << "\n#"
+                 << "\n#    Both values are set to 127.0.0.1 by default but should"
+                 << "\n#      be set to your local IP address on the network"
+                 << "\n#      for example: 10.0.0.2"
+                 << "\n#"
+                 << "\n#    Default ports are listed below:"
+                 << "\n#      AccountDatabase db_port:		5432"
+                 << "\n#      CharacterDatabase db_port:	5432"
+                 << "\n#      AuthServer listen_addr:		2106"
+                 << "\n#      GameServer listen_addr:		7002"
+                 << "\n#      GameServer location_addr:     7002"
+                 << "\n#      MapServer listen_addr:		7003"
+                 << "\n#      MapServer location_addr:		7003"
+                 << "\n#"
+                 << "\n##############################################################";
 
-        m_settings_file.close();
+        sfile.close();
         
         setDefaultSettings();
         
@@ -75,11 +91,12 @@ void Settings::createSettingsFile()
     }
     else
     {
-        qDebug() << "Settings file already exists at" << m_settings_path;
+        qDebug() << "Settings file already exists at" << Settings::getSettingsPath();
         return;
     }
 }
 
+// TODO: Any time you set settings values it deletes all file comments. There is no known workaround.
 void Settings::setDefaultSettings()
 {
     QSettings *s = getSettings();

--- a/Components/Settings.h
+++ b/Components/Settings.h
@@ -9,7 +9,8 @@
 #pragma once
 #include <QSettings>
 #include <QString>
-#include <QTextStream>#include <QFile>
+#include <QTextStream>
+#include <QFile>
 #include <QFileInfo>
 #include <QDebug>
 
@@ -19,14 +20,15 @@ public:
     Settings();
 
     static QSettings    *getSettings();
-    void         createSettingsFile();
-    void         setDefaultSettings();
+    void                setSettingsPath(const QString path);
+    QString             getSettingsPath();
 
-    QString     m_settings_path = "settings.cfg"; // default path 'settings.cfg'
-    QFile       m_settings_file;
+    void        createSettingsFile();
+    void        setDefaultSettings();
 
 private:
     static QSettings m_settings;
+    QString   m_settings_path; // default path 'settings.cfg' from args
 };
 
 void settingsDump();

--- a/Components/Settings.h
+++ b/Components/Settings.h
@@ -1,0 +1,28 @@
+/*
+ * Super Entity Game Server
+ * http://github.com/Segs
+ * Copyright (c) 2006 - 2018 Super Entity Game Server Team (see Authors.txt)
+ * This software is licensed! (See License.txt for details)
+ *
+ */
+
+#pragma once
+#include <QSettings>
+#include <QString>
+#include <QFile>
+
+class Settings {
+
+public:
+    QSettings   &getSettings();
+    void        createSettingsFile();
+    void        setDefaultSettings();
+    void        dump();
+    QString     m_settings_path = "settings.cfg"; // default path 'settings.cfg'
+    QFile       m_settings_file;
+private:
+    Settings();
+    ~Settings();
+
+    QSettings* m_settings;
+}

--- a/Components/Settings.h
+++ b/Components/Settings.h
@@ -10,19 +10,23 @@
 #include <QSettings>
 #include <QString>
 #include <QFile>
+#include <QFileInfo>
+#include <QDebug>
 
-class Settings {
+class Settings : public QSettings {
 
 public:
-    QSettings   &getSettings();
-    void        createSettingsFile();
-    void        setDefaultSettings();
-    void        dump();
-    QString     m_settings_path = "settings.cfg"; // default path 'settings.cfg'
-    QFile       m_settings_file;
-private:
     Settings();
     ~Settings();
 
+    QSettings  *getSettings();
+    void        createSettingsFile();
+    void        setDefaultSettings();
+    void        dump();
+
+    QString     m_settings_path = "settings.cfg"; // default path 'settings.cfg'
+    QFile       m_settings_file;
+
+private:
     QSettings* m_settings;
-}
+};

--- a/Components/Settings.h
+++ b/Components/Settings.h
@@ -9,24 +9,24 @@
 #pragma once
 #include <QSettings>
 #include <QString>
-#include <QFile>
+#include <QTextStream>#include <QFile>
 #include <QFileInfo>
 #include <QDebug>
 
-class Settings : public QSettings {
+class Settings {
 
 public:
     Settings();
-    ~Settings();
 
-    QSettings  *getSettings();
-    void        createSettingsFile();
-    void        setDefaultSettings();
-    void        dump();
+    static QSettings    *getSettings();
+    void         createSettingsFile();
+    void         setDefaultSettings();
 
     QString     m_settings_path = "settings.cfg"; // default path 'settings.cfg'
     QFile       m_settings_file;
 
 private:
-    QSettings* m_settings;
+    static QSettings m_settings;
 };
+
+void settingsDump();

--- a/Components/Settings.h
+++ b/Components/Settings.h
@@ -32,3 +32,4 @@ private:
 };
 
 void settingsDump();
+void settingsDump(QSettings *s);

--- a/Components/Settings.h
+++ b/Components/Settings.h
@@ -14,21 +14,23 @@
 #include <QFileInfo>
 #include <QDebug>
 
-class Settings {
+class Settings : public QSettings {
 
 public:
-    Settings();
-
-    static QSettings    *getSettings();
-    void                setSettingsPath(const QString path);
-    QString             getSettingsPath();
+    static QSettings*   getSettings();
+    static void         setSettingsPath(const QString path);
+    static QString      getSettingsPath();
 
     void        createSettingsFile();
     void        setDefaultSettings();
 
 private:
-    static QSettings m_settings;
-    QString   m_settings_path; // default path 'settings.cfg' from args
+    Settings();
+    Settings(Settings const&);
+    Settings& operator=(Settings const&);
+
+    static QSettings*   m_settings;
+    static QString      m_settings_path;
 };
 
 void settingsDump();

--- a/Projects/CoX/Common/Servers/AdminServerInterface.cpp
+++ b/Projects/CoX/Common/Servers/AdminServerInterface.cpp
@@ -56,9 +56,9 @@ bool AdminServerInterface::Run()
 {
     return m_server->Run();
 }
-bool AdminServerInterface::ReadConfig(const QString &name)
+bool AdminServerInterface::ReadConfig()
 {
-    return m_server->ReadConfig(name);
+    return m_server->ReadConfig();
 }
 bool AdminServerInterface::ShutDown(const QString &reason)
 {

--- a/Projects/CoX/Common/Servers/AdminServerInterface.h
+++ b/Projects/CoX/Common/Servers/AdminServerInterface.h
@@ -53,7 +53,7 @@ public:
                         AdminServerInterface(IAdminServer *srv);
                         ~AdminServerInterface(void);
 
-        bool            ReadConfig(const QString &name);
+        bool            ReadConfig();
         bool            Run(void);
         bool            ShutDown(const QString &reason);
 

--- a/Projects/CoX/Common/Servers/AuthServerInterface.cpp
+++ b/Projects/CoX/Common/Servers/AuthServerInterface.cpp
@@ -30,9 +30,9 @@ bool AuthServerInterface::Run()
 {
     return m_server->Run();
 }
-bool AuthServerInterface::ReadConfig(const QString &name)
+bool AuthServerInterface::ReadConfig()
 {
-    return m_server->ReadConfig(name);
+    return m_server->ReadConfig();
 }
 bool AuthServerInterface::ShutDown(const QString &reason)
 {

--- a/Projects/CoX/Common/Servers/AuthServerInterface.h
+++ b/Projects/CoX/Common/Servers/AuthServerInterface.h
@@ -19,7 +19,7 @@ class IAdminServer;
 class IAuthServer : public Server
 {
 public:
-virtual bool                        ReadConfig(const QString &name)=0;
+virtual bool                        ReadConfig()=0;
 virtual bool                        Run(void)=0;
 virtual bool                        ShutDown(const QString &reason)=0;
 virtual AuthClient *                GetClientByLogin(const char *)=0;
@@ -34,7 +34,7 @@ public:
                     AuthServerInterface(IAuthServer *server);
                     ~AuthServerInterface(void);
 
-        bool        ReadConfig(const QString &name);
+        bool        ReadConfig();
         bool        Run(void);
         bool        ShutDown(const QString &reason);
 

--- a/Projects/CoX/Common/Servers/GameServerInterface.cpp
+++ b/Projects/CoX/Common/Servers/GameServerInterface.cpp
@@ -13,10 +13,10 @@ bool GameServerInterface::Run()
     assert(m_instance);
     return m_instance->Run();
 }
-bool GameServerInterface::ReadConfig(const QString &name)
+bool GameServerInterface::ReadConfig()
 {
     assert(m_instance);
-    return m_instance->ReadConfig(name);
+    return m_instance->ReadConfig();
 }
 bool GameServerInterface::ShutDown(const QString &reason)
 {

--- a/Projects/CoX/Common/Servers/GameServerInterface.h
+++ b/Projects/CoX/Common/Servers/GameServerInterface.h
@@ -39,7 +39,7 @@ public:
                                 GameServerInterface(IGameServer *mi) : m_instance(mi){}
                                 ~GameServerInterface(void){}
         //uint32_t GetClientCookie(const ACE_INET_Addr &client_addr);
-        bool                    ReadConfig(const QString &name); //! later name will be used to read GameServer specific configuration
+        bool                    ReadConfig();
         bool                    Run(void);
         bool                    ShutDown(const QString &reason);
 

--- a/Projects/CoX/Common/Servers/MapServerInterface.cpp
+++ b/Projects/CoX/Common/Servers/MapServerInterface.cpp
@@ -13,10 +13,10 @@ bool MapServerInterface::Run()
         assert(m_instance);
         return m_instance->Run();
 }
-bool MapServerInterface::ReadConfig(const QString &name)
+bool MapServerInterface::ReadConfig()
 {
         assert(m_instance);
-        return m_instance->ReadConfig(name);
+        return m_instance->ReadConfig();
 }
 bool MapServerInterface::ShutDown(const QString &reason)
 {

--- a/Projects/CoX/Common/Servers/MapServerInterface.h
+++ b/Projects/CoX/Common/Servers/MapServerInterface.h
@@ -27,7 +27,7 @@ public:
                                 MapServerInterface(IMapServer *mi) : m_instance(mi){}
                                 ~MapServerInterface(void){}
 
-    bool                    ReadConfig(const QString &name); // later name will be used to read GameServer specific configuration
+    bool                    ReadConfig(); // later name will be used to read GameServer specific configuration
     bool                    Run(void);
     bool                    ShutDown(const QString &reason);
     bool                    isLocal(){return true;} // this method returns true if this interface is a local ( same process )

--- a/Projects/CoX/Common/Servers/RoamingServer.cpp
+++ b/Projects/CoX/Common/Servers/RoamingServer.cpp
@@ -15,23 +15,25 @@
  */
 bool RoamingServer::ReadConfig()
 {
-    QSettings *config = Settings::getSettings();
-    config->beginGroup("RoamingServer");
-    if(!config->contains("location_addr"))
+    qDebug() << "RoamingServer settings:";
+    QSettings config(Settings::getSettings());
+
+    config.beginGroup("RoamingServer");
+    if(!config.contains("location_addr"))
         qDebug() << "Config file is missing 'location_addr' entry, will try to use default";
 
-    QString location_addr = config->value("location_addr","127.0.0.1:2106").toString();
+    QString location_addr = config.value("location_addr","127.0.0.1:2106").toString();
     if(!parseAddress(location_addr,m_authaddr))
     {
         qCritical() << "Badly formed IP address" << location_addr;
         return false;
     }
-    if(!config->contains("auth_pass")) {
+    if(!config.contains("auth_pass")) {
         qDebug() << "Config file is missing 'auth_pass' entry, will try to use default";
     }
-    m_passw = config->value("auth_pass","").toString();
+    m_passw = config.value("auth_pass","").toString();
 
-    config->endGroup();
+    config.endGroup();
     return true;
 }
 

--- a/Projects/CoX/Common/Servers/RoamingServer.cpp
+++ b/Projects/CoX/Common/Servers/RoamingServer.cpp
@@ -2,6 +2,7 @@
 #include "ServerHandle.h"
 #include "InterfaceManager.h"
 #include "ConfigExtension.h"
+#include "Settings.h"
 
 #include <QtCore/QSettings>
 #include <QtCore/QString>
@@ -12,30 +13,25 @@
  * @param  configpath This is a platform specific path to a config file containing
  * general RoamingServer vars.
  */
-bool RoamingServer::ReadConfig(const QString &inipath) 
+bool RoamingServer::ReadConfig()
 {
-    if (!QFile::exists(inipath))
-    {
-        qCritical() << "Config file" << inipath <<"does not exist.";
-        return false;
-    }
-    QSettings config(inipath,QSettings::IniFormat);
-    config.beginGroup("RoamingServer");
-    if(!config.contains("location_addr"))
+    QSettings *config = Settings::getSettings();
+    config->beginGroup("RoamingServer");
+    if(!config->contains("location_addr"))
         qDebug() << "Config file is missing 'location_addr' entry, will try to use default";
 
-    QString location_addr = config.value("location_addr","127.0.0.1:2106").toString();
+    QString location_addr = config->value("location_addr","127.0.0.1:2106").toString();
     if(!parseAddress(location_addr,m_authaddr))
     {
         qCritical() << "Badly formed IP address" << location_addr;
         return false;
     }
-    if(!config.contains("auth_pass")) {
+    if(!config->contains("auth_pass")) {
         qDebug() << "Config file is missing 'auth_pass' entry, will try to use default";
     }
-    m_passw = config.value("auth_pass","").toString();
+    m_passw = config->value("auth_pass","").toString();
 
-    config.endGroup();
+    config->endGroup();
     return true;
 }
 

--- a/Projects/CoX/Common/Servers/RoamingServer.cpp
+++ b/Projects/CoX/Common/Servers/RoamingServer.cpp
@@ -15,25 +15,27 @@
  */
 bool RoamingServer::ReadConfig()
 {
-    qDebug() << "RoamingServer settings:";
-    QSettings config(Settings::getSettings());
+    qWarning() << "Loading RoamingServer settings...";
+    QSettings *config(Settings::getSettings());
 
-    config.beginGroup("RoamingServer");
-    if(!config.contains("location_addr"))
+    config->beginGroup("RoamingServer");
+    if(!config->contains("location_addr"))
         qDebug() << "Config file is missing 'location_addr' entry, will try to use default";
 
-    QString location_addr = config.value("location_addr","127.0.0.1:2106").toString();
+    QString location_addr = config->value("location_addr","127.0.0.1:2106").toString();
+
     if(!parseAddress(location_addr,m_authaddr))
     {
         qCritical() << "Badly formed IP address" << location_addr;
         return false;
     }
-    if(!config.contains("auth_pass")) {
+    if(!config->contains("auth_pass")) {
         qDebug() << "Config file is missing 'auth_pass' entry, will try to use default";
     }
-    m_passw = config.value("auth_pass","").toString();
+    m_passw = config->value("auth_pass","").toString();
 
-    config.endGroup();
+    config->endGroup(); // RoamingServer
+
     return true;
 }
 

--- a/Projects/CoX/Common/Servers/RoamingServer.h
+++ b/Projects/CoX/Common/Servers/RoamingServer.h
@@ -23,7 +23,7 @@ class RoamingServer : public Server
 public:
 virtual         ~RoamingServer() = default;
 
-virtual bool    ReadConfig(const QString &configpath)=0;
+virtual bool    ReadConfig()=0;
 virtual bool    Run(void) = 0;
 virtual bool    ShutDown(const QString &reason)=0;
 virtual bool    Online()=0;

--- a/Projects/CoX/Common/Servers/Server.h
+++ b/Projects/CoX/Common/Servers/Server.h
@@ -14,7 +14,7 @@ class Server
 {
 public:
 virtual         ~Server() = default;
-virtual bool    ReadConfig(const QString &name)=0;
+virtual bool    ReadConfig()=0;
 virtual bool    Run(void)=0;
 virtual bool    ShutDown(const QString &reason="No particular reason")=0;
 };

--- a/Projects/CoX/Common/Servers/ServerManager.cpp
+++ b/Projects/CoX/Common/Servers/ServerManager.cpp
@@ -20,17 +20,17 @@ ServerManagerC::ServerManagerC() : m_authserv(nullptr),m_adminserv(nullptr)
 {
 }
 //! this loads this process configuration
-bool ServerManagerC::LoadConfiguration(const QString &config_file_full_path)
+bool ServerManagerC::LoadConfiguration()
 {
-    bool loaded_ok = m_adminserv->ReadConfig(config_file_full_path);
-    loaded_ok &= m_authserv->ReadConfig(config_file_full_path);
+    bool loaded_ok = m_adminserv->ReadConfig();
+    loaded_ok &= m_authserv->ReadConfig();
     for(GameServerInterface * serv : m_GameServers)
     {
-        loaded_ok &= serv->ReadConfig(config_file_full_path);
+        loaded_ok &= serv->ReadConfig();
     }
     for(MapServerInterface *serv : m_MapServers)
     {
-        loaded_ok &= serv->ReadConfig(config_file_full_path);
+        loaded_ok &= serv->ReadConfig();
     }
     return loaded_ok;
 }

--- a/Projects/CoX/Common/Servers/ServerManager.h
+++ b/Projects/CoX/Common/Servers/ServerManager.h
@@ -28,7 +28,7 @@ public:
                                 ServerManagerC(void);
 virtual                         ~ServerManagerC(void){}
 
-        bool                    LoadConfiguration(const QString &config_file_path);
+        bool                    LoadConfiguration();
         bool                    StartLocalServers(void);
         bool                    CreateServerConnections(void);
         void                    StopLocalServers(void);

--- a/Projects/CoX/Data/settings.cfg
+++ b/Projects/CoX/Data/settings.cfg
@@ -37,15 +37,15 @@ CharacterDatabase\db_user   = segsadmin
 CharacterDatabase\db_pass   = segs123
 
 [AuthServer]
-listen_addr       = 127.0.0.1:2106
+location_addr         = 127.0.0.1:2106
 
 [GameServer] 
-server_name       = first server
-listen_addr       = 127.0.0.1:7002
-location_addr     = 127.0.0.1:7002
-max_players       = 200
-max_account_slots = 8
+server_name         = first server
+listen_addr         = 127.0.0.1:7002
+location_addr       = 127.0.0.1:7002
+max_players         = 200
+max_character_slots = 8
 
 [MapServer]  
-listen_addr       = 127.0.0.1:7003
-location_addr     = 127.0.0.1:7003
+listen_addr         = 127.0.0.1:7003
+location_addr       = 127.0.0.1:7003

--- a/Projects/CoX/Servers/AdminServer/AdminServer.cpp
+++ b/Projects/CoX/Servers/AdminServer/AdminServer.cpp
@@ -51,19 +51,19 @@ bool _AdminServer::ReadConfig()
     if(m_running)
         ACE_ERROR_RETURN((LM_ERROR,ACE_TEXT("(%P|%t) AdminServer: Already initialized and running\n") ),false);
 
-    qDebug() << "AdminServer settings:";
-    QSettings config(Settings::getSettings());
+    qWarning() << "Loading AdminServer settings...";
+    QSettings *config(Settings::getSettings());
 
-    config.beginGroup("AdminServer");
+    config->beginGroup("AdminServer");
 
-    config.beginGroup("AccountDatabase");
-    QString dbdriver = config.value("db_driver","QSQLITE").toString();
-    QString dbhost = config.value("db_host","127.0.0.1").toString();
-    int dbport = config.value("db_port","5432").toInt();
-    QString dbname = config.value("db_name","segs").toString();
-    QString dbuser = config.value("db_user","none").toString();
-    QString dbpass = config.value("db_pass","none").toString();
-    config.endGroup();
+    config->beginGroup("AccountDatabase");
+    QString dbdriver = config->value("db_driver","QSQLITE").toString();
+    QString dbhost = config->value("db_host","127.0.0.1").toString();
+    int dbport = config->value("db_port","5432").toInt();
+    QString dbname = config->value("db_name","segs").toString();
+    QString dbuser = config->value("db_user","segsadmin").toString();
+    QString dbpass = config->value("db_pass","segs123").toString();
+    config->endGroup(); // AccountDatabase
     QSqlDatabase *db1;
     QStringList driver_list {"QSQLITE","QPSQL"};
     if(!driver_list.contains(dbdriver.toUpper())) {
@@ -77,14 +77,13 @@ bool _AdminServer::ReadConfig()
     db1->setPassword(dbpass);
     m_db->setDb(db1);
 
-    config.beginGroup("CharacterDatabase");
-    dbdriver = config.value("db_driver","QSQLITE").toString();
-    dbhost = config.value("db_host","127.0.0.1").toString();
-    dbport = config.value("db_port","5432").toInt();
-    dbname = config.value("db_name","segs_game").toString();
-    dbuser = config.value("db_user","none").toString();
-    dbpass = config.value("db_pass","none").toString();
-    config.endGroup();
+    config->beginGroup("CharacterDatabase");
+    dbdriver = config->value("db_driver","QSQLITE").toString();
+    dbhost = config->value("db_host","127.0.0.1").toString();
+    dbport = config->value("db_port","5432").toInt();
+    dbname = config->value("db_name","segs_game").toString();
+    dbuser = config->value("db_user","segsadmin").toString();
+    dbpass = config->value("db_pass","segs123").toString();
     QSqlDatabase *db2;
     if(!driver_list.contains(dbdriver.toUpper())) {
         qWarning() << "Database driver" << dbdriver << " not supported";
@@ -96,6 +95,10 @@ bool _AdminServer::ReadConfig()
     db2->setUserName(dbuser);
     db2->setPassword(dbpass);
     m_char_db->setDb(db2);
+
+    config->endGroup(); // CharacterDatabase
+    config->endGroup(); // AdminServer
+
     return true;
 }
 bool _AdminServer::Run()

--- a/Projects/CoX/Servers/AdminServer/AdminServer.cpp
+++ b/Projects/CoX/Servers/AdminServer/AdminServer.cpp
@@ -51,17 +51,19 @@ bool _AdminServer::ReadConfig()
     if(m_running)
         ACE_ERROR_RETURN((LM_ERROR,ACE_TEXT("(%P|%t) AdminServer: Already initialized and running\n") ),false);
 
-    QSettings *config = Settings::getSettings();
-    config->beginGroup("AdminServer");
+    qDebug() << "AdminServer settings:";
+    QSettings config(Settings::getSettings());
 
-    config->beginGroup("AccountDatabase");
-    QString dbdriver = config->value("db_driver","QSQLITE").toString();
-    QString dbhost = config->value("db_host","127.0.0.1").toString();
-    int dbport = config->value("db_port","5432").toInt();
-    QString dbname = config->value("db_name","segs").toString();
-    QString dbuser = config->value("db_user","none").toString();
-    QString dbpass = config->value("db_pass","none").toString();
-    config->endGroup();
+    config.beginGroup("AdminServer");
+
+    config.beginGroup("AccountDatabase");
+    QString dbdriver = config.value("db_driver","QSQLITE").toString();
+    QString dbhost = config.value("db_host","127.0.0.1").toString();
+    int dbport = config.value("db_port","5432").toInt();
+    QString dbname = config.value("db_name","segs").toString();
+    QString dbuser = config.value("db_user","none").toString();
+    QString dbpass = config.value("db_pass","none").toString();
+    config.endGroup();
     QSqlDatabase *db1;
     QStringList driver_list {"QSQLITE","QPSQL"};
     if(!driver_list.contains(dbdriver.toUpper())) {
@@ -75,14 +77,14 @@ bool _AdminServer::ReadConfig()
     db1->setPassword(dbpass);
     m_db->setDb(db1);
 
-    config->beginGroup("CharacterDatabase");
-    dbdriver = config->value("db_driver","QSQLITE").toString();
-    dbhost = config->value("db_host","127.0.0.1").toString();
-    dbport = config->value("db_port","5432").toInt();
-    dbname = config->value("db_name","segs_game").toString();
-    dbuser = config->value("db_user","none").toString();
-    dbpass = config->value("db_pass","none").toString();
-    config->endGroup();
+    config.beginGroup("CharacterDatabase");
+    dbdriver = config.value("db_driver","QSQLITE").toString();
+    dbhost = config.value("db_host","127.0.0.1").toString();
+    dbport = config.value("db_port","5432").toInt();
+    dbname = config.value("db_name","segs_game").toString();
+    dbuser = config.value("db_user","none").toString();
+    dbpass = config.value("db_pass","none").toString();
+    config.endGroup();
     QSqlDatabase *db2;
     if(!driver_list.contains(dbdriver.toUpper())) {
         qWarning() << "Database driver" << dbdriver << " not supported";

--- a/Projects/CoX/Servers/AdminServer/AdminServer.cpp
+++ b/Projects/CoX/Servers/AdminServer/AdminServer.cpp
@@ -16,6 +16,7 @@
 #include "ConfigExtension.h"
 #include "CharacterDatabase.h"
 #include "ServerManager.h"
+#include "Settings.h"
 
 #include <QtCore/QSettings>
 #include <QtCore/QString>
@@ -45,27 +46,22 @@ _AdminServer::~_AdminServer()
 }
 
 /// later name will be used to read GameServer specific configuration
-bool _AdminServer::ReadConfig(const QString &inipath)
+bool _AdminServer::ReadConfig()
 {
     if(m_running)
         ACE_ERROR_RETURN((LM_ERROR,ACE_TEXT("(%P|%t) AdminServer: Already initialized and running\n") ),false);
 
-    if (!QFile::exists(inipath))
-    {
-        qCritical() << "Config file" << inipath <<"does not exist.";
-        return false;
-    }
-    QSettings config(inipath,QSettings::IniFormat);
-    config.beginGroup("AdminServer");
+    QSettings *config = Settings::getSettings();
+    config->beginGroup("AdminServer");
 
-    config.beginGroup("AccountDatabase");
-    QString dbdriver = config.value("db_driver","QSQLITE").toString();
-    QString dbhost = config.value("db_host","127.0.0.1").toString();
-    int dbport = config.value("db_port","5432").toInt();
-    QString dbname = config.value("db_name","segs").toString();
-    QString dbuser = config.value("db_user","none").toString();
-    QString dbpass = config.value("db_pass","none").toString();
-    config.endGroup();
+    config->beginGroup("AccountDatabase");
+    QString dbdriver = config->value("db_driver","QSQLITE").toString();
+    QString dbhost = config->value("db_host","127.0.0.1").toString();
+    int dbport = config->value("db_port","5432").toInt();
+    QString dbname = config->value("db_name","segs").toString();
+    QString dbuser = config->value("db_user","none").toString();
+    QString dbpass = config->value("db_pass","none").toString();
+    config->endGroup();
     QSqlDatabase *db1;
     QStringList driver_list {"QSQLITE","QPSQL"};
     if(!driver_list.contains(dbdriver.toUpper())) {
@@ -79,14 +75,14 @@ bool _AdminServer::ReadConfig(const QString &inipath)
     db1->setPassword(dbpass);
     m_db->setDb(db1);
 
-    config.beginGroup("CharacterDatabase");
-    dbdriver = config.value("db_driver","QSQLITE").toString();
-    dbhost = config.value("db_host","127.0.0.1").toString();
-    dbport = config.value("db_port","5432").toInt();
-    dbname = config.value("db_name","segs_game").toString();
-    dbuser = config.value("db_user","none").toString();
-    dbpass = config.value("db_pass","none").toString();
-    config.endGroup();
+    config->beginGroup("CharacterDatabase");
+    dbdriver = config->value("db_driver","QSQLITE").toString();
+    dbhost = config->value("db_host","127.0.0.1").toString();
+    dbport = config->value("db_port","5432").toInt();
+    dbname = config->value("db_name","segs_game").toString();
+    dbuser = config->value("db_user","none").toString();
+    dbpass = config->value("db_pass","none").toString();
+    config->endGroup();
     QSqlDatabase *db2;
     if(!driver_list.contains(dbdriver.toUpper())) {
         qWarning() << "Database driver" << dbdriver << " not supported";

--- a/Projects/CoX/Servers/AdminServer/AdminServer.cpp
+++ b/Projects/CoX/Servers/AdminServer/AdminServer.cpp
@@ -43,29 +43,7 @@ _AdminServer::~_AdminServer()
 {
     (void)ShutDown();
 }
-static void createDefaultConfigEntries(const std::string &inipath) {
-    QSettings config(inipath.c_str(),QSettings::IniFormat);
 
-    config.beginGroup("AdminServer");
-        config.beginGroup("AccountDatabase");
-            config.setValue("db_driver","QSQLITE");
-            config.value("db_host","127.0.0.1").toString();
-            config.value("db_port","5432").toString();
-            config.value("db_name","segs").toString();
-            config.value("db_user","none").toString();
-            config.value("db_pass","none").toString();
-        config.endGroup();
-        config.beginGroup("CharacterDatabase");
-            config.setValue("db_driver","QSQLITE");
-            config.value("db_host","127.0.0.1").toString();
-            config.value("db_port","5432").toString();
-            config.value("db_name","segs_game").toString();
-            config.value("db_user","none").toString();
-            config.value("db_pass","none").toString();
-        config.endGroup();
-    config.endGroup();
-
-}
 /// later name will be used to read GameServer specific configuration
 bool _AdminServer::ReadConfig(const QString &inipath)
 {

--- a/Projects/CoX/Servers/AdminServer/AdminServer.h
+++ b/Projects/CoX/Servers/AdminServer/AdminServer.h
@@ -57,7 +57,7 @@ public:
     int                         AddIPBan(const ACE_INET_Addr &client_addr) override;
     void                        InvalidGameServerConnection(const ACE_INET_Addr &) override;
 
-    bool                        ReadConfig(const QString &name) override;
+    bool                        ReadConfig() override;
     bool                        Run(void) override;
     bool                        ShutDown(const QString &reason="No particular reason") override;
     bool                        Online(void) override;

--- a/Projects/CoX/Servers/AuthServer/AuthServer.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthServer.cpp
@@ -55,16 +55,17 @@ bool AuthServer::ReadConfig()
     if(m_running)
         ACE_ERROR_RETURN((LM_ERROR,ACE_TEXT("(%P|%t) AuthServer: Already initialized and running\n") ),false);
 
-    QSettings *config = Settings::getSettings();
+    qDebug() << "AuthServer settings:";
+    QSettings config(Settings::getSettings());
 
-    config->beginGroup("AuthServer");
-    QString location_addr = config->value("listen_addr","127.0.0.1:2106").toString();
+    config.beginGroup("AuthServer");
+    QString location_addr = config.value("listen_addr","127.0.0.1:2106").toString();
     if(!parseAddress(location_addr,m_location))
     {
         qCritical() << "Badly formed IP address" << location_addr;
         return false;
     }
-    config->endGroup();
+    config.endGroup();
 
     return true;
 }

--- a/Projects/CoX/Servers/AuthServer/AuthServer.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthServer.cpp
@@ -17,6 +17,7 @@
 #include "AuthProtocol/AuthLink.h"
 #include "AuthHandler.h"
 #include "AuthClient.h"
+#include "Settings.h"
 
 #include <QtCore/QSettings>
 #include <QtCore/QString>
@@ -49,25 +50,22 @@ AuthServer::~AuthServer()
  * @param inipath is a path to our configuration file.
  * @return bool, if it's false, this function failed somehow.
  */
-bool AuthServer::ReadConfig(const QString &inipath)
+bool AuthServer::ReadConfig()
 {
     if(m_running)
         ACE_ERROR_RETURN((LM_ERROR,ACE_TEXT("(%P|%t) AuthServer: Already initialized and running\n") ),false);
-    if (!QFile::exists(inipath))
-    {
-        qCritical() << "Config file" << inipath <<"does not exist.";
-        return false;
-    }
-    QSettings config(inipath,QSettings::IniFormat);
 
-    config.beginGroup("AuthServer");
-    QString location_addr = config.value("listen_addr","127.0.0.1:2106").toString();
+    QSettings *config = Settings::getSettings();
+
+    config->beginGroup("AuthServer");
+    QString location_addr = config->value("listen_addr","127.0.0.1:2106").toString();
     if(!parseAddress(location_addr,m_location))
     {
         qCritical() << "Badly formed IP address" << location_addr;
         return false;
     }
-    config.endGroup();
+    config->endGroup();
+
     return true;
 }
 /*!

--- a/Projects/CoX/Servers/AuthServer/AuthServer.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthServer.cpp
@@ -55,17 +55,21 @@ bool AuthServer::ReadConfig()
     if(m_running)
         ACE_ERROR_RETURN((LM_ERROR,ACE_TEXT("(%P|%t) AuthServer: Already initialized and running\n") ),false);
 
-    qDebug() << "AuthServer settings:";
-    QSettings config(Settings::getSettings());
+    qWarning() << "Loading AuthServer settings...";
+    QSettings *config(Settings::getSettings());
 
-    config.beginGroup("AuthServer");
-    QString location_addr = config.value("listen_addr","127.0.0.1:2106").toString();
+    config->beginGroup("AuthServer");
+    if(!config->contains("location_addr"))
+        qDebug() << "Config file is missing 'location_addr' entry, will try to use default";
+
+    QString location_addr = config->value("location_addr","127.0.0.1:2106").toString();
+
     if(!parseAddress(location_addr,m_location))
     {
         qCritical() << "Badly formed IP address" << location_addr;
         return false;
     }
-    config.endGroup();
+    config->endGroup(); // AuthServer
 
     return true;
 }

--- a/Projects/CoX/Servers/AuthServer/AuthServer.h
+++ b/Projects/CoX/Servers/AuthServer/AuthServer.h
@@ -42,7 +42,7 @@ public:
                                     AuthServer();
                                     ~AuthServer() override;
 
-        bool                        ReadConfig(const QString &name) override;
+        bool                        ReadConfig() override;
         bool                        Run(void) override;
         bool                        ShutDown(const QString &reason="No particular reason") override;
 

--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -135,8 +135,8 @@ ACE_INT32 ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
     Settings s;
     s.setSettingsPath(parser.value("config")); // set settings.cfg from args
+    qDebug() << "Main settings:";
     QSettings *config = Settings::getSettings(); // create config instance
-    //settingsDump();
 
     ACE_Sig_Set interesting_signals;
     interesting_signals.sig_add(SIGINT);

--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -133,10 +133,7 @@ ACE_INT32 ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     if(parser.isSet("help")||parser.isSet("version"))
         return 0;
 
-    Settings s;
-    s.setSettingsPath(parser.value("config")); // set settings.cfg from args
-    qDebug() << "Main settings:";
-    QSettings *config = Settings::getSettings(); // create config instance
+    Settings::setSettingsPath(parser.value("config")); // set settings.cfg from args
 
     ACE_Sig_Set interesting_signals;
     interesting_signals.sig_add(SIGINT);

--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -137,7 +137,7 @@ ACE_INT32 ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     if(parser.isSet("help")||parser.isSet("version"))
         return 0;
 
-    QString config_file_path = parser.value("config");
+    QString config_file_path = parser.value("config"); // settings.cfg from args
     ACE_Sig_Set interesting_signals;
     interesting_signals.sig_add(SIGINT);
     interesting_signals.sig_add(SIGHUP);

--- a/Projects/CoX/Servers/GameServer/GameServer.cpp
+++ b/Projects/CoX/Servers/GameServer/GameServer.cpp
@@ -129,14 +129,15 @@ bool GameServer::ReadConfig()
         return true;
     }
 
-    QSettings *config = Settings::getSettings();
+    qDebug() << "GameServer settings:";
+    QSettings config(Settings::getSettings());
 
-    config->beginGroup("GameServer");
-    QString listen_addr = config->value("listen_addr","0.0.0.0:7002").toString();
-    QString location_addr = config->value("location_addr","127.0.0.1:7002").toString();
-    d->m_serverName = config->value("server_name","unnamed").toString();
-    d->m_max_players = config->value("max_players",600).toUInt();
-    d->m_max_character_slots = config->value("max_character_slots",MaxCharacterSlots).toInt();
+    config.beginGroup("GameServer");
+    QString listen_addr = config.value("listen_addr","0.0.0.0:7002").toString();
+    QString location_addr = config.value("location_addr","127.0.0.1:7002").toString();
+    d->m_serverName = config.value("server_name","unnamed").toString();
+    d->m_max_players = config.value("max_players",600).toUInt();
+    d->m_max_character_slots = config.value("max_character_slots",MaxCharacterSlots).toInt();
     if(!parseAddress(listen_addr,d->m_listen_point))
     {
         qCritical() << "Badly formed IP address" << listen_addr;

--- a/Projects/CoX/Servers/GameServer/GameServer.cpp
+++ b/Projects/CoX/Servers/GameServer/GameServer.cpp
@@ -129,15 +129,21 @@ bool GameServer::ReadConfig()
         return true;
     }
 
-    qDebug() << "GameServer settings:";
-    QSettings config(Settings::getSettings());
+    qWarning() << "Loading GameServer settings...";
+    QSettings *config(Settings::getSettings());
 
-    config.beginGroup("GameServer");
-    QString listen_addr = config.value("listen_addr","0.0.0.0:7002").toString();
-    QString location_addr = config.value("location_addr","127.0.0.1:7002").toString();
-    d->m_serverName = config.value("server_name","unnamed").toString();
-    d->m_max_players = config.value("max_players",600).toUInt();
-    d->m_max_character_slots = config.value("max_character_slots",MaxCharacterSlots).toInt();
+    config->beginGroup("GameServer");
+    if(!config->contains("listen_addr"))
+        qDebug() << "Config file is missing 'listen_addr' entry, will try to use default";
+    if(!config->contains("location_addr"))
+        qDebug() << "Config file is missing 'location_addr' entry, will try to use default";
+
+    QString listen_addr = config->value("listen_addr","127.0.0.1:7002").toString();
+    QString location_addr = config->value("location_addr","127.0.0.1:7002").toString();
+
+    d->m_serverName = config->value("server_name","unnamed").toString();
+    d->m_max_players = config->value("max_players",600).toUInt();
+    d->m_max_character_slots = config->value("max_character_slots",MaxCharacterSlots).toInt();
     if(!parseAddress(listen_addr,d->m_listen_point))
     {
         qCritical() << "Badly formed IP address" << listen_addr;
@@ -154,6 +160,9 @@ bool GameServer::ReadConfig()
     d->m_unk1=d->m_unk2=0;
     d->m_online = false;
     //m_db = new GameServerDb("");
+
+    config->endGroup(); // GameServer
+
     return true;
 }
 bool GameServer::ShutDown(const QString &reason)

--- a/Projects/CoX/Servers/GameServer/GameServer.cpp
+++ b/Projects/CoX/Servers/GameServer/GameServer.cpp
@@ -17,6 +17,7 @@
 #include "GameHandler.h"
 #include "Common/CRUDP_Protocol/CRUDP_Protocol.h"
 #include "Common/Servers/RoamingServer.h"
+#include "Settings.h"
 
 #include <ace/ACE.h>
 #include <ace/Synch.h>
@@ -34,7 +35,7 @@
 #include <QtCore/QDebug>
 
 namespace {
-    const constexpr int MaxAccountSlots=8;
+    const constexpr int MaxCharacterSlots=8;
 }
 GameServer *g_GlobalGameServer=nullptr;
 
@@ -120,25 +121,22 @@ bool GameServer::Run()
     return true;
 }
 // later name will be used to read GameServer specific configuration
-bool GameServer::ReadConfig(const QString &inipath)
+bool GameServer::ReadConfig()
 {
     if(d->m_endpoint)
     {
         ACE_DEBUG((LM_WARNING,ACE_TEXT("(%P|%t) Game server already initialized and running\n") ));
         return true;
     }
-    if (!QFile::exists(inipath))
-    {
-        qCritical() << "Config file" << inipath <<"does not exist.";
-        return false;
-    }
-    QSettings config(inipath,QSettings::IniFormat);
-    config.beginGroup("GameServer");
-    QString listen_addr = config.value("listen_addr","0.0.0.0:7002").toString();
-    QString location_addr = config.value("location_addr","127.0.0.1:7002").toString();
-    d->m_serverName = config.value("server_name","unnamed").toString();
-    d->m_max_players = config.value("max_players",600).toUInt();
-    d->m_max_character_slots = config.value("max_character_slots",MaxAccountSlots).toInt();
+
+    QSettings *config = Settings::getSettings();
+
+    config->beginGroup("GameServer");
+    QString listen_addr = config->value("listen_addr","0.0.0.0:7002").toString();
+    QString location_addr = config->value("location_addr","127.0.0.1:7002").toString();
+    d->m_serverName = config->value("server_name","unnamed").toString();
+    d->m_max_players = config->value("max_players",600).toUInt();
+    d->m_max_character_slots = config->value("max_character_slots",MaxCharacterSlots).toInt();
     if(!parseAddress(listen_addr,d->m_listen_point))
     {
         qCritical() << "Badly formed IP address" << listen_addr;

--- a/Projects/CoX/Servers/GameServer/GameServer.h
+++ b/Projects/CoX/Servers/GameServer/GameServer.h
@@ -39,7 +39,7 @@ class GameServer : public IGameServer
 public:
                                 ~GameServer(void);
                                 GameServer(void);
-        bool                    ReadConfig(const QString &configpath) override;
+        bool                    ReadConfig() override;
         bool                    Run(void) override;
         bool                    ShutDown(const QString &reason="No particular reason") override;
         void                    Online(bool s );

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -1212,7 +1212,10 @@ void MapInstance::on_console_command(ConsoleCommand * ev)
         src->addCommandToSendNextUpdate(std::unique_ptr<InfoMessageCmd>(info));
     }
     else if(lowerContents == "settingsdump") {
-        Settings::dump();
+        Settings s;
+        QSettings *settings = s.getSettings();
+
+        s.dump();
 
         QString msg = "Sending settings config dump to console output.";
         info = new InfoMessageCmd(InfoType::DEBUG_INFO, msg);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -25,6 +25,7 @@
 #include "InternalEvents.h"
 #include "Database.h"
 #include "Common/GameData/CoHMath.h"
+#include "Settings.h"
 
 #include <QtCore/QDebug>
 #include <QtCore/QFile>
@@ -1207,6 +1208,13 @@ void MapInstance::on_console_command(ConsoleCommand * ev)
                 + "\n  tgt_idx: " + QString::number(getTargetIdx(*ent));
         ent->dump();
         //qDebug().noquote() << msg;
+        info = new InfoMessageCmd(InfoType::DEBUG_INFO, msg);
+        src->addCommandToSendNextUpdate(std::unique_ptr<InfoMessageCmd>(info));
+    }
+    else if(lowerContents == "settingsdump") {
+        Settings::dump();
+
+        QString msg = "Sending settings config dump to console output.";
         info = new InfoMessageCmd(InfoType::DEBUG_INFO, msg);
         src->addCommandToSendNextUpdate(std::unique_ptr<InfoMessageCmd>(info));
     }

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -1212,10 +1212,7 @@ void MapInstance::on_console_command(ConsoleCommand * ev)
         src->addCommandToSendNextUpdate(std::unique_ptr<InfoMessageCmd>(info));
     }
     else if(lowerContents == "settingsdump") {
-        Settings s;
-        QSettings *settings = s.getSettings();
-
-        s.dump();
+        settingsDump();
 
         QString msg = "Sending settings config dump to console output.";
         info = new InfoMessageCmd(InfoType::DEBUG_INFO, msg);

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -99,10 +99,10 @@ bool MapServer::Run()
  */
 bool MapServer::ReadConfig()
 {
-    qDebug() << "MapServer settings:";
-    QSettings config(Settings::getSettings());
+    qWarning() << "Loading MapServer settings...";
+    QSettings *config(Settings::getSettings());
 
-    config.beginGroup("MapServer");
+    config->beginGroup("MapServer");
     if(m_endpoint)
     {
         //TODO: perform shutdown, and load config ?
@@ -113,9 +113,15 @@ bool MapServer::ReadConfig()
     if(!RoamingServer::ReadConfig()) // try to read control channel configuration
         return false;
 
-    QString listen_addr = config.value("listen_addr","127.0.0.1:7003").toString();
-    QString location_addr = config.value("location_addr","127.0.0.1:7003").toString();
-    QString map_templates_dir = config.value("maps",".").toString();
+    if(!config->contains("listen_addr"))
+        qDebug() << "Config file is missing 'listen_addr' entry, will try to use default";
+    if(!config->contains("location_addr"))
+        qDebug() << "Config file is missing 'location_addr' entry, will try to use default";
+
+    QString listen_addr = config->value("listen_addr","127.0.0.1:7003").toString();
+    QString location_addr = config->value("location_addr","127.0.0.1:7003").toString();
+
+    QString map_templates_dir = config->value("maps",".").toString();
     if(!parseAddress(listen_addr,m_listen_point))
     {
         qCritical() << "Badly formed IP address" << listen_addr;
@@ -128,6 +134,9 @@ bool MapServer::ReadConfig()
     }
 
     m_online = false;
+
+    config->endGroup(); // MapServer
+
     return d->m_manager.load_templates(qPrintable(map_templates_dir));
 }
 bool MapServer::ShutDown(const QString &reason)

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -99,9 +99,10 @@ bool MapServer::Run()
  */
 bool MapServer::ReadConfig()
 {
-    QSettings *config = Settings::getSettings();
-    config->beginGroup("MapServer");
+    qDebug() << "MapServer settings:";
+    QSettings config(Settings::getSettings());
 
+    config.beginGroup("MapServer");
     if(m_endpoint)
     {
         //TODO: perform shutdown, and load config ?
@@ -112,9 +113,9 @@ bool MapServer::ReadConfig()
     if(!RoamingServer::ReadConfig()) // try to read control channel configuration
         return false;
 
-    QString listen_addr = config->value("listen_addr","0.0.0.0:7003").toString();
-    QString location_addr = config->value("location_addr","127.0.0.1:7003").toString();
-    QString map_templates_dir = config->value("maps",".").toString();
+    QString listen_addr = config.value("listen_addr","127.0.0.1:7003").toString();
+    QString location_addr = config.value("location_addr","127.0.0.1:7003").toString();
+    QString map_templates_dir = config.value("maps",".").toString();
     if(!parseAddress(listen_addr,m_listen_point))
     {
         qCritical() << "Badly formed IP address" << listen_addr;

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -19,6 +19,7 @@
 #include "MapTemplate.h"
 #include "MapInstance.h"
 #include "SEGSTimer.h"
+#include "Settings.h"
 
 #include <ace/Reactor.h>
 
@@ -96,15 +97,10 @@ bool MapServer::Run()
  * @param  inipath Doc at RoamingServer::ReadConfig
  * @return bool (false means an error occurred )
  */
-bool MapServer::ReadConfig(const QString &inipath)
+bool MapServer::ReadConfig()
 {
-    if (!QFile::exists(inipath))
-    {
-        qCritical() << "Config file" << inipath <<"does not exist.";
-        return false;
-    }
-    QSettings config(inipath,QSettings::IniFormat);
-    config.beginGroup("MapServer");
+    QSettings *config = Settings::getSettings();
+    config->beginGroup("MapServer");
 
     if(m_endpoint)
     {
@@ -113,12 +109,12 @@ bool MapServer::ReadConfig(const QString &inipath)
         return true;
     }
     //TODO: this should read a properly nested MapServer/RoamingServer block, instead of reading ini-'global' [RoamingServer]
-    if(!RoamingServer::ReadConfig(inipath)) // try to read control channel configuration
+    if(!RoamingServer::ReadConfig()) // try to read control channel configuration
         return false;
 
-    QString listen_addr = config.value("listen_addr","0.0.0.0:7003").toString();
-    QString location_addr = config.value("location_addr","127.0.0.1:7003").toString();
-    QString map_templates_dir = config.value("maps",".").toString();
+    QString listen_addr = config->value("listen_addr","0.0.0.0:7003").toString();
+    QString location_addr = config->value("location_addr","127.0.0.1:7003").toString();
+    QString map_templates_dir = config->value("maps",".").toString();
     if(!parseAddress(listen_addr,m_listen_point))
     {
         qCritical() << "Badly formed IP address" << listen_addr;

--- a/Projects/CoX/Servers/MapServer/MapServer.h
+++ b/Projects/CoX/Servers/MapServer/MapServer.h
@@ -44,7 +44,7 @@ public:
                                 ~MapServer(void) override;
 
         bool                    Run(void) override;
-        bool                    ReadConfig(const QString &name) override;
+        bool                    ReadConfig() override;
 
         bool                    ShutDown(const QString &reason="No particular reason") override;
         void                    Online(bool s);


### PR DESCRIPTION
Closes #89

Additions/modifications proposed in this pull request:
- New `Settings` class
- New `getSettings()` static function
- New `setSettingsPath()` static function
- New `getSettingsPath()` static function
- New `settingsDump()` function
- New `/settingsdump` slash command
- Changed `m_account_slots` to `m_character_slots` for clarity
- Added several missing `QSettings::endgroup()` methods and commented for clarity
- Added some debug messages
- Recoded AdminServer, AuthServer, GameServer, MapServer, and RoamingServer to use new Settings class.
- Tested several times trying to bork the system. Seems OK :+1: 

TODO: As far as I can tell nothing :+1: 

NOTE: `setDefaultSettings()` will delete ALL comments in the `settings.cfg` file. This is "expected" QSettings behavior. :frowning_face: 
