### PR TITLE
Error out when passing the wrong version into versioned serializers

### DIFF
--- a/Projects/CoX/Common/GameData/chardata_definitions.h
+++ b/Projects/CoX/Common/GameData/chardata_definitions.h
@@ -4,27 +4,28 @@
 
 struct CharacterData
 {
-    uint32_t    m_level             = 0;
-    uint32_t    m_combat_level      = 0; // might be different if player is sidekick or exemplar, or hasn't trained up.
-    uint32_t    m_experience_points = 0;
-    uint32_t    m_experience_debt   = 0;
-    uint32_t    m_experience_patrol = 0; // planned future use
-    uint32_t    m_influence         = 0;
-    bool        m_has_titles;
-    bool        m_has_the_prefix;
-    QString     m_titles[3];             // Generic, Origin, Special
-    QString     m_battle_cry;
-    QString     m_character_description;
-    bool        m_afk               = false;
-    QString     m_afk_msg;
-    uint8_t     m_lfg               = 0;
-    QString     m_alignment         = "hero";
-    uint64_t    m_last_costume_id;
-    QString     m_last_online;
-    QString     m_class_name;
-    QString     m_origin_name;
-    QString     m_mapName;
-    bool        m_supergroup_costume; // player has a sg costume
-    bool        m_using_sg_costume;   // player uses sg costume currently
-    uint8_t     m_cur_chat_channel          = 10; // Default is local
+    static const constexpr  uint32_t    class_version          = 2;
+                            uint32_t    m_level                = 0;
+                            uint32_t    m_combat_level         = 0; // might be different if player is sidekick or exemplar, or hasn't trained up.
+                            uint32_t    m_experience_points    = 0;
+                            uint32_t    m_experience_debt      = 0;
+                            uint32_t    m_experience_patrol    = 0; // planned future use
+                            uint32_t    m_influence            = 0;
+                            bool        m_has_titles;
+                            bool        m_has_the_prefix;
+                            QString     m_titles[3];           // Generic, Origin, Special
+                            QString     m_battle_cry;
+                            QString     m_character_description;
+                            bool        m_afk                  = false;
+                            QString     m_afk_msg;
+                            uint8_t     m_lfg                  = 0;
+                            QString     m_alignment            = "hero";
+                            uint64_t    m_last_costume_id;
+                            QString     m_last_online;
+                            QString     m_class_name;
+                            QString     m_origin_name;
+                            QString     m_mapName;
+                            bool        m_supergroup_costume; // player has a sg costume
+                            bool        m_using_sg_costume;   // player uses sg costume currently
+                            uint8_t     m_cur_chat_channel    = 10; // Default is local
 };

--- a/Projects/CoX/Common/GameData/chardata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/chardata_serializers.cpp
@@ -4,34 +4,42 @@
 #include "DataStorage.h"
 #include "serialization_common.h"
 
