### PR TITLE
[RFC] Email System

### DIFF
--- a/Projects/CoX/Servers/MapServer/CMakeLists.txt
+++ b/Projects/CoX/Servers/MapServer/CMakeLists.txt
@@ -40,6 +40,8 @@ SET(target_INCLUDE
     Events/GameCommandList.h
     Events/ChatDividerMoved.h
     Events/ChatMessage.h
+    Events/EmailHeaders.h
+    Events/EmailRead.h
     Events/EntitiesResponse.h
     Events/FloatingDamage.h
     Events/FriendsListUpdate.h

--- a/Projects/CoX/Servers/MapServer/CMakeLists.txt
+++ b/Projects/CoX/Servers/MapServer/CMakeLists.txt
@@ -41,6 +41,7 @@ SET(target_INCLUDE
     Events/ChatDividerMoved.h
     Events/ChatMessage.h
     Events/EmailHeaders.h
+    Events/EmailMessageStatus.h
     Events/EmailRead.h
     Events/EntitiesResponse.h
     Events/FloatingDamage.h

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -7,6 +7,8 @@
 #include "Character.h"
 #include "AdminServer/AdminServer.h"
 #include "AdminServer/CharacterDatabase.h"
+#include "Events/EmailHeaders.h"
+#include "Events/EmailRead.h"
 #include "Team.h"
 #include "LFG.h"
 #include "Logging.h"
@@ -268,6 +270,30 @@ void sendServerMOTD(Entity *e)
         qDebug() << errormsg;
         sendInfoMessage(MessageChannel::DEBUG_INFO, errormsg, src);
     }
+}
+
+void sendEmailHeaders(Entity *e){
+    if(!e->m_client)
+    {
+        qWarning() << "m_client does not yet exist!";
+        return;
+    }
+    MapClient *src = e->m_client;
+
+    EmailHeaders *header = new EmailHeaders(152, "TestSender ", "TEST", 576956720);
+    src->addCommandToSendNextUpdate(std::unique_ptr<EmailHeaders>(header));
+}
+
+void readEmailMessage(Entity *e, const int id){
+    if(!e->m_client)
+    {
+        qWarning() << "m_client does not yet exist!";
+        return;
+    }
+    MapClient *src = e->m_client;
+
+    EmailRead *msg = new EmailRead(id, "https://youtu.be/PsCKnxe8hGY\\nhttps://youtu.be/dQw4w9WgXcQ", "TestSender");
+    src->addCommandToSendNextUpdate(std::unique_ptr<EmailRead>(msg));
 }
 
 

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -1,6 +1,7 @@
 #pragma once
-#include "CommonNetStructures.h"
+
 #include "Events/MessageChannels.h"
+#include "CommonNetStructures.h"
 
 class QString;
 class Entity;
@@ -126,3 +127,9 @@ void sendFriendsListUpdate(Entity *src, FriendsList *friends_list);
 void sendSidekickOffer(Entity *tgt, uint32_t src_db_id);
 void sendTeamLooking(Entity *tgt);
 void sendTeamOffer(Entity *src, Entity *tgt);
+
+/*
+ * sendEmail Wrappers for providing access to Email Database
+ */
+void sendEmailHeaders(Entity *e);
+void readEmailMessage(Entity *e, const int id);

