### PR TITLE
Issue #274 - Settings load messages categorized as warnings

### DIFF
--- a/Projects/CoX/Common/Servers/RoamingServer.cpp
+++ b/Projects/CoX/Common/Servers/RoamingServer.cpp
@@ -15,7 +15,7 @@
  */
 bool RoamingServer::ReadConfig()
 {
-    qWarning() << "Loading RoamingServer settings...";
+    qInfo() << "Loading RoamingServer settings...";
     QSettings *config(Settings::getSettings());
 
     config->beginGroup("RoamingServer");

--- a/Projects/CoX/Servers/AdminServer/AdminServer.cpp
+++ b/Projects/CoX/Servers/AdminServer/AdminServer.cpp
@@ -51,7 +51,7 @@ bool _AdminServer::ReadConfig()
     if(m_running)
         ACE_ERROR_RETURN((LM_ERROR,ACE_TEXT("(%P|%t) AdminServer: Already initialized and running\n") ),false);
 
-    qWarning() << "Loading AdminServer settings...";
+    qInfo() << "Loading AdminServer settings...";
     QSettings *config(Settings::getSettings());
 
     config->beginGroup("AdminServer");

--- a/Projects/CoX/Servers/AuthServer/AuthServer.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthServer.cpp
@@ -55,7 +55,7 @@ bool AuthServer::ReadConfig()
     if(m_running)
         ACE_ERROR_RETURN((LM_ERROR,ACE_TEXT("(%P|%t) AuthServer: Already initialized and running\n") ),false);
 
-    qWarning() << "Loading AuthServer settings...";
+    qInfo() << "Loading AuthServer settings...";
     QSettings *config(Settings::getSettings());
 
     config->beginGroup(QStringLiteral("AuthServer"));

--- a/Projects/CoX/Servers/GameServer/GameServer.cpp
+++ b/Projects/CoX/Servers/GameServer/GameServer.cpp
@@ -129,7 +129,7 @@ bool GameServer::ReadConfig()
         return true;
     }
 
-    qWarning() << "Loading GameServer settings...";
+    qInfo() << "Loading GameServer settings...";
     QSettings *config(Settings::getSettings());
 
     config->beginGroup("GameServer");

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -99,7 +99,7 @@ bool MapServer::Run()
  */
 bool MapServer::ReadConfig()
 {
-    qWarning() << "Loading MapServer settings...";
+    qInfo() << "Loading MapServer settings...";
     QSettings *config(Settings::getSettings());
 
     config->beginGroup("MapServer");


### PR DESCRIPTION
Hi all, 
First contribution! @Jhon in Discord... 

Changed the qWarning() calls at the relevant places into qInfo() calls to not alarm the end-user. 

Closes #274 (hopefully) 