-CEREAL_CLASS_VERSION(CharacterData, 2); // register CharacterData class version
+# define CHARACTER_DATA_CLASS_VERSION 2
+CEREAL_CLASS_VERSION(CharacterData, CHARACTER_DATA_CLASS_VERSION); // register CharacterData class version
 
 template<class Archive>
 void serialize(Archive & archive, CharacterData &cd, uint32_t const version)
 {
-    archive(cereal::make_nvp("Level",cd.m_level));
-    archive(cereal::make_nvp("CombatLevel",cd.m_combat_level));
-    archive(cereal::make_nvp("XP",cd.m_experience_points));
-    archive(cereal::make_nvp("Debt",cd.m_experience_debt));
-    archive(cereal::make_nvp("PatrolXP",cd.m_experience_patrol));
-    archive(cereal::make_nvp("Influence",cd.m_influence));
-    archive(cereal::make_nvp("HasTitles",cd.m_has_titles));
-    archive(cereal::make_nvp("ThePrefix",cd.m_has_the_prefix));
-    archive(cereal::make_nvp("Titles",cd.m_titles));
-    archive(cereal::make_nvp("BattleCry",cd.m_battle_cry));
-    archive(cereal::make_nvp("Description",cd.m_character_description));
-    archive(cereal::make_nvp("AFK",cd.m_afk));
-    archive(cereal::make_nvp("AfkMsg",cd.m_afk_msg));
-    archive(cereal::make_nvp("LFG",cd.m_lfg));
-    archive(cereal::make_nvp("Alignment",cd.m_alignment));
-    archive(cereal::make_nvp("LastCostumeID",cd.m_last_costume_id));
-    archive(cereal::make_nvp("LastOnline",cd.m_last_online));
-    archive(cereal::make_nvp("Class",cd.m_class_name));
-    archive(cereal::make_nvp("Origin",cd.m_origin_name));
-    archive(cereal::make_nvp("MapName",cd.m_mapName));
-    archive(cereal::make_nvp("SuperGroupCostume",cd.m_supergroup_costume));
-    archive(cereal::make_nvp("UsingSGCostume",cd.m_using_sg_costume));
-    archive(cereal::make_nvp("CurrentChatChannel",cd.m_cur_chat_channel));
+    if (version == CHARACTER_DATA_CLASS_VERSION)
+    {
+        archive(cereal::make_nvp("Level",cd.m_level));
+        archive(cereal::make_nvp("CombatLevel",cd.m_combat_level));
+        archive(cereal::make_nvp("XP",cd.m_experience_points));
+        archive(cereal::make_nvp("Debt",cd.m_experience_debt));
+        archive(cereal::make_nvp("PatrolXP",cd.m_experience_patrol));
+        archive(cereal::make_nvp("Influence",cd.m_influence));
+        archive(cereal::make_nvp("HasTitles",cd.m_has_titles));
+        archive(cereal::make_nvp("ThePrefix",cd.m_has_the_prefix));
+        archive(cereal::make_nvp("Titles",cd.m_titles));
+        archive(cereal::make_nvp("BattleCry",cd.m_battle_cry));
+        archive(cereal::make_nvp("Description",cd.m_character_description));
+        archive(cereal::make_nvp("AFK",cd.m_afk));
+        archive(cereal::make_nvp("AfkMsg",cd.m_afk_msg));
+        archive(cereal::make_nvp("LFG",cd.m_lfg));
+        archive(cereal::make_nvp("Alignment",cd.m_alignment));
+        archive(cereal::make_nvp("LastCostumeID",cd.m_last_costume_id));
+        archive(cereal::make_nvp("LastOnline",cd.m_last_online));
+        archive(cereal::make_nvp("Class",cd.m_class_name));
+        archive(cereal::make_nvp("Origin",cd.m_origin_name));
+        archive(cereal::make_nvp("MapName",cd.m_mapName));
+        archive(cereal::make_nvp("SuperGroupCostume",cd.m_supergroup_costume));
+        archive(cereal::make_nvp("UsingSGCostume",cd.m_using_sg_costume));
+        archive(cereal::make_nvp("CurrentChatChannel",cd.m_cur_chat_channel));
+    }
+    else
+    {
+        qCritical() << "Failed to serialize CharacterData, incompatible serialization format version " << version;
+    }
 }
 
 void saveTo(const CharacterData & target, const QString & baseName, bool text_format)

--- a/Projects/CoX/Common/GameData/chardata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/chardata_serializers.cpp
@@ -4,42 +4,40 @@
 #include "DataStorage.h"
 #include "serialization_common.h"
 