--- a/Projects/CoX/Servers/MapServer/Events/EmailHeaders.h
+++ b/Projects/CoX/Servers/MapServer/Events/EmailHeaders.h
@@ -15,7 +15,7 @@ class EmailHeaders final : public GameCommand
 {
 public:
     struct EmailHeader {
-        int valid = true;
+        bool valid; //Checked if the email exists, can probably use this to mark emails that are awaiting garbage collection
         int id;
         QString sender;
         QString subject;
@@ -25,53 +25,34 @@ public:
     /*Send multiple emails*/
     EmailHeaders(QVector<EmailHeader> &email) : GameCommand(MapEventTypes::evEmailHeadersCmd),
         m_fullupdate(true),
-        m_count(email.size()),
         m_emails(email)
     {
     }
 
     /*Defines a single email header to send*/
     EmailHeaders(const int &id, const QString &sender,  const QString &subject, const int &timestamp) : GameCommand(MapEventTypes::evEmailHeadersCmd),
-        m_fullupdate(false),
-        m_count(1),
-        m_id(id),
-        m_sender(sender),
-        m_subject(subject),
-        m_timestamp(timestamp)
+        m_fullupdate(false)
     {
+        m_emails.append(EmailHeader{ true, id, sender, subject, timestamp });
     }
 
     void    serializeto(BitStream &bs) const override {
         bs.StorePackedBits(1, type()-MapEventTypes::evFirstServerToClient);
         bs.StorePackedBits(1, m_fullupdate);
-        bs.StorePackedBits(1, m_count);
+        bs.StorePackedBits(1, m_emails.size());
 
-        if(m_count > 1){
-            for(int i = 0; i < m_count; ++i){
-                bs.StoreBits(1, m_emails.at(i).valid);
-                bs.StoreBits(32, m_emails.at(i).id);
-                bs.StoreString(m_emails.at(i).sender);
-                bs.StoreString(m_emails.at(i).subject);
-                bs.StoreBits(32, m_emails.at(i).timestamp);
-            }
-        }else{
-            bs.StoreBits(1, m_valid);
-            bs.StoreBits(32, m_id);
-            bs.StoreString(m_sender);
-            bs.StoreString(m_subject);
-            bs.StoreBits(32, m_timestamp);
+        for(const EmailHeader &hdr : m_emails){
+            bs.StoreBits(1, hdr.valid);
+            bs.StoreBits(32, hdr.id);
+            bs.StoreString(hdr.sender);
+            bs.StoreString(hdr.subject);
+            bs.StoreBits(32, hdr.timestamp);
         }
     }
     void    serializefrom(BitStream &src);
 
 protected:
-    int     m_fullupdate; //Basically forces a refresh of the email window
-    int     m_count;
-    int     m_valid = true; //Checked if the email exists, can probably use this to mark emails that are awaiting garbage collection
-    int     m_id;
-    QString m_sender;
-    QString m_subject;
-    int     m_timestamp; //# of seconds since Y2K, in relation to server defined timezone
+    bool    m_fullupdate; //Basically forces a refresh of the email window
 
     QVector<EmailHeader> m_emails;
 };

--- a/Projects/CoX/Servers/MapServer/Events/EmailHeaders.h
+++ b/Projects/CoX/Servers/MapServer/Events/EmailHeaders.h
@@ -15,7 +15,6 @@ class EmailHeaders final : public GameCommand
 {
 public:
     struct EmailHeader {
-        bool valid; //Checked if the email exists, can probably use this to mark emails that are awaiting garbage collection
         int id;
         QString sender;
         QString subject;
@@ -33,7 +32,7 @@ public:
     EmailHeaders(const int &id, const QString &sender,  const QString &subject, const int &timestamp) : GameCommand(MapEventTypes::evEmailHeadersCmd),
         m_fullupdate(false)
     {
-        m_emails.append(EmailHeader{ true, id, sender, subject, timestamp });
+        m_emails.push_back(EmailHeader{ id, sender, subject, timestamp });
     }
 
     void    serializeto(BitStream &bs) const override {
@@ -42,7 +41,7 @@ public:
         bs.StorePackedBits(1, m_emails.size());
 
         for(const EmailHeader &hdr : m_emails){
-            bs.StoreBits(1, hdr.valid);
+            bs.StoreBits(1, true); //"valid" flag
             bs.StoreBits(32, hdr.id);
             bs.StoreString(hdr.sender);
             bs.StoreString(hdr.subject);
@@ -52,7 +51,7 @@ public:
     void    serializefrom(BitStream &src);
 
 protected:
-    bool    m_fullupdate; //Basically forces a refresh of the email window
+    bool    m_fullupdate; //Forces a refresh of the email window
 
     QVector<EmailHeader> m_emails;
 };

--- a/Projects/CoX/Servers/MapServer/Events/EmailHeaders.h
+++ b/Projects/CoX/Servers/MapServer/Events/EmailHeaders.h
@@ -1,0 +1,77 @@
+/*
+ * Super Entity Game Server Project
+ * http://github.com/Segs
+ * Copyright (c) 2006 - 2017 Super Entity Game Server Team (see Authors.txt)
+ * This software is licensed! (See License.txt for details)
+ *
+ */
+
+#pragma once
+#include "GameCommandList.h"
+
+#include <QtCore/QString>
+
+class EmailHeaders final : public GameCommand
+{
+public:
+    struct EmailHeader {
+        int valid = true;
+        int id;
+        QString sender;
+        QString subject;
+        int timestamp;
+    };
+
+    /*Send multiple emails*/
+    EmailHeaders(QVector<EmailHeader> &email) : GameCommand(MapEventTypes::evEmailHeadersCmd),
+        m_fullupdate(true),
+        m_count(email.size()),
+        m_emails(email)
+    {
+    }
+
+    /*Defines a single email header to send*/
+    EmailHeaders(const int &id, const QString &sender,  const QString &subject, const int &timestamp) : GameCommand(MapEventTypes::evEmailHeadersCmd),
+        m_fullupdate(false),
+        m_count(1),
+        m_id(id),
+        m_sender(sender),
+        m_subject(subject),
+        m_timestamp(timestamp)
+    {
+    }
+
+    void    serializeto(BitStream &bs) const override {
+        bs.StorePackedBits(1, type()-MapEventTypes::evFirstServerToClient);
+        bs.StorePackedBits(1, m_fullupdate);
+        bs.StorePackedBits(1, m_count);
+
+        if(m_count > 1){
+            for(int i = 0; i < m_count; ++i){
+                bs.StoreBits(1, m_emails.at(i).valid);
+                bs.StoreBits(32, m_emails.at(i).id);
+                bs.StoreString(m_emails.at(i).sender);
+                bs.StoreString(m_emails.at(i).subject);
+                bs.StoreBits(32, m_emails.at(i).timestamp);
+            }
+        }else{
+            bs.StoreBits(1, m_valid);
+            bs.StoreBits(32, m_id);
+            bs.StoreString(m_sender);
+            bs.StoreString(m_subject);
+            bs.StoreBits(32, m_timestamp);
+        }
+    };
+    void    serializefrom(BitStream &src);
+
+protected:
+    int     m_fullupdate; //Basically forces a refresh of the email window
+    int     m_count;
+    int     m_valid = true; //Checked if the email exists, can probably use this to mark emails that are awaiting garbage collection
+    int     m_id;
+    QString m_sender;
+    QString m_subject;
+    int     m_timestamp; //# of seconds since Y2K, in relation to server defined timezone
+
+    QVector<EmailHeader> m_emails;
+};

--- a/Projects/CoX/Servers/MapServer/Events/EmailHeaders.h
+++ b/Projects/CoX/Servers/MapServer/Events/EmailHeaders.h
@@ -61,7 +61,7 @@ public:
             bs.StoreString(m_subject);
             bs.StoreBits(32, m_timestamp);
         }
-    };
+    }
     void    serializefrom(BitStream &src);
 
 protected:

--- a/Projects/CoX/Servers/MapServer/Events/EmailMessageStatus.h
+++ b/Projects/CoX/Servers/MapServer/Events/EmailMessageStatus.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "GameCommandList.h"
+
+#include <QtCore/QString>
+
+class EmailMessageStatus final : public GameCommand
+{
+public:
+    EmailMessageStatus(const int status, const QString &recipient) : GameCommand(MapEventTypes::evEmailMsgStatus),
+        m_status(status),
+        m_recipient(recipient)
+    {
+    }
+
+    void    serializeto(BitStream &bs) const override {
+        bs.StorePackedBits(1, type()-MapEventTypes::evFirstServerToClient);
+        bs.StorePackedBits(1, status);
+        bs.StoreString(m_recipient);
+    }
+
+    void    serializefrom(BitStream &src);
+
+protected:
+    int m_status;
+    QString m_recipient;
+};

--- a/Projects/CoX/Servers/MapServer/Events/EmailRead.h
+++ b/Projects/CoX/Servers/MapServer/Events/EmailRead.h
@@ -25,7 +25,7 @@ public:
         bs.StoreString(m_message);
         bs.StorePackedBits(1, m_count);
         bs.StoreString(m_recipient);
-    };
+    }
 
     void    serializefrom(BitStream &src);
 

