### PR TITLE
Mem fixes

### DIFF
--- a/Components/EventProcessor.cpp
+++ b/Components/EventProcessor.cpp
@@ -36,7 +36,10 @@ int EventProcessor::svc( )
             if (thr_count() > 1)
                 putq(mb); // put this back on our message queue, our siblings will receive it and shut down as well
             else
+            {
                 mb->release();
+                this->flush();
+            }
             return 0;
         }
         dispatch(mb);

--- a/Components/SEGSEvent.cpp
+++ b/Components/SEGSEvent.cpp
@@ -1,5 +1,6 @@
 #include "SEGSEvent.h"
 
+SEGSEvent SEGSEvent::s_ev_finish(SEGS_EventTypes::evFinish,nullptr);
 
 const char *SEGSEvent::info()
 {

--- a/Projects/CoX/Common/CRUDP_Protocol/CRUD_Link.cpp
+++ b/Projects/CoX/Common/CRUDP_Protocol/CRUD_Link.cpp
@@ -117,7 +117,7 @@ int CRUDLink::handle_output( ACE_HANDLE )
                 connection_update();
                 break;
             case SEGS_EventTypes::evDisconnect:
-                putq(new SEGSEvent(SEGS_EventTypes::evFinish)); // close the link
+                putq(SEGSEvent::s_ev_finish.shallow_copy()); // close the link
                 break;
             case CRUD_EventTypes::evPacket: // CRUDP_Protocol has posted a pre-parsed packet to us
                 event_for_packet(static_cast<PacketEvent *>(ev));

--- a/Projects/CoX/Common/Servers/ClientManager.h
+++ b/Projects/CoX/Common/Servers/ClientManager.h
@@ -268,7 +268,7 @@ public:
                     if(waiting_session.m_session->link()) // it's a temporary session
                     {
                         // telling the temporary link to close.
-                        waiting_session.m_session->link()->putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+                        waiting_session.m_session->link()->putq(SEGSEvent::s_ev_finish.shallow_copy());
                     }
                     // we destroy the session object
                     remove_by_token(waiting_session.m_session_token, waiting_session.m_session->auth_id());

--- a/Projects/CoX/Common/Servers/HandlerLocator.cpp
+++ b/Projects/CoX/Common/Servers/HandlerLocator.cpp
@@ -21,7 +21,7 @@ void shutDownAllActiveHandlers()
         warn<<"Shutting down GameDBSync..";
         while(game_db_handler->thr_count())
         {
-            game_db_handler->putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+            game_db_handler->putq(SEGSEvent::s_ev_finish.shallow_copy());
             game_db_handler->wait();
         }
         warn<<"Done";
@@ -34,7 +34,7 @@ void shutDownAllActiveHandlers()
         warn<<"Shutting down DBSync..";
         if(dbsync->thr_count()>0)
         {
-            dbsync->putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+            dbsync->putq(SEGSEvent::s_ev_finish.shallow_copy());
             dbsync->wait();
         }
         warn<<"Done";

--- a/Projects/CoX/Common/Servers/MessageBus.cpp
+++ b/Projects/CoX/Common/Servers/MessageBus.cpp
@@ -111,7 +111,7 @@ void postGlobalEvent(SEGSEvent *ev)
 /// \note this cannot be called from one of the message bus handling threads.
 void shutDownMessageBus()
 {
-    HandlerLocator::getMessageBus()->putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+    HandlerLocator::getMessageBus()->putq(SEGSEvent::s_ev_finish.shallow_copy());
     HandlerLocator::getMessageBus()->wait();
 
 }

--- a/Projects/CoX/Common/Servers/ServerEndpoint.cpp
+++ b/Projects/CoX/Common/Servers/ServerEndpoint.cpp
@@ -42,7 +42,7 @@ int ServerEndpoint::handle_output(ACE_HANDLE /*fd*/) //! Called when output is p
             if (send_cnt == -1)
             {
                 // inform the link that it should die.
-                pkt_ev->src()->putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+                pkt_ev->src()->putq(SEGSEvent::s_ev_finish.shallow_copy());
                 ACE_ERROR ((LM_ERROR,ACE_TEXT ("(%P|%t) %p\n"), ACE_TEXT ("send")));
                 ev->release();
                 break;

--- a/Projects/CoX/Servers/AuthServer/AuthServer.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthServer.cpp
@@ -132,11 +132,11 @@ bool AuthServer::ShutDown(const QString &reason)
         m_acceptor->close();
     }
     // force our handler to finish
-    m_handler->putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+    m_handler->putq(SEGSEvent::s_ev_finish.shallow_copy());
     m_handler->wait();
     qWarning() << "Shut down reason:" << reason;
     m_running = false;
-    putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+    putq(SEGSEvent::s_ev_finish.shallow_copy());
     wait();
     return true;
 }

