### PR TITLE
Couple small fixes to m_account_level and Windows serialization

### DIFF
--- a/Projects/CoX/Common/GameData/gui_definitions.h
+++ b/Projects/CoX/Common/GameData/gui_definitions.h
@@ -76,16 +76,16 @@ public:
     GUIWindow() { }
 
         // GUI Window Params
-        WindowIDX           m_idx;
-        WindowVisibility    m_mode;
-        bool                m_draggable_frame;
-        uint32_t            m_posx;
-        uint32_t            m_posy;
-        uint32_t            m_width            = 0;
-        uint32_t            m_height           = 0;
-        uint32_t            m_locked;
-        uint32_t            m_color            = 0x3399FF99;   // 0x3399FF99 (light blue with 60% transparency)
-        uint32_t            m_alpha            = 0x88;         // default 136 (0x88)
+        WindowIDX           m_idx               = wdw_Unknown0;
+        WindowVisibility    m_mode              = wv_Uninitialized;
+        bool                m_draggable_frame   = false;
+        uint32_t            m_posx              = 0;
+        uint32_t            m_posy              = 0;
+        uint32_t            m_width             = 0;
+        uint32_t            m_height            = 0;
+        uint32_t            m_locked            = 0;
+        uint32_t            m_color             = 0x3399FF99;   // 0x3399FF99 (light blue with 60% transparency)
+        uint32_t            m_alpha             = 0x88;         // default 136 (0x88)
 
         void guiWindowDump() const
         {

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -393,7 +393,6 @@ void Character::sendWindows( BitStream &bs ) const
 
 void Character::sendWindow(BitStream &bs,const GUIWindow &wnd) const
 {
-
     qCDebug(logGUI) << "sendWindow:" << wnd.m_idx;
     if(logGUI().isDebugEnabled())
         wnd.guiWindowDump();

--- a/Projects/CoX/Common/NetStructures/Entity.cpp
+++ b/Projects/CoX/Common/NetStructures/Entity.cpp
@@ -161,7 +161,6 @@ void initializeNewPlayerEntity(Entity &e)
     e.m_has_supergroup                  = false;
     e.m_has_team                        = false;
     e.m_pchar_things                    = true;
-    e.m_entity_data.m_access_level      = 1;
 
     e.m_char->reset();
     e.might_have_rare = e.m_rare_bits   = true;

--- a/Projects/CoX/Servers/MapServer/MapClient.cpp
+++ b/Projects/CoX/Servers/MapServer/MapClient.cpp
@@ -33,4 +33,5 @@ void MapClient::entity( Entity * val )
 {
     m_ent = val;
     m_ent->m_char->setName(m_name); // this is used because the new characters are passed to us nameless
+    m_ent->m_entity_data.m_access_level = account_info().access_level();
 }


### PR DESCRIPTION
- Fix m_access_level by pulling value from `accountInfo()`.
- Initialize window settings to 0 (hopefully this fixes random crashing when server is running debug mode)