--- a/Projects/CoX/Servers/MapServer/Events/EmailRead.h
+++ b/Projects/CoX/Servers/MapServer/Events/EmailRead.h
@@ -1,0 +1,37 @@
+/*
+ * Super Entity Game Server Project
+ * http://github.com/Segs
+ * Copyright (c) 2006 - 2017 Super Entity Game Server Team (see Authors.txt)
+ * This software is licensed! (See License.txt for details)
+ *
+ */
+
+#pragma once
+#include "GameCommandList.h"
+
+#include <QtCore/QString>
+
+class EmailRead final : public GameCommand
+{
+public:
+    EmailRead(const int id, const QString &message, const QString recipient) : GameCommand(MapEventTypes::evEmailReadCmd),
+        m_id(id), m_message(message), m_recipient(recipient)
+    {
+    }
+
+    void    serializeto(BitStream &bs) const override {
+        bs.StorePackedBits(1, type()-MapEventTypes::evFirstServerToClient);
+        bs.StoreBits(32, m_id);
+        bs.StoreString(m_message);
+        bs.StorePackedBits(1, m_count);
+        bs.StoreString(m_recipient);
+    };
+
+    void    serializefrom(BitStream &src);
+
+protected:
+    int m_id;
+    QString m_message;
+    int m_count = 1; //Doesn't do anything in Issue 0, seemingly, so hardcoding as 1
+    QString m_recipient; //Possible misnamed variable, as this is actually the sender in the email's read tab
+};