--- a/Projects/CoX/Servers/GameServer/GameServer.cpp
+++ b/Projects/CoX/Servers/GameServer/GameServer.cpp
@@ -160,7 +160,7 @@ bool GameServer::ReadConfigAndRestart()
 bool GameServer::ShutDown(const QString &reason)
 {
     bool res = d->ShutDown(reason);
-    putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+    putq(SEGSEvent::s_ev_finish.shallow_copy());
     return res;
 }
 

--- a/Projects/CoX/Servers/GameServer/GameServer.h
+++ b/Projects/CoX/Servers/GameServer/GameServer.h
@@ -23,7 +23,7 @@ class GameServer  : public EventProcessor
 {
         class PrivateData;
 public:
-                                ~GameServer();
+                                ~GameServer() override;
                                 GameServer(int id);
         bool                    ReadConfigAndRestart();
         bool                    Run(void);

--- a/Projects/CoX/Servers/MapServer/MapManager.cpp
+++ b/Projects/CoX/Servers/MapServer/MapManager.cpp
@@ -19,14 +19,21 @@
 
 static QHash<QString,int> s_map_name_to_id =
 {
-    {"City_00_01",0}, // Outbreak
-    {"City_01_01",1}, // Atlas Park
-    {"City_01_03",29}, // Galaxy City
+    {"city_00_01",0}, // Outbreak
+    {"city_01_01",1}, // Atlas Park
+    {"city_01_03",29}, // Galaxy City
 };
 
 using namespace std;
 MapManager::MapManager( ) : m_max_instances(2)
 {
+}
+MapManager::~MapManager()
+{
+    for(auto & v : m_templates)
+    {
+        delete v.second;
+    }
 }
 //! \brief Loads all templates available in given directory, will populate m_templates attribute
 bool MapManager::load_templates(const QString &template_directory, uint8_t game_id, uint32_t map_id,
@@ -37,10 +44,10 @@ bool MapManager::load_templates(const QString &template_directory, uint8_t game_
     while (map_dir_visitor.hasNext())
     {
         QString dirname = map_dir_visitor.next();
-        if (dirname.contains("City_"))
+        if (dirname.contains("City_",Qt::CaseInsensitive))
         {
             auto tpl = new MapTemplate(map_dir_visitor.fileInfo().filePath(), game_id, map_id, loc);
-            m_templates[s_map_name_to_id[dirname]] = tpl;
+            m_templates[s_map_name_to_id[tpl->base_name()]] = tpl;
             m_name_to_template[tpl->client_filename()] = tpl;
             qCDebug(logSettings) << "Detected a map"<<map_dir_visitor.fileInfo().filePath();
         }

--- a/Projects/CoX/Servers/MapServer/MapManager.h
+++ b/Projects/CoX/Servers/MapServer/MapManager.h
@@ -26,6 +26,7 @@ class MapManager
     size_t                      m_max_instances; // how many maps can we instantiate
 public:
                     MapManager();
+                    ~MapManager();
     bool            load_templates(const QString &template_directory, uint8_t game_id, uint32_t map_id,
                                    const struct ListenAndLocationAddresses &loc);
     MapTemplate *   get_template(QString id);

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -67,7 +67,7 @@ bool MapServer::Run()
         return false;
     }
     assert(d->m_manager.num_templates()>0); // we have to have a world to run
-    return startup();
+    return true;
 }
 /**
  * @param  inipath Doc at RoamingServer::ReadConfig
@@ -116,7 +116,7 @@ bool MapServer::ShutDown(const QString &reason)
     qWarning() << "Shutting down map server because :"<<reason;
     // tell all instances to shut down too
     d->m_manager.shut_down_all();
-    putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+    putq(SEGSEvent::s_ev_finish.shallow_copy());
     return true;
 }
 
@@ -133,16 +133,6 @@ MapServerData &MapServer::runtimeData()
 void MapServer::sett_game_server_owner(uint8_t owner_id)
 {
     m_owner_game_server_id = owner_id;
-}
-
-/**
-* Processing according to MapServerStartup sequence diagram.
-*/
-bool MapServer::startup()
-{
-    //FIXME: global timer queue should be activated in some central place!
-    GlobalTimerQueue::instance()->activate();
-    return true;
 }
 
 void MapServer::dispatch(SEGSEvent *ev)

--- a/Projects/CoX/Servers/MapServer/MapServer.h
+++ b/Projects/CoX/Servers/MapServer/MapServer.h
@@ -38,7 +38,6 @@ public:
         void                    sett_game_server_owner(uint8_t owner_id);
 private:
         bool                    Run(void);
-        bool                    startup(); // MapServerStartup sequence diagram entry point.
         // EventProcessor interface
         void                    dispatch(SEGSEvent *ev) override;
         void                    on_expect_client(struct ExpectMapClientRequest *ev);

--- a/Projects/CoX/Servers/MapServer/MapTemplate.cpp
+++ b/Projects/CoX/Servers/MapServer/MapTemplate.cpp
@@ -36,7 +36,7 @@ void MapTemplate::shut_down_all()
     {
         if(instance->thr_count()>0)
         {
-            instance->putq(new SEGSEvent(SEGS_EventTypes::evFinish));
+            instance->putq(SEGSEvent::s_ev_finish.shallow_copy());
             instance->wait();
         }
         delete instance;
@@ -45,13 +45,17 @@ void MapTemplate::shut_down_all()
 
 QString MapTemplate::client_filename() const
 {
-    assert(m_map_filename.contains("City_"));
+    QString map_desc_from_path = base_name();
+    return QString("maps/city_zones/%1/%1.txt").arg(map_desc_from_path);
+}
+
+QString MapTemplate::base_name() const
+{
     int city_idx     = m_map_filename.indexOf("City_");
     int end_or_slash = m_map_filename.indexOf("/", city_idx);
     assert(city_idx != -1);
-    QString map_desc_from_path =
-        m_map_filename.mid(city_idx, end_or_slash == -1 ? -1 : m_map_filename.size() - end_or_slash).toLower();
-    return QString("maps/city_zones/%1/%1.txt").arg(map_desc_from_path);
+    return m_map_filename.mid(city_idx, end_or_slash == -1 ? -1 : m_map_filename.size() - end_or_slash).toLower();
+
 }
 
 size_t MapTemplate::num_instances()

--- a/Projects/CoX/Servers/MapServer/MapTemplate.h
+++ b/Projects/CoX/Servers/MapServer/MapTemplate.h
@@ -31,6 +31,7 @@ public:
         size_t                      num_instances();
         void                        shut_down_all();
         QString                     client_filename() const;
+        QString                     base_name() const;
 };
 // Generates instances based on some kind of schema file
 class GeneratedMapTemplate : public MapTemplate


### PR DESCRIPTION
SEGSEvent now can be constructed in global memory, thus allowing for efficient shallow_copies to be made and put on queues.
MapManager now correctly records/releases MapTemplates
