### PR TITLE
Add support for `Interact with this` packets

### DIFF
--- a/Projects/CoX/Servers/MapServer/CMakeLists.txt
+++ b/Projects/CoX/Servers/MapServer/CMakeLists.txt
@@ -61,6 +61,7 @@ SET(target_INCLUDE
     Events/TeamLooking.h
     Events/TeamOffer.h
     Events/InfoMessageCmd.h
+    Events/InteractWithEntity.h
     Events/WindowState.h
     NpcStore.h
     MapEventFactory.h

--- a/Projects/CoX/Servers/MapServer/Events/InteractWithEntity.h
+++ b/Projects/CoX/Servers/MapServer/Events/InteractWithEntity.h
@@ -1,0 +1,30 @@
+/*
+ * Super Entity Game Server Project
+ * http://segs.sf.net/
+ * Copyright (c) 2006 - 2018 Super Entity Game Server Team (see Authors.txt)
+ * This software is licensed! (See License.txt for details)
+ *
+ */
+
+#pragma once
+#include "GameCommandList.h"
+#include "Logging.h"
+
+#include "MapEvents.h"
+#include "MapLink.h"
+
+class InteractWithEntity final : public MapLinkEvent
+{
+public:
+    uint32_t m_srv_idx = 0;
+    InteractWithEntity() : MapLinkEvent(MapEventTypes::evInteractWithEntity) {}
+    void serializeto(BitStream &bs) const override
+    {
+        bs.StorePackedBits(1, type() - MapEventTypes::evConsoleCommand); // 7
+        bs.StorePackedBits(12, m_srv_idx);
+    }
+    void serializefrom(BitStream &src)
+    {
+        m_srv_idx = src.GetPackedBits(12);
+    }
+};

--- a/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
+++ b/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
@@ -72,6 +72,7 @@ public:
 //    EVENT_DECL(evRefreshWindows             ,203) // TODO: Refresh Windows? Issue #268
     EVENT_DECL(evClientResumedRendering     ,204)
     EVENT_DECL(evCookieRequest              ,206)
+    EVENT_DECL(evInteractWithEntity         ,207)
     EVENT_DECL(evSwitchTray                 ,208) // Switch Tray using left-right arrows next to power tray
     EVENT_DECL(evEnterDoor                  ,209)
     EVENT_DECL(evSetDestination             ,211)

--- a/Projects/CoX/Servers/MapServer/MapEventFactory.cpp
+++ b/Projects/CoX/Servers/MapServer/MapEventFactory.cpp
@@ -52,6 +52,7 @@ MapLinkEvent *MapEventFactory::CommandEventFromStream(BitStream & bs)
         //case 2: return new Unknown2; // TODO: What is this?
         //case 3: return new RefreshWindows; // TODO: Refreshes all windows? Issue #268
         case 4: return new ClientResumedRendering;
+        case 7: return new InteractWithEntity;
         case 8: return new SwitchTray;
         case 9: return new EnterDoor;
         case 11: return new SetDestination;

--- a/Projects/CoX/Servers/MapServer/MapEvents.h
+++ b/Projects/CoX/Servers/MapServer/MapEvents.h
@@ -622,3 +622,4 @@ public:
 #include "Events/SidekickOffer.h"
 #include "Events/TeamLooking.h"
 #include "Events/TeamOffer.h"
+#include "Events/InteractWithEntity.h"

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -310,6 +310,9 @@ void MapInstance::dispatch( SEGSEvent *ev )
         case MapEventTypes::evActivateInspiration:
             on_activate_inspiration(static_cast<ActivateInspiration *>(ev));
             break;
+        case MapEventTypes::evInteractWithEntity:
+            on_interact_with(static_cast<InteractWithEntity *>(ev));
+            break;
         case MapEventTypes::evSwitchTray:
             on_switch_tray(static_cast<SwitchTray *>(ev));
             break;
@@ -1820,4 +1823,10 @@ void MapInstance::on_select_keybind_profile(SelectKeybindProfile *ev)
 
     ent->m_player->m_keybinds.setKeybindProfile(ev->profile);
     qCDebug(logMapEvents) << "Saving currently selected Keybind Profile. Profile name: " << ev->profile;
+}
+void MapInstance::on_interact_with(InteractWithEntity *ev)
+{
+    MapClientSession &session(m_session_store.session_from_event(ev));
+
+    qCDebug(logMapEvents) << "Entity: " << session.m_ent->m_idx << "wants to interact with"<<ev->m_srv_idx;
 }

--- a/Projects/CoX/Servers/MapServer/MapInstance.h
+++ b/Projects/CoX/Servers/MapServer/MapInstance.h
@@ -123,4 +123,5 @@ protected:
         void on_set_keybind(class SetKeybind *ev);
         void on_remove_keybind(class RemoveKeybind *ev);
         void on_emote_command(const QString &command, Entity *ent);
+        void on_interact_with(class InteractWithEntity *ev);
 };


### PR DESCRIPTION
Server should no longer crash when clicking on spawned npcs