--- a/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
+++ b/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
@@ -63,6 +63,7 @@ public:
 //    EVENT_DECL(evCSRBugReport             ,164)
     EVENT_DECL(evEmailHeadersCmd            ,165)
     EVENT_DECL(evEmailReadCmd               ,166)
+    EVENT_DECL(evEmailMsgStatus             ,167)
     EVENT_DECL(evEntityInfoResponse         ,169) // Send entity info (description)
 //    EVENT_DECL(evClueUpdate               ,170)
 // client -> server commands

--- a/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
+++ b/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
@@ -61,6 +61,8 @@ public:
 //    EVENT_DECL(evDeadNoGurney             ,152)
 //    EVENT_DECL(evLevelUp                  ,160)
 //    EVENT_DECL(evCSRBugReport             ,164)
+    EVENT_DECL(evEmailHeadersCmd            ,165)
+    EVENT_DECL(evEmailReadCmd               ,166)
     EVENT_DECL(evEntityInfoResponse         ,169) // Send entity info (description)
 //    EVENT_DECL(evClueUpdate               ,170)
 // client -> server commands

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -81,7 +81,11 @@ std::vector<SlashCommand> g_defined_slash_commands = {
     {{"team_accept"}, "Accept Team invite", &cmdHandler_TeamAccept, 0},
     {{"team_decline"}, "Decline Team invite", &cmdHandler_TeamDecline, 0},
     {{"sidekick_accept"}, "Accept Sidekick invite", &cmdHandler_SidekickAccept, 0},
-    {{"sidekick_decline"}, "Decline Sidekick invite", &cmdHandler_SidekickDecline, 0}
+    {{"sidekick_decline"}, "Decline Sidekick invite", &cmdHandler_SidekickDecline, 0},
+    {{"emailheaders"}, "Request Email Headers", &cmdHandler_EmailHeaders, 0},
+    {{"emailread"}, "Request Email Message with Given ID", &cmdHandler_EmailRead, 0},
+    {{"emailsend"}, "Send Email", &cmdHandler_EmailSend, 0},
+    {{"emaildelete"}, "Delete Email with Given ID",&cmdHandler_EmailDelete, 0},
 };
 
 bool canAccessCommand(const SlashCommand &cmd, const Entity &e)
