### PR TITLE
Added slash commands for sending damage and health

### DIFF
--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -311,8 +311,26 @@ void setCombatLevel(Character &c, uint32_t val)
         val = 50;
     c.m_char_data.m_combat_level = val;
 }
-void    setHP(Character &c, uint32_t val) { c.m_current_attribs.m_HitPoints = val; }
-void    setEnd(Character &c, uint32_t val) { c.m_current_attribs.m_Endurance = val; }
+void setHP(Character &c, uint32_t val)
+{
+    if(val <= 0)
+        val = 0;
+
+    if(val > c.m_max_attribs.m_HitPoints)
+        val = c.m_max_attribs.m_HitPoints;
+
+    c.m_current_attribs.m_HitPoints = val;
+}
+void setEnd(Character &c, uint32_t val)
+{
+    if(val <= 0)
+        val = 0;
+
+    if(val > c.m_max_attribs.m_Endurance)
+        val = c.m_max_attribs.m_Endurance;
+
+    c.m_current_attribs.m_Endurance = val;
+}
 void    setLastCostumeId(Character &c, uint64_t val) { c.m_char_data.m_last_costume_id = val; }
 void    setMapName(Character &c, const QString &val) { c.m_char_data.m_mapName = val; }
 
@@ -403,9 +421,9 @@ void messageOutput(MessageChannel ch, QString &msg, Entity &tgt)
 /*
  * SendUpdate Wrappers to provide access to NetStructures
  */
-void sendDamage(Entity *src, uint32_t tgt_idx, uint32_t amount)
+void sendFloatingNumbers(Entity *src, uint32_t tgt_idx, int32_t amount)
 {
-    qCDebug(logSlashCommand, "Sending %d FloatingDamage from %d to %d", amount, src->m_idx, tgt_idx);
+    qCDebug(logSlashCommand, "Sending %d FloatingNumbers from %d to %d", amount, src->m_idx, tgt_idx);
     src->m_client->addCommandToSendNextUpdate(std::unique_ptr<FloatingDamage>(new FloatingDamage(src->m_idx, tgt_idx, amount)));
 }
 void sendFriendsListUpdate(Entity *src, FriendsList *friends_list)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -403,6 +403,11 @@ void messageOutput(MessageChannel ch, QString &msg, Entity &tgt)
 /*
  * SendUpdate Wrappers to provide access to NetStructures
  */
+void sendDamage(Entity *src, uint32_t tgt_idx, uint32_t amount)
+{
+    qCDebug(logSlashCommand, "Sending %d FloatingDamage from %d to %d", amount, src->m_idx, tgt_idx);
+    src->m_client->addCommandToSendNextUpdate(std::unique_ptr<FloatingDamage>(new FloatingDamage(src->m_idx, tgt_idx, amount)));
+}
 void sendFriendsListUpdate(Entity *src, FriendsList *friends_list)
 {
     qCDebug(logFriends) << "Sending FriendsList Update.";

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -121,6 +121,7 @@ void messageOutput(MessageChannel ch, QString &msg, Entity &tgt);
 /*
  * SendUpdate Wrappers to provide access to NetStructures
  */
+void sendDamage(Entity *src, uint32_t tgt_idx, uint32_t amount);
 void sendFriendsListUpdate(Entity *src, FriendsList *friends_list);
 void sendSidekickOffer(Entity *tgt, uint32_t src_db_id);
 void sendTeamLooking(Entity *tgt);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -121,7 +121,7 @@ void messageOutput(MessageChannel ch, QString &msg, Entity &tgt);
 /*
  * SendUpdate Wrappers to provide access to NetStructures
  */
-void sendDamage(Entity *src, uint32_t tgt_idx, uint32_t amount);
+void sendFloatingNumbers(Entity *src, uint32_t tgt_idx, int32_t amount);
 void sendFriendsListUpdate(Entity *src, FriendsList *friends_list);
 void sendSidekickOffer(Entity *tgt, uint32_t src_db_id);
 void sendTeamLooking(Entity *tgt);

--- a/Projects/CoX/Servers/MapServer/Events/FloatingDamage.h
+++ b/Projects/CoX/Servers/MapServer/Events/FloatingDamage.h
@@ -19,7 +19,7 @@ class FloatingDamage final : public GameCommand
 public:
     int whos_fault_was_it;
     int who_was_damaged;
-    int damage_amount;
+    int damage_amount; // should be float?
     FloatingDamage(int source,int target,int amount) : GameCommand(MapEventTypes::evFloatingDamage),
         whos_fault_was_it(source),
         who_was_damaged(target),

--- a/Projects/CoX/Servers/MapServer/SlashCommand.h
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.h
@@ -55,7 +55,7 @@ void cmdHandler_SetWindowVisibility(QString &cmd, Entity *e);
 void cmdHandler_KeybindDebug(QString &cmd, Entity *e);
 void cmdHandler_ToggleLogging(QString &cmd, Entity *e);
 void cmdHandler_FriendsListDebug(QString &cmd, Entity *e);
-void cmdHandler_SendDamage(QString &cmd, Entity *e);
+void cmdHandler_SendFloatingNumbers(QString &cmd, Entity *e);
 void cmdHandler_SetU1(QString &cmd, Entity *e);
 void cmdHandler_SetU2(QString &cmd, Entity *e);
 void cmdHandler_SetU3(QString &cmd, Entity *e);

--- a/Projects/CoX/Servers/MapServer/SlashCommand.h
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.h
@@ -55,6 +55,7 @@ void cmdHandler_SetWindowVisibility(QString &cmd, Entity *e);
 void cmdHandler_KeybindDebug(QString &cmd, Entity *e);
 void cmdHandler_ToggleLogging(QString &cmd, Entity *e);
 void cmdHandler_FriendsListDebug(QString &cmd, Entity *e);
+void cmdHandler_SendDamage(QString &cmd, Entity *e);
 void cmdHandler_SetU1(QString &cmd, Entity *e);
 void cmdHandler_SetU2(QString &cmd, Entity *e);
 void cmdHandler_SetU3(QString &cmd, Entity *e);

--- a/Projects/CoX/Servers/MapServer/WorldSimulation.cpp
+++ b/Projects/CoX/Servers/MapServer/WorldSimulation.cpp
@@ -26,11 +26,6 @@ void World::update(const ACE_Time_Value &tick_timer)
     for(Entity * e : ref_ent_mager.m_live_entlist)
     {
         updateEntity(e,delta);
-        if(e->m_client)
-        {
-            auto dmg = new FloatingDamage(e->m_idx,e->m_idx,1);
-            e->m_client->addCommandToSendNextUpdate(std::unique_ptr<FloatingDamage>(dmg));
-        }
     }
 }
 void World::physicsStep(Entity *e,uint32_t msec)


### PR DESCRIPTION
Addresses #149 

Additions/modifications proposed in this pull request:
- Add `/damage` and `/heal` slash commands
- Format is `/damage <iterations> <amount> <target_name>` and will accept replacement strings for target name
- Add `cmdHandler_SendFloatingNumbers()`
- Add `sendFloatingNumbers()` helper function
- Add some fringe-value support to `setHP()` and `setEnd()`
- Removed auto dmg from world update tick, which was confusing some new users.

![screenshot from 2018-04-11 01-52-43](https://user-images.githubusercontent.com/10159505/38606531-159ee96a-3d2b-11e8-854e-c58a4e463887.png)