### PR TITLE
Address Issue #282 in the SlashCommand handlers

### DIFF
--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -212,15 +212,17 @@ void cmdHandler_Jumppack(QString &cmd, Entity *e) {
 void cmdHandler_SetSpeed(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
 
-    QStringList args;
-    args = cmd.split(" ");
+    QVector<QStringRef> args(cmd.splitRef(' '));
     float v1 = args.value(1).toFloat();
     float v2 = args.value(2).toFloat();
     float v3 = args.value(3).toFloat();
     setSpeed(*e, v1, v2, v3);
 
     args.removeAt(0); // remove command string
-    QString msg = "Set Speed to: " + args.join(" ");
+    QString msg = "Set Speed to: <"
+            + QString::number(v1) + ","
+            + QString::number(v2) + ","
+            + QString::number(v3) + ">";
     qDebug() << msg;
     sendInfoMessage(MessageChannel::DEBUG_INFO, msg, src);
 }
@@ -228,7 +230,7 @@ void cmdHandler_SetSpeed(QString &cmd, Entity *e) {
 void cmdHandler_SetBackupSpd(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
 
-    float val = cmd.split(" ").value(1).toFloat();
+    float val = cmd.midRef(cmd.indexOf(' ')+1).toFloat();
     setBackupSpd(*e, val);
 
     QString msg = "Set BackupSpd to: " + QString::number(val);
@@ -239,7 +241,7 @@ void cmdHandler_SetBackupSpd(QString &cmd, Entity *e) {
 void cmdHandler_SetJumpHeight(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
 
-    float val = cmd.split(" ").value(1).toFloat();
+    float val = cmd.midRef(cmd.indexOf(' ')+1).toFloat();
     setJumpHeight(*e, val);
 
     QString msg = "Set JumpHeight to: " + QString::number(val);
@@ -250,7 +252,7 @@ void cmdHandler_SetJumpHeight(QString &cmd, Entity *e) {
 void cmdHandler_SetHP(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
 
-    float attrib = cmd.split(" ").value(1).toFloat();
+    float attrib = cmd.midRef(cmd.indexOf(' ')+1).toFloat();
     float maxattrib = e->m_char.m_max_attribs.m_HitPoints;
 
     if(attrib > maxattrib)
@@ -266,7 +268,7 @@ void cmdHandler_SetHP(QString &cmd, Entity *e) {
 void cmdHandler_SetEnd(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
 
-    float attrib = cmd.split(" ").value(1).toFloat();
+    float attrib = cmd.midRef(cmd.indexOf(' ')+1).toFloat();
     float maxattrib = e->m_char.m_max_attribs.m_Endurance;
 
     if(attrib > maxattrib)
@@ -282,7 +284,7 @@ void cmdHandler_SetEnd(QString &cmd, Entity *e) {
 void cmdHandler_SetXP(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
 
-    uint32_t attrib = cmd.split(" ").value(1).toUInt();
+    uint32_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
     uint32_t lvl = getLevel(e->m_char);
 
     setXP(e->m_char, attrib);
@@ -298,7 +300,7 @@ void cmdHandler_SetXP(QString &cmd, Entity *e) {
 
 void cmdHandler_SetDebt(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    float attrib = cmd.split(" ").value(1).toFloat();
+    float attrib = cmd.midRef(cmd.indexOf(' ')+1).toFloat();
 
     setDebt(e->m_char, attrib);
     QString msg = "Setting XP Debt to " + QString::number(attrib);
@@ -309,7 +311,7 @@ void cmdHandler_SetDebt(QString &cmd, Entity *e) {
 
 void cmdHandler_SetInf(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    uint32_t attrib = cmd.split(" ").value(1).toUInt();
+    uint32_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setInf(e->m_char, attrib);
 
@@ -320,7 +322,7 @@ void cmdHandler_SetInf(QString &cmd, Entity *e) {
 
 void cmdHandler_SetLevel(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    uint32_t attrib = cmd.split(" ").value(1).toUInt();
+    uint32_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setLevel(e->m_char, attrib); // TODO: Why does this result in -1?
 
@@ -331,7 +333,7 @@ void cmdHandler_SetLevel(QString &cmd, Entity *e) {
 
 void cmdHandler_SetCombatLevel(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    uint32_t attrib = cmd.split(" ").value(1).toUInt();
+    uint32_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setCombatLevel(e->m_char, attrib); // TODO: Why does this result in -1?
 
@@ -383,7 +385,7 @@ void cmdHandler_ControlsDisabled(QString &cmd, Entity *e) {
 
 void cmdHandler_UpdateId(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    uint8_t attrib = cmd.split(" ").value(1).toUInt();
+    uint8_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setUpdateID(*e, attrib);
 
@@ -414,7 +416,7 @@ void cmdHandler_HasControlId(QString &cmd, Entity *e) {
 
 void cmdHandler_SetTeam(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    int val = cmd.split(" ").value(1).toUInt();
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setTeamID(*e, val);
 
@@ -425,7 +427,7 @@ void cmdHandler_SetTeam(QString &cmd, Entity *e) {
 
 void cmdHandler_SetSuperGroup(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    int val = cmd.split(" ").value(1).toUInt();
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setSuperGroupID(*e, val);
 
@@ -447,7 +449,7 @@ void cmdHandler_SettingsDump(QString &cmd, Entity *e) {
 // Slash commands for setting bit values
 void cmdHandler_SetU1(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    int val = cmd.split(" ").value(1).toUInt();
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setu1(*e, val);
 
@@ -458,7 +460,7 @@ void cmdHandler_SetU1(QString &cmd, Entity *e) {
 
 void cmdHandler_SetU2(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    int val = cmd.split(" ").value(1).toUInt();
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setu2(*e, val);
 
@@ -469,7 +471,7 @@ void cmdHandler_SetU2(QString &cmd, Entity *e) {
 
 void cmdHandler_SetU3(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    int val = cmd.split(" ").value(1).toUInt();
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setu3(*e, val);
 
@@ -480,7 +482,7 @@ void cmdHandler_SetU3(QString &cmd, Entity *e) {
 
 void cmdHandler_SetU4(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    int val = cmd.split(" ").value(1).toUInt();
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setu4(*e, val);
 
@@ -491,7 +493,7 @@ void cmdHandler_SetU4(QString &cmd, Entity *e) {
 
 void cmdHandler_SetU5(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    int val = cmd.split(" ").value(1).toUInt();
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setu5(*e, val);
 
@@ -502,7 +504,7 @@ void cmdHandler_SetU5(QString &cmd, Entity *e) {
 
 void cmdHandler_SetU6(QString &cmd, Entity *e) {
     MapClient *src = e->m_client;
-    int val = cmd.split(" ").value(1).toUInt();
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
 
     setu6(*e, val);
 

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -218,7 +218,6 @@ void cmdHandler_SetSpeed(QString &cmd, Entity *e) {
     float v3 = args.value(3).toFloat();
     setSpeed(*e, v1, v2, v3);
 
-    args.removeAt(0); // remove command string
     QString msg = "Set Speed to: <"
             + QString::number(v1) + ","
             + QString::number(v2) + ","


### PR DESCRIPTION
Addresses #282 

* Changed uses of split for commands with single args to midRef(indexOf(" ")+1)
* Used a splitRef for SetSpeed without the conversion checking
* Changed the Info output of setSpeed to indicate it is setting a vector via use of "< , , >".

Tested a few commands like /setHP and /setSpeed in-game with no errors, though visually wasn't sure what setSpeed was actually doing to verify with the rubber-banding issue currently present.