@@ -1105,4 +1109,47 @@ void cmdHandler_FriendList(QString &cmd, Entity *e) {
         return;
 
     toggleFriendList(*e);
+}
+
+void cmdHandler_EmailHeaders(QString &cmd, Entity *e) {
+    MapClient *src = e->m_client;
+
+    sendEmailHeaders(e);
+
+    QString msg = "Sent Email Headers";
+    qDebug().noquote() << msg;
+    sendInfoMessage(MessageChannel::DEBUG_INFO, msg, src);
+}
+
+void cmdHandler_EmailRead(QString &cmd, Entity *e){
+    MapClient *src = e->m_client;
+    int id = cmd.midRef(cmd.indexOf(' ')+1).toInt();
+
+    readEmailMessage(e, id);
+
+    QString msg = "Opening Email ID: " + QString::number(id);
+    qDebug().noquote() << msg;
+    sendInfoMessage(MessageChannel::DEBUG_INFO, msg, src);
+}
+
+void cmdHandler_EmailSend(QString &cmd, Entity *e){
+    MapClient *src = e->m_client;
+    QVector<QStringRef> args(cmd.splitRef(' '));
+
+    //storeEmailInDB(src, args);
+
+    QString msg = "Email Sent";
+    qDebug().noquote() << msg;
+    sendInfoMessage(MessageChannel::SERVER, msg, src);
+}
+
+void cmdHandler_EmailDelete(QString &cmd, Entity *e){
+    MapClient *src = e->m_client;
+    int id = cmd.midRef(cmd.indexOf(' ')+1).toInt();
+
+    //deleteEmailFromDB(id);
+
+    QString msg = "Email Deleted ID: " + QString::number(id);
+    qDebug().noquote() << msg;
+    sendInfoMessage(MessageChannel::DEBUG_INFO, msg, src);
 }

--- a/Projects/CoX/Servers/MapServer/SlashCommand.h
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.h
@@ -87,3 +87,7 @@ void cmdHandler_TeamBuffs(QString &cmd, Entity *e);
 void cmdHandler_Friend(QString &cmd, Entity *e);
 void cmdHandler_Unfriend(QString &cmd, Entity *e);
 void cmdHandler_FriendList(QString &cmd, Entity *e);
+void cmdHandler_EmailHeaders(QString &cmd, Entity *e);
+void cmdHandler_EmailRead(QString &cmd, Entity *e);
+void cmdHandler_EmailSend(QString &cmd, Entity *e);
+void cmdHandler_EmailDelete(QString &cmd, Entity *e);


### PR DESCRIPTION
**Additions:**
* Adds the EmailHeaders and EmailRead game commands
* Adds the EmailHeaders, EmailMessageStatus, and EmailRead events
* Support the sending of multiple headers or a single email header

Current functionality is just sending a test email header and email read with the same ID.

**TODO:**
* Add emails to the database with EmailSend (This will likely require some input sanitizing)
    Ex. /emailsend "\q[Name]\q " "Subject" "Content"
* Send EmailMessageStatus event on Success/Failure of Send, rather than using a InfoMessageCmd
* Add timestamp generation as the client does not send this information - This is the number of seconds elapsed since Y2K relative to the server's defined timezone (Currently 0, -12 GMT).
* Remove emails from database with EmailDelete (Will need to check that the entity ID is the owner, as EmailDelete only sends "emaildelete [id]")

![Email Image](https://i.imgur.com/wTReM2X.png)