### PR TITLE
Fix for qsettings branch slashcommand merge

### DIFF
--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -27,7 +27,6 @@
 #include "Database.h"
 #include "SlashCommand.h"
 #include "Common/GameData/CoHMath.h"
-#include "Settings.h"
 
 #include <QtCore/QDebug>
 #include <QtCore/QFile>
@@ -783,13 +782,6 @@ void MapInstance::on_console_command(ConsoleCommand * ev)
             || contents.startsWith("me ",Qt::CaseInsensitive))                                  // ERICEDIT: This encompasses all emotes.
     {
         on_emote_command(lowerContents, ent);
-    }
-    else if(lowerContents == "settingsdump") {
-        settingsDump();
-
-        QString msg = "Sending settings config dump to console output.";
-        info = new InfoMessageCmd(InfoType::DEBUG_INFO, msg);
-        src->addCommandToSendNextUpdate(std::unique_ptr<InfoMessageCmd>(info));
     }
     else {
         runCommand(contents,*ent);

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -1,6 +1,7 @@
 #include "SlashCommand.h"
 #include "DataHelpers.h"
 #include "MapInstance.h"
+#include "Settings.h"
 
 #include <QtCore/QString>
 #include <QtCore/QFile>
@@ -39,6 +40,7 @@ std::vector<SlashCommand> g_defined_slash_commands = {
     {{"hascontrolid"}, &cmdHandler_HasControlId, 9},
     {{"setTeam"}, &cmdHandler_SetTeam, 9},
     {{"setSuperGroup"}, &cmdHandler_SetSuperGroup, 9},
+    {{"settingsDump"}, &cmdHandler_SettingsDump, 9},
     {{"setu1"}, &cmdHandler_SetU1, 9},
     {{"setu2"}, &cmdHandler_SetU2, 9},
     {{"setu3"}, &cmdHandler_SetU3, 9},
@@ -430,6 +432,16 @@ void cmdHandler_SetSuperGroup(QString &cmd, Entity *e) {
     QString msg = "Set SuperGroup ID to: " + QString::number(val);
     qDebug() << msg;
     sendInfoMessage(MessageChannel::DEBUG_INFO, msg, src);
+}
+
+void cmdHandler_SettingsDump(QString &cmd, Entity *e) {
+    MapClient *src = e->m_client;
+
+    QString msg = "Sending settings config dump to console output.";
+    qDebug() << msg;
+    sendInfoMessage(MessageChannel::DEBUG_INFO, msg, src);
+
+    settingsDump(); // Send settings dump
 }
 
 // Slash commands for setting bit values

--- a/Projects/CoX/Servers/MapServer/SlashCommand.h
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.h
@@ -47,6 +47,7 @@ void cmdHandler_FullUpdate(QString &cmd, Entity *e);
 void cmdHandler_HasControlId(QString &cmd, Entity *e);
 void cmdHandler_SetTeam(QString &cmd, Entity *e);
 void cmdHandler_SetSuperGroup(QString &cmd, Entity *e);
+void cmdHandler_SettingsDump(QString &cmd, Entity *e);
 void cmdHandler_SetU1(QString &cmd, Entity *e);
 void cmdHandler_SetU2(QString &cmd, Entity *e);
 void cmdHandler_SetU3(QString &cmd, Entity *e);


### PR DESCRIPTION
Resolves lingering slashcommand created by PR #264 and #265 merging around the same time.

Closes #269.

Additions/modifications proposed in this pull request:
- Moved `/settingsdump` to SlashCommands.cpp
