### PR TITLE
Added MySQL and PostgreSQL support in dbtool.

### DIFF
--- a/Projects/CoX/Data/mysql/segs_game_mysql_create.sql
+++ b/Projects/CoX/Data/mysql/segs_game_mysql_create.sql
@@ -7,15 +7,14 @@ SET time_zone = "+00:00";
 /*!40101 SET NAMES utf8mb4 */;
 
 
+DROP TABLE IF EXISTS `accounts`;
 CREATE TABLE `accounts` (
   `id` int(11) NOT NULL,
   `account_id` int(11) DEFAULT NULL,
   `max_slots` int(11) NOT NULL DEFAULT '8'
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-INSERT INTO `accounts` (`id`, `account_id`, `max_slots`) VALUES
-(1, 1, 8);
-
+DROP TABLE IF EXISTS `characters`;
 CREATE TABLE `characters` (
   `id` int(11) NOT NULL,
   `account_id` int(11) NOT NULL,
@@ -32,6 +31,7 @@ CREATE TABLE `characters` (
   `player_data` mediumblob
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
+DROP TABLE IF EXISTS `costume`;
 CREATE TABLE `costume` (
   `id` int(11) NOT NULL,
   `character_id` int(11) NOT NULL,
@@ -40,6 +40,7 @@ CREATE TABLE `costume` (
   `parts` blob
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+DROP TABLE IF EXISTS `progress`;
 CREATE TABLE `progress` (
   `id` int(11) NOT NULL,
   `character_id` int(11) DEFAULT NULL,
@@ -49,6 +50,7 @@ CREATE TABLE `progress` (
   `souvenirs` blob
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+DROP TABLE IF EXISTS `supergroups`;
 CREATE TABLE `supergroups` (
   `id` int(11) NOT NULL,
   `supergroup_id` int(11) DEFAULT NULL,
@@ -62,6 +64,7 @@ CREATE TABLE `supergroups` (
   `sg_members` blob
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+DROP TABLE IF EXISTS `table_versions`;
 CREATE TABLE `table_versions` (
   `id` int(11) NOT NULL,
   `table_name` varchar(20) NOT NULL,
@@ -104,11 +107,11 @@ ALTER TABLE `table_versions`
 
 
 ALTER TABLE `accounts`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
 ALTER TABLE `characters`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 ALTER TABLE `costume`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 ALTER TABLE `progress`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 ALTER TABLE `supergroups`

--- a/Projects/CoX/Data/mysql/segs_mysql_create.sql
+++ b/Projects/CoX/Data/mysql/segs_mysql_create.sql
@@ -7,6 +7,7 @@ SET time_zone = "+00:00";
 /*!40101 SET NAMES utf8mb4 */;
 
 
+DROP TABLE IF EXISTS `accounts`;
 CREATE TABLE `accounts` (
   `id` int(11) NOT NULL,
   `username` varchar(20) NOT NULL,
@@ -16,9 +17,7 @@ CREATE TABLE `accounts` (
   `salt` blob NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-INSERT INTO `accounts` (`id`, `username`, `access_level`, `creation_date`, `passw`, `salt`) VALUES
-(1, 'segsadmin', 9, '2018-04-20 08:42:33', 0xab6ef29656c1a0b0f9ef11dba9de1393fe6494b445cf22d335c57d21108bcde0, 0x625551474b5942456364534a4a756f7a);
-
+DROP TABLE IF EXISTS `bans`;
 CREATE TABLE `bans` (
   `id` int(11) NOT NULL,
   `account_id` int(11) NOT NULL,
@@ -27,6 +26,7 @@ CREATE TABLE `bans` (
   `reason` text NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+DROP TABLE IF EXISTS `game_servers`;
 CREATE TABLE `game_servers` (
   `id` int(11) NOT NULL,
   `addr` varchar(20) NOT NULL,
@@ -35,6 +35,7 @@ CREATE TABLE `game_servers` (
   `token` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+DROP TABLE IF EXISTS `table_versions`;
 CREATE TABLE `table_versions` (
   `id` int(11) NOT NULL,
   `table_name` varchar(20) NOT NULL,
@@ -66,7 +67,7 @@ ALTER TABLE `table_versions`
 
 
 ALTER TABLE `accounts`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
 ALTER TABLE `bans`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 ALTER TABLE `game_servers`

--- a/Projects/CoX/Utilities/dbtool/CMakeLists.txt
+++ b/Projects/CoX/Utilities/dbtool/CMakeLists.txt
@@ -14,4 +14,4 @@ set(tool_SRC
 add_executable(dbtool ${tool_SRC})
 qt5_use_modules(dbtool Core)
 target_link_libraries(dbtool Qt5::Core Qt5::Sql)
-target_link_libraries(dbtool password_hasher)
+target_link_libraries(dbtool password_hasher SEGS_Components)

--- a/Projects/CoX/Utilities/dbtool/main.cpp
+++ b/Projects/CoX/Utilities/dbtool/main.cpp
@@ -1,10 +1,11 @@
 /*
-* SEGS dbtool v0.2 dated 2017-11-04
+* SEGS dbtool v0.4 dated 2018-04-22
 * A database creation and management tool.
 */
 #include "PasswordHasher/PasswordHasher.h"
 
-#include <iostream>
+#include <QtCore/QSettings>
+#include <QtCore/QString>
 #include <QtCore/QFileInfo>
 #include <QtCore/QFile>
 #include <QtCore/QDir>
@@ -16,8 +17,8 @@
 #include <QtSql/QSqlError>
 #include <QtSql/QSqlQuery>
 
-static QString segs = "segs";
-static QString segs_game = "segs_game";
+#include <iostream>
+#include <vector>
 
 static bool fileExists(QString path)
 {
@@ -25,11 +26,155 @@ static bool fileExists(QString path)
     return check_file.exists() && check_file.isFile();
 }
 
+class ConfigStruct
+{
+private:
+    void putFilePath();
+public:
+    QString m_driver;
+    QString m_dbname;
+    QString m_host;
+    QString m_port;
+    QString m_user;
+    QString m_pass;
+    QString m_file_path;
+    bool m_character_db = false;
+
+    ConfigStruct() = default;
+    
+    bool initialize_from_settings(const QString &settings_file_name, const QString &group_name);
+    
+    bool isMysql() const {return m_driver.startsWith("QMYSQL");}
+    bool isPostgresql() const {return m_driver.startsWith("QPSQL");}
+    bool isSqlite() const {return m_driver.startsWith("QSQLITE");}
+
+};
+
+bool ConfigStruct::initialize_from_settings(const QString &settings_file_name, const QString &group_name){
+    if(!fileExists(settings_file_name))
+        return false;
+    
+    QSettings config(settings_file_name,QSettings::IniFormat,nullptr);
+    
+    config.beginGroup(QStringLiteral("AdminServer"));
+    config.beginGroup(group_name);
+    m_driver = config.value(QStringLiteral("db_driver"),"QSQLITE").toString();
+    m_dbname = config.value(QStringLiteral("db_name"),"segs").toString();
+    m_host = config.value(QStringLiteral("db_host"),"127.0.0.1").toString();
+    m_port = config.value(QStringLiteral("db_port"),"5432").toString();
+    m_user = config.value(QStringLiteral("db_user"),"segs").toString();
+    m_pass = config.value(QStringLiteral("db_pass"),"segs123").toString();
+    m_character_db = group_name.compare("AccountDatabase");
+    putFilePath();
+    config.endGroup(); // group_name
+    config.endGroup(); // AdminServer
+    return true;
+}
+
+
+void ConfigStruct::putFilePath()
+{
+    QDir db_dir(QDir::currentPath());
+    if(isSqlite())
+    {
+        if(m_character_db)
+            m_file_path = db_dir.currentPath() + "/default_dbs/sqlite/segs_sqlite_create.sql";
+        else
+            m_file_path = db_dir.currentPath() + "/default_dbs/sqlite/segs_game_sqlite_create.sql";
+    }
+    else if(isMysql())
+    {
+        if(m_character_db)
+            m_file_path = db_dir.currentPath() + "/default_dbs/mysql/segs_mysql_create.sql";
+        else
+            m_file_path = db_dir.currentPath() + "/default_dbs/mysql/segs_game_mysql_create.sql";
+    }
+    else if(isPostgresql())
+    {
+        if(m_character_db)
+            m_file_path = db_dir.currentPath() + "/default_dbs/pgsql/segs_postgres_create.sql";
+        else
+            m_file_path = db_dir.currentPath() + "/default_dbs/pgsql/segs_game_postgres_create.sql";
+    }
+    else
+        qFatal("Unknown database driver.");
+}
+
+bool dbExists(const ConfigStruct &database_to_look_for)
+{
+    bool ret = false;
+    QString querytext;
+    if(database_to_look_for.isSqlite())
+        return ret;
+    else if(database_to_look_for.isMysql() || database_to_look_for.isPostgresql())
+    {
+        QSqlDatabase segs_db(QSqlDatabase::addDatabase(database_to_look_for.m_driver,
+                                                       database_to_look_for.m_dbname));
+        QSqlQuery query(segs_db);
+        segs_db.setDatabaseName(database_to_look_for.m_dbname);
+        segs_db.setHostName(database_to_look_for.m_host);
+        segs_db.setPort(database_to_look_for.m_port.toInt());
+        segs_db.setUserName(database_to_look_for.m_user);
+        segs_db.setPassword(database_to_look_for.m_pass);
+        segs_db.open();
+        if(database_to_look_for.isMysql())
+            querytext = "show tables";
+        else
+        {
+            querytext = "SELECT table_schema || '.' || table_name FROM";
+            querytext.append("information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema ='");
+            querytext.append(database_to_look_for.m_dbname);
+            querytext.append("';");
+        }
+        query.exec(querytext);
+        if(query.size() >= 1)
+            ret = true;
+        
+        segs_db.close();
+    }
+    QSqlDatabase::removeDatabase(database_to_look_for.m_dbname);
+    return ret;
+}
+
+bool deleteDb(QString const& db_file_name)
+{
+    QFile target_file(db_file_name);
+    if(target_file.exists() && !target_file.remove())
+        return false;
+    
+    return true;
+}
+
 void Pause(void)
 {
     qInfo() << endl << "Press ENTER to continue...";
     std::cin.ignore(100000, '\n');  // Ignore characters until an ENTER (newline) is received.
     return;
+}
+
+bool fileQueryDb(QFile &source_file, QSqlQuery &query)
+{
+    // Open file. If unsuccessful, return early.
+    if(!source_file.open(QIODevice::ReadOnly))
+    {
+        qWarning().noquote()<<"Query source file could not be opened.";
+        return false;
+    }
+    // The SQLite driver executes only a single (the first) query in the QSqlQuery.
+    // If the script contains more queries, it needs to be split.
+    QStringList scriptQueries = QTextStream(&source_file).readAll().split(';');
+    
+    foreach(QString queryTxt, scriptQueries) // Execute each command in the source file.
+    {
+        if(queryTxt.trimmed().isEmpty())
+            continue;
+        
+        if(!query.exec(queryTxt))
+            return false;
+        
+        query.finish();
+    }
+    return true;
 }
 
 void errorHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
@@ -56,90 +201,96 @@ void errorHandler(QtMsgType type, const QMessageLogContext &context, const QStri
             fprintf(stderr, "%sWARNING!%s %s\n", colorTable[1], resetColor, localMsg.constData());
             break;
         case QtCriticalMsg:
-            fprintf(stderr, "%sCRITICAL!%s %s (%s:%u, %s)\n", colorTable[2], resetColor, localMsg.constData(), context.file, context.line, context.function);
+            fprintf(stderr, "%sCRITICAL!%s %s (%s:%u, %s)\n", colorTable[2], resetColor, localMsg.constData(),
+                    context.file, context.line, context.function);
             break;
         case QtFatalMsg:
-            fprintf(stderr, "%sFATAL!%s %s (%s:%u, %s)\n", colorTable[3], resetColor, localMsg.constData(), context.file, context.line, context.function);
+            fprintf(stderr, "%sFATAL!%s %s (%s:%u, %s)\n", colorTable[3], resetColor, localMsg.constData(),
+                    context.file, context.line, context.function);
             abort();
     }
 }
 
-void createDatabases()
+void createDatabases(std::vector<ConfigStruct> const& configs)
 {
-    QDir db_dir(QDir::currentPath());
-    qInfo() << "Creating database files...";
-    std::map<QString, QString> files_and_targets =
+    qInfo() << "Creating databases...";
+
+    for(const ConfigStruct &cfg : configs)
     {
+        if(!QFileInfo(cfg.m_file_path).isReadable())
         {
-            db_dir.currentPath() + "/default_dbs/sqlite/segs_sqlite_create.sql",
-            db_dir.currentPath() + "/segs"
-        },
-        {
-            db_dir.currentPath() + "/default_dbs/sqlite/segs_game_sqlite_create.sql",
-            db_dir.currentPath() + "/segs_game"
+            qCritical() << cfg.m_file_path << "is not readable!"
+                        << "Please check that the file is present and not corrupted.";
+            break;
         }
-    };
-//    if(nofile)
-//        db_files << db_dir.currentPath() + "/default_dbs/sqlite/segs_sqlite_create.sql" << db_dir.currentPath() + "./default_dbs/sqlite/segs_game_sqlite_create.sql";
-//    else
-//        db_files = args;
-    for(const std::pair<QString, QString> &source_and_target : files_and_targets)
-    {
-        const QString &source_file_string(source_and_target.first);
-        const QString &target_file_string(source_and_target.second);
-        if(!QFileInfo(source_file_string).isReadable())
-        {
-          qCritical() << source_file_string << "is not readable! Please check that the file is present and not corrupted.";
-          break;
-        }
-        QFile source_file(source_file_string);
-        QFile target_file(target_file_string);
-        QSqlDatabase segs_db(QSqlDatabase::addDatabase("QSQLITE",target_file_string));
+        QFile source_file(cfg.m_file_path);
+        QSqlDatabase segs_db(QSqlDatabase::addDatabase(cfg.m_driver, cfg.m_dbname));
         QSqlQuery query(segs_db);
-        if(target_file.exists())
+        segs_db.setDatabaseName(cfg.m_dbname);
+        if(cfg.isSqlite())
         {
-            if(!target_file.remove()) // We have to remove the file if it already exists; otherwise, many errors are thrown.
+            // We have to remove the file if it already exists;
+            // otherwise, many errors are thrown.
+            if(!deleteDb(cfg.m_dbname))
             {
-                qInfo("FAILED to remove existing file:");
-                qInfo().noquote()<<target_file_string;
+                qWarning(qPrintable(QString("FAILED to remove existing file: %1").arg(cfg.m_dbname)));
                 qFatal("Ensure no processes are using it and you have permission to modify it.");
             }
         }
-        segs_db.setDatabaseName(target_file_string);
-        segs_db.open(); // /*INSERT INTO accounts VALUES(1,'segsadmin',1,'2017-11-11 17:41:19',X'7365677331323300000000000000');*/ <- ignore this
-        if(source_file.open(QIODevice::ReadOnly)) // Execute each command in the source file.
+        else if(cfg.isMysql() || cfg.isPostgresql())
         {
-            // The SQLite driver executes only a single (the first) query in the QSqlQuery.
-            // If the script contains more queries, it needs to be split.
-            QStringList scriptQueries = QTextStream(&source_file).readAll().split(';');
-
-            foreach(QString queryTxt, scriptQueries)
-            {
-                if(queryTxt.trimmed().isEmpty())
-                {
-                    continue;
-                }
-                if(!query.exec(queryTxt))
-                {
-                    segs_db.rollback(); // Roll back the database if something goes wrong, so we're not left with useless poop.
-                    qFatal("One of the query failed to execute.\n Error detail: %s\n",qPrintable(query.lastError().text()));
-                }
-                query.finish();
-            }
+            segs_db.setHostName(cfg.m_host);
+            segs_db.setPort(cfg.m_port.toInt());
+            segs_db.setUserName(cfg.m_user);
+            segs_db.setPassword(cfg.m_pass);
         }
+        if(!segs_db.open())
+        {
+            qCritical("Could not open connection to database.\n Details:%s",
+                      qPrintable(segs_db.lastError().text()));
+            break;
+        }
+        if(!fileQueryDb(source_file, query))
+        {
+            // Roll back the database if something goes wrong,
+            // so we're not left with useless poop.
+            segs_db.rollback(); 
+            qFatal("One of the queries failed to execute.\n Error detail: %s\n",
+                   qPrintable(query.lastError().text()));
+        }
+        source_file.close();
         segs_db.close();
-        qInfo() << "COMPLETED creating:" << target_file_string;
+        qInfo() << "COMPLETED creating:" << cfg.m_dbname;
     }
+    for(auto opened: configs)
+        QSqlDatabase::removeDatabase(opened.m_dbname);
 }
 
-void addAccount(const QString & username, const QString & password, uint16_t access_level)
+void addAccount(const ConfigStruct &char_database, const QString & username,
+                const QString & password, uint16_t access_level)
 {
     QDir db_dir(QDir::currentPath());
-    const QString &target_file_string(db_dir.currentPath() + "/segs");
-    QFile target_file(target_file_string);
-
-    QSqlDatabase segs_db(QSqlDatabase::addDatabase("QSQLITE"));
+    QString target_file_string("");
+    if(char_database.isSqlite())
+    {
+        target_file_string = db_dir.currentPath() + "/" + char_database.m_dbname ;
+        QFile target_file(target_file_string);
+        if(!target_file.exists())
+            qFatal("Target file could not be found. Verify its existence and try again.");
+    }
+    else
+        target_file_string = char_database.m_dbname;
+    
+    QSqlDatabase segs_db(QSqlDatabase::addDatabase(char_database.m_driver,
+                                                   char_database.m_dbname));
     segs_db.setDatabaseName(target_file_string);
+    if(char_database.isMysql() || char_database.isPostgresql())
+    {
+        segs_db.setHostName(char_database.m_host);
+        segs_db.setPort(char_database.m_port.toInt());
+        segs_db.setUserName(char_database.m_user);
+        segs_db.setPassword(char_database.m_pass);
+    }
     segs_db.open();
     QSqlQuery query(segs_db);
     if(!query.prepare("INSERT INTO accounts (username,passw,access_level,salt) VALUES (?,?,?,?);"))
@@ -156,13 +307,13 @@ void addAccount(const QString & username, const QString & password, uint16_t acc
     query.bindValue(2, access_level);
     query.bindValue(3, salt);
 
-    if(!target_file.exists())
-        qFatal("Target file could not be found. Verify its existence and try again.");
     if(!query.exec())
     {
         qDebug() << "SQL_ERROR:" << query.lastError(); // Why the query failed
         return;
     }
+    query.finish();
+    segs_db.close();
 }
 
 int main(int argc, char **argv)
@@ -172,15 +323,20 @@ int main(int argc, char **argv)
     qInstallMessageHandler(errorHandler);
     QCoreApplication app(argc,argv);
     QCoreApplication::setApplicationName("segs-dbtool");
-    QCoreApplication::setApplicationVersion("0.3");
+    QCoreApplication::setApplicationVersion("0.4");
 
     QCommandLineParser parser;
     parser.setApplicationDescription("SEGS database management utility");
     parser.addHelpOption();
     parser.addVersionOption();
 
+    std::vector<ConfigStruct> configs;
+    configs.emplace_back(ConfigStruct());
+    configs.emplace_back(ConfigStruct());
 
-    parser.addPositionalArgument("command", QCoreApplication::translate("main", "Command to execute."),"(create|adduser)");
+    parser.addPositionalArgument("command",
+                                 QCoreApplication::translate("main", "Command to execute."),
+                                 "(create|adduser)");
 
     // A boolean option with multiple names (-f, --force)
     QCommandLineOption forceOption(QStringList() << "f" << "force",
@@ -191,11 +347,15 @@ int main(int argc, char **argv)
         QCoreApplication::translate("main", "Provide password for added account"),"password");
     QCommandLineOption accessLevelOption(QStringList() << "a" << "access_level",
         QCoreApplication::translate("main", "Provide access_level [1-9] for account"),"access_level","1");
+    QCommandLineOption configFileOption(QStringList() << "c" << "config",
+        QCoreApplication::translate("main", "Use provided settings file, default = settings.cfg"),
+                                        "config", "settings.cfg");
     parser.addOption(forceOption);
     parser.addOption(loginOption);
     parser.addOption(passOption);
     parser.addOption(accessLevelOption);
-
+    parser.addOption(configFileOption);
+    
     parser.process(app);
     const QStringList positionalArguments = parser.positionalArguments();
     if(positionalArguments.size()<1 || !known_commands.contains(positionalArguments.first()))
@@ -206,6 +366,14 @@ int main(int argc, char **argv)
             qDebug()<<"Command is required";
         parser.showHelp(1);
     }
+    
+    if(!configs[0].initialize_from_settings(parser.value(configFileOption), "AccountDatabase"))
+    {
+        qFatal(qPrintable(QString("File \"%1\" not found.").arg(parser.value(configFileOption))));
+        return 2;
+    }
+    configs[1].initialize_from_settings(parser.value(configFileOption), "CharacterDatabase");
+    
     int selected_operation = known_commands.indexOf(positionalArguments.first());
     switch (selected_operation) {
         case 0:
@@ -216,7 +384,8 @@ int main(int argc, char **argv)
             QDir default_dbs_dir(QDir::currentPath() + "/default_dbs");
             if(!default_dbs_dir.exists())
             {
-                qDebug() << "SEGS dbtool must be run from the SEGS root folder (where the default_dbs directory resides)";
+                qDebug() << "SEGS dbtool must be run from the SEGS root folder "
+                         << "(where the default_dbs directory resides)";
                 Pause();
                 return 0;
             }
@@ -224,13 +393,22 @@ int main(int argc, char **argv)
 
             // Check if database already exists
             qInfo() << "Checking for existing databases OR -f command...";
-            if((fileExists(segs) || fileExists(segs_game)) && !forced)
+            if((((configs[0].isSqlite() && fileExists(configs[0].m_dbname)) ||
+                 (configs[1].isSqlite() && fileExists(configs[1].m_dbname))) ||
+                (((configs[0].isMysql() || configs[0].isPostgresql()) &&
+                  dbExists(configs[0])) ||
+                 ((configs[1].isMysql() || configs[1].isPostgresql()) &&
+                  dbExists(configs[1]))))
+               && !forced)
             {
-                if(fileExists(segs))
-                    qWarning() << "Database" << segs << "already exists.";
-                if(fileExists(segs_game))
-                    qWarning() << "Database" << segs_game << "already exists.";
-                qDebug() << "Run dbtool with -f option to overwrite existing databases. THIS CANNOT BE UNDONE.";
+                if(fileExists(configs[0].m_dbname) || dbExists(configs[0]))
+                    qWarning() << "Database" << configs[0].m_dbname << "already exists.";
+                
+                if(fileExists(configs[1].m_dbname) || dbExists(configs[1]))
+                    qWarning() << "Database" << configs[1].m_dbname << "already exists.";
+                
+                qInfo() << "Run dbtool with -f option to overwrite existing databases. "
+                         << "THIS CANNOT BE UNDONE.";
                 Pause();
                 return 0;
             }
@@ -238,8 +416,8 @@ int main(int argc, char **argv)
             if(forced)
                 qWarning() << "Forced flag used '-f'. Existing databases may be overwritten.";
 
-            createDatabases();
-            addAccount("segsadmin", "segs123", 9);
+            createDatabases(configs);
+            addAccount(configs[1], "segsadmin", "segs123", 9);
             break;
         }
         case 1:
@@ -249,12 +427,13 @@ int main(int argc, char **argv)
                 qCritical()<< "adduser operation requires login and password";
                 return -1;
             }
-            if(!fileExists(segs))
+            if(configs[0].isSqlite() && !fileExists(configs[0].m_dbname))
             {
                 qCritical() << "Cannot add account, the database does not exist";
                 return -1;
             }
-            addAccount(parser.value(loginOption),parser.value(passOption),parser.value(accessLevelOption).toUInt());
+            addAccount(configs[1], parser.value(loginOption),
+                       parser.value(passOption), parser.value(accessLevelOption).toUInt());
         }
     }
     Pause();


### PR DESCRIPTION
Additions/modifications proposed in this pull request:
- dbtool now cares about settings.cfg
- dbtool always selects db_driver and db_name from settings.cfg
- If db_driver != QSQLITE, db_host, db_port, db_user and db_pass from settings.cfg is used
- Both database creation and user addition works

Left to do:
- ~~dbtool will not work if selected MySQL database is not available~~
- ~~dbtool will not work if a MySQL table already exists~~
- ~~dbtool does not check if MySQL database is available before trying to execute queries~~
- ~~dbtool does not fetch settings file name dynamically (i.e. "settings.cfg" is hard coded)~~

Updated: If user has permissions, new databases will be created.
If -force is provided, old tables will be dropped and new ones created.

-c/--config switch used to select settings file other than settings.cfg
dbtool no longer relies on global variables.