-# define CHARACTER_DATA_CLASS_VERSION 2
-CEREAL_CLASS_VERSION(CharacterData, CHARACTER_DATA_CLASS_VERSION); // register CharacterData class version
+CEREAL_CLASS_VERSION(CharacterData, CharacterData::class_version); // register CharacterData class version
 
 template<class Archive>
 void serialize(Archive & archive, CharacterData &cd, uint32_t const version)
 {
-    if (version == CHARACTER_DATA_CLASS_VERSION)
-    {
-        archive(cereal::make_nvp("Level",cd.m_level));
-        archive(cereal::make_nvp("CombatLevel",cd.m_combat_level));
-        archive(cereal::make_nvp("XP",cd.m_experience_points));
-        archive(cereal::make_nvp("Debt",cd.m_experience_debt));
-        archive(cereal::make_nvp("PatrolXP",cd.m_experience_patrol));
-        archive(cereal::make_nvp("Influence",cd.m_influence));
-        archive(cereal::make_nvp("HasTitles",cd.m_has_titles));
-        archive(cereal::make_nvp("ThePrefix",cd.m_has_the_prefix));
-        archive(cereal::make_nvp("Titles",cd.m_titles));
-        archive(cereal::make_nvp("BattleCry",cd.m_battle_cry));
-        archive(cereal::make_nvp("Description",cd.m_character_description));
-        archive(cereal::make_nvp("AFK",cd.m_afk));
-        archive(cereal::make_nvp("AfkMsg",cd.m_afk_msg));
-        archive(cereal::make_nvp("LFG",cd.m_lfg));
-        archive(cereal::make_nvp("Alignment",cd.m_alignment));
-        archive(cereal::make_nvp("LastCostumeID",cd.m_last_costume_id));
-        archive(cereal::make_nvp("LastOnline",cd.m_last_online));
-        archive(cereal::make_nvp("Class",cd.m_class_name));
-        archive(cereal::make_nvp("Origin",cd.m_origin_name));
-        archive(cereal::make_nvp("MapName",cd.m_mapName));
-        archive(cereal::make_nvp("SuperGroupCostume",cd.m_supergroup_costume));
-        archive(cereal::make_nvp("UsingSGCostume",cd.m_using_sg_costume));
-        archive(cereal::make_nvp("CurrentChatChannel",cd.m_cur_chat_channel));
-    }
-    else
+    if (version != CharacterData::class_version)
     {
         qCritical() << "Failed to serialize CharacterData, incompatible serialization format version " << version;
+        return;
     }
+
+    archive(cereal::make_nvp("Level",cd.m_level));
+    archive(cereal::make_nvp("CombatLevel",cd.m_combat_level));
+    archive(cereal::make_nvp("XP",cd.m_experience_points));
+    archive(cereal::make_nvp("Debt",cd.m_experience_debt));
+    archive(cereal::make_nvp("PatrolXP",cd.m_experience_patrol));
+    archive(cereal::make_nvp("Influence",cd.m_influence));
+    archive(cereal::make_nvp("HasTitles",cd.m_has_titles));
+    archive(cereal::make_nvp("ThePrefix",cd.m_has_the_prefix));
+    archive(cereal::make_nvp("Titles",cd.m_titles));
+    archive(cereal::make_nvp("BattleCry",cd.m_battle_cry));
+    archive(cereal::make_nvp("Description",cd.m_character_description));
+    archive(cereal::make_nvp("AFK",cd.m_afk));
+    archive(cereal::make_nvp("AfkMsg",cd.m_afk_msg));
+    archive(cereal::make_nvp("LFG",cd.m_lfg));
+    archive(cereal::make_nvp("Alignment",cd.m_alignment));
+    archive(cereal::make_nvp("LastCostumeID",cd.m_last_costume_id));
+    archive(cereal::make_nvp("LastOnline",cd.m_last_online));
+    archive(cereal::make_nvp("Class",cd.m_class_name));
+    archive(cereal::make_nvp("Origin",cd.m_origin_name));
+    archive(cereal::make_nvp("MapName",cd.m_mapName));
+    archive(cereal::make_nvp("SuperGroupCostume",cd.m_supergroup_costume));
+    archive(cereal::make_nvp("UsingSGCostume",cd.m_using_sg_costume));
+    archive(cereal::make_nvp("CurrentChatChannel",cd.m_cur_chat_channel));
 }
 
 void saveTo(const CharacterData & target, const QString & baseName, bool text_format)

--- a/Projects/CoX/Common/GameData/chardata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/chardata_serializers.cpp
@@ -4,6 +4,7 @@
 #include "DataStorage.h"
 #include "serialization_common.h"
 
+const constexpr uint32_t CharacterData::class_version;
 CEREAL_CLASS_VERSION(CharacterData, CharacterData::class_version); // register CharacterData class version
 
 template<class Archive>

--- a/Projects/CoX/Common/GameData/entitydata_definitions.h
+++ b/Projects/CoX/Common/GameData/entitydata_definitions.h
@@ -6,9 +6,10 @@
 
 struct EntityData
 {
-    uint32_t            m_access_level              = 0;
-    uint8_t             m_origin_idx                = {0};
-    uint8_t             m_class_idx                 = {0};
-    glm::vec3           pos;
-    glm::vec3           m_orientation_pyr;          // Stored in Radians
+    static const constexpr  uint32_t    class_version       = 2;
+                            uint32_t    m_access_level      = 0;
+                            uint8_t     m_origin_idx        = {0};
+                            uint8_t     m_class_idx         = {0};
+                            glm::vec3   pos;
+                            glm::vec3   m_orientation_pyr; // Stored in Radians
 };

