### PR TITLE
Fixing Issue #227 (Zero-Termination of Login and Password Arrays)

### DIFF
--- a/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
@@ -148,12 +148,6 @@ void AuthHandler::auth_error(EventProcessor *lnk,uint32_t code)
     lnk->putq(new AuthorizationError(code));
 }
 
-static void zero_terminate_strings(LoginRequest *ev)
-{
-    ev->m_data.login[sizeof(ev->m_data.login) -1] = '\0';
-    ev->m_data.password[sizeof(ev->m_data.password) -1] = '\0';
-}
-
 bool AuthHandler::isClientConnectedAnywhere(uint32_t client_id)
 {
     uint64_t token = m_sessions.token_for_id(client_id);
@@ -275,9 +269,6 @@ void AuthHandler::on_login( LoginRequest *ev )
         lnk->putq(s_auth_error_blocked_account.shallow_copy());
         return;
     }
-
-    // for safety reasons, ensure the last character in the arrays are null-terminated
-    zero_terminate_strings(ev);
 
     if(!auth_db_handler)
     {

--- a/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
@@ -262,15 +262,15 @@ void AuthHandler::on_login( LoginRequest *ev )
     assert(m_authserv); // if this fails it means we were not created.. ( AuthServer is creation point for the Handler)
 
     // if username is too long (same size as with the related char array)
-    // will have no null-termination and take in pwd as well
-    if(strlen(ev->m_data.login) >= sizeof(ev->m_data.login))
+    // will have no null-termination and take in data from pwd array as well
+    if(ev->m_data.login[sizeof(ev->m_data.login) -1] != '\0')
     {
         lnk->putq(s_auth_error_blocked_account.shallow_copy());
         return;
     }
 
     // if password is too long
-    if (strlen(ev->m_data.password) >= sizeof(ev->m_data.password))
+    if (ev->m_data.password[sizeof(ev->m_data.password)-1] != '\0')
     {
         lnk->putq(s_auth_error_blocked_account.shallow_copy());
         return;

--- a/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
@@ -147,6 +147,13 @@ void AuthHandler::auth_error(EventProcessor *lnk,uint32_t code)
 {
     lnk->putq(new AuthorizationError(code));
 }
+
+void AuthHandler::zero_terminate_strings(LoginRequest *ev)
+{
+    memset(ev->m_data.login, 0x00, sizeof(ev->m_data.login));
+    memset(ev->m_data.password, 0x00, sizeof(ev->m_data.password));
+}
+
 bool AuthHandler::isClientConnectedAnywhere(uint32_t client_id)
 {
     uint64_t token = m_sessions.token_for_id(client_id);
@@ -257,18 +264,21 @@ void AuthHandler::on_login( LoginRequest *ev )
     if(!auth_db_handler)
     {
         lnk->putq(s_auth_error_no_db.shallow_copy()); // we cannot do much without that
+        zero_terminate_strings(ev);
         return;
     }
 
     if(lnk->m_state!=AuthLink::CONNECTED)
     {
         lnk->putq(s_auth_error_unknown.shallow_copy());
+        zero_terminate_strings(ev);
         return;
     }
     qDebug() <<"User" << ev->m_data.login<< "trying to login from" << lnk->peer_addr().get_host_addr();
     if(strlen(ev->m_data.login)<=2)
     {
         lnk->putq(s_auth_error_blocked_account.shallow_copy());
+        zero_terminate_strings(ev);
         return;
     }
     uint64_t sess_tok;
@@ -290,6 +300,8 @@ void AuthHandler::on_login( LoginRequest *ev )
     // here we will wait for db response, so here we're going to put the session on the read-to-reap list
     // in case db does not respond in sane time frame, the session is going to be removed.
     m_sessions.locked_mark_session_for_reaping(session_ptr,sess_tok);
+
+    zero_terminate_strings(ev);
 }
 void AuthHandler::on_server_list_request( ServerListRequest *ev )
 {

--- a/Projects/CoX/Servers/AuthServer/AuthHandler.h
+++ b/Projects/CoX/Servers/AuthServer/AuthHandler.h
@@ -95,6 +95,9 @@ protected:
     void        on_login( LoginRequest *ev );
     void        on_server_list_request( ServerListRequest *ev );
     void        on_server_selected(ServerSelectRequest *ev);
+
+    // zero-terminating login and password arrays from LoginRequest
+    void        zero_terminate_strings(LoginRequest *ev);
     //////////////////////////////////////////////////////////////////////////
     // Server <-> server event handlers
     void        on_retrieve_account_response(RetrieveAccountResponse *msg);

--- a/Projects/CoX/Servers/AuthServer/AuthHandler.h
+++ b/Projects/CoX/Servers/AuthServer/AuthHandler.h
@@ -96,8 +96,6 @@ protected:
     void        on_server_list_request( ServerListRequest *ev );
     void        on_server_selected(ServerSelectRequest *ev);
 
-    // zero-terminating login and password arrays from LoginRequest
-    void        zero_terminate_strings(LoginRequest *ev);
     //////////////////////////////////////////////////////////////////////////
     // Server <-> server event handlers
     void        on_retrieve_account_response(RetrieveAccountResponse *msg);


### PR DESCRIPTION
Affected files:
AuthHandler.cpp and AuthHandler.h

Additions/modifications proposed in this pull request:
- Zero-Terminate the login and password arrays of ev casted as a LoginRequest

Suggestions to save more coding space:
- Maybe make it so that we don't have to call the function before every return (Call the function inside the switch case instead?) 