--- a/Projects/CoX/Common/GameData/entitydata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/entitydata_serializers.cpp
@@ -4,6 +4,7 @@
 #include "DataStorage.h"
 #include "serialization_common.h"
 
+const constexpr uint32_t EntityData::class_version;
 CEREAL_CLASS_VERSION(EntityData, EntityData::class_version); // register EntityData class version
 
 template<class Archive>

--- a/Projects/CoX/Common/GameData/entitydata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/entitydata_serializers.cpp
@@ -4,16 +4,24 @@
 #include "DataStorage.h"
 #include "serialization_common.h"
 
-CEREAL_CLASS_VERSION(EntityData, 2); // register EntityData class version
+#define ENTITY_DATA_CLASS_VERSION 2
+CEREAL_CLASS_VERSION(EntityData, ENTITY_DATA_CLASS_VERSION); // register EntityData class version
 
 template<class Archive>
 void serialize(Archive & archive, EntityData &ed, uint32_t const version)
 {
-    archive(cereal::make_nvp("AccessLevel",ed.m_access_level));
-    archive(cereal::make_nvp("OriginIdx",ed.m_origin_idx));
-    archive(cereal::make_nvp("ClassIdx",ed.m_class_idx));
-    archive(cereal::make_nvp("Position",ed.pos));
-    archive(cereal::make_nvp("Orientation",ed.m_orientation_pyr));
+    if (version == ENTITY_DATA_CLASS_VERSION)
+    {
+        archive(cereal::make_nvp("AccessLevel",ed.m_access_level));
+        archive(cereal::make_nvp("OriginIdx",ed.m_origin_idx));
+        archive(cereal::make_nvp("ClassIdx",ed.m_class_idx));
+        archive(cereal::make_nvp("Position",ed.pos));
+        archive(cereal::make_nvp("Orientation",ed.m_orientation_pyr));
+    }
+    else
+    {
+        qCritical() << "Failed to serialize EntityData, incompatible serialization format version " << version;
+    }
 }
 
 void saveTo(const EntityData & target, const QString & baseName, bool text_format)

--- a/Projects/CoX/Common/GameData/entitydata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/entitydata_serializers.cpp
@@ -4,24 +4,22 @@
 #include "DataStorage.h"
 #include "serialization_common.h"
 
-#define ENTITY_DATA_CLASS_VERSION 2
-CEREAL_CLASS_VERSION(EntityData, ENTITY_DATA_CLASS_VERSION); // register EntityData class version
+CEREAL_CLASS_VERSION(EntityData, EntityData::class_version); // register EntityData class version
 
 template<class Archive>
 void serialize(Archive & archive, EntityData &ed, uint32_t const version)
 {
-    if (version == ENTITY_DATA_CLASS_VERSION)
-    {
-        archive(cereal::make_nvp("AccessLevel",ed.m_access_level));
-        archive(cereal::make_nvp("OriginIdx",ed.m_origin_idx));
-        archive(cereal::make_nvp("ClassIdx",ed.m_class_idx));
-        archive(cereal::make_nvp("Position",ed.pos));
-        archive(cereal::make_nvp("Orientation",ed.m_orientation_pyr));
-    }
-    else
+    if (version != EntityData::class_version)
     {
         qCritical() << "Failed to serialize EntityData, incompatible serialization format version " << version;
+        return;
     }
+
+    archive(cereal::make_nvp("AccessLevel",ed.m_access_level));
+    archive(cereal::make_nvp("OriginIdx",ed.m_origin_idx));
+    archive(cereal::make_nvp("ClassIdx",ed.m_class_idx));
+    archive(cereal::make_nvp("Position",ed.pos));
+    archive(cereal::make_nvp("Orientation",ed.m_orientation_pyr));
 }
 
 void saveTo(const EntityData & target, const QString & baseName, bool text_format)


### PR DESCRIPTION
Closes #298.

My C++ is a little bit rusty but this should fit the bill. These are the only 2 versioned serialization functions I could find.

Additions/modifications proposed in this pull request:

- Display an error if the serialization version argument does not match the version of the object to be serialized
- Add macro / constant for current object version  
