### PR TITLE
Compiler warning fixes to address #352

### DIFF
--- a/Projects/CoX/Common/AuthProtocol/AuthLink.cpp
+++ b/Projects/CoX/Common/AuthProtocol/AuthLink.cpp
@@ -216,6 +216,7 @@ int AuthLink::handle_output( ACE_HANDLE /*= ACE_INVALID_HANDLE*/ )
 
 void AuthLink::encode_buffer(const AuthLinkEvent *ev,size_t start)
 {
+    (void)start; // temporary to quell unused var warning similar to Q_UNUSED
     assert(ev);
     if(ev==nullptr)
         return;

--- a/Projects/CoX/Common/GameData/Colors.h
+++ b/Projects/CoX/Common/GameData/Colors.h
@@ -16,11 +16,12 @@ struct ARGB
     {
         uint8_t v[4];
         uint32_t val;
-        struct { uint8_t a,r,g,b;};
+        struct { uint8_t a,r,g,b;} argb;
     };
     ARGB() {}
     ARGB(uint32_t _v) { val =_v;}
 };
+
 struct URG {
     uint32_t v;
     URG & operator=(uint32_t x) {
@@ -42,6 +43,7 @@ struct URG {
     uint8_t A() const { return (v>>24) & 0xFF; }
 
 };
+
 #pragma pack(push,1)
 struct RGB
 {
@@ -56,6 +58,7 @@ struct RGB
         return B;
     }
 };
+
 #pragma pack(pop)
 static_assert(sizeof(RGB)==3,"sizeof(RGB)==3");
 
@@ -65,41 +68,47 @@ struct RGBA
     {
         uint8_t v[4];
         uint32_t val;
-        struct { uint8_t r,g,b,a;};
-        struct { uint8_t x,y,z,w;};
+        struct { uint8_t r,g,b,a;} rgba;
+        struct { uint8_t x,y,z,w;} xyzw;
     };
-    RGBA(uint8_t r_,uint8_t g_,uint8_t b_,uint8_t a_) : r(r_),g(g_),b(b_),a(a_) {}
+    RGBA(uint8_t r_,uint8_t g_,uint8_t b_,uint8_t a_)
+    {
+      rgba.r = r_;
+      rgba.g = g_;
+      rgba.b = b_;
+      rgba.a = a_;
+    }
     RGBA() {}
     RGBA(uint32_t v)  {
-        a = v & 0xFF;
+        rgba.a = v & 0xFF;
         v>>=8;
-        b = v & 0xFF;
+        rgba.b = v & 0xFF;
         v>>=8;
-        g = v & 0xFF;
+        rgba.g = v & 0xFF;
         v>>=8;
-        r = v & 0xFF;
+        rgba.r = v & 0xFF;
     }
     RGBA &operator=(uint32_t v) {
-        a = v & 0xFF;
+        rgba.a = v & 0xFF;
         v>>=8;
-        b = v & 0xFF;
+        rgba.b = v & 0xFF;
         v>>=8;
-        g = v & 0xFF;
+        rgba.g = v & 0xFF;
         v>>=8;
-        r = v & 0xFF;
+        rgba.r = v & 0xFF;
         return *this;
     }
     RGBA &operator=(RGB v) {
-        b = v.B;
-        g = v.G;
-        r = v.R;
+        rgba.b = v.B;
+        rgba.g = v.G;
+        rgba.r = v.R;
         return *this;
     }
-    bool rgb_are_zero() const { return !(r|g|b); }
+    bool rgb_are_zero() const { return !(rgba.r|rgba.g|rgba.b); }
     uint8_t &operator[](uint8_t idx) { return v[idx];}
-    glm::vec4 toFloats() const { return glm::vec4(r/255.0f,g/255.0f,b/255.0f,a/255.0f); }
-    glm::vec3 to3Floats() const { return glm::vec3(r/255.0f,g/255.0f,b/255.0f); }
-    RGB toRGB() const { return {r,g,b}; }
+    glm::vec4 toFloats() const { return glm::vec4(rgba.r/255.0f,rgba.g/255.0f,rgba.b/255.0f,rgba.a/255.0f); }
+    glm::vec3 to3Floats() const { return glm::vec3(rgba.r/255.0f,rgba.g/255.0f,rgba.b/255.0f); }
+    RGB toRGB() const { return {rgba.r, rgba.g, rgba.b}; }
 };
 
 //static_assert(offsetof(RGBA,r)==0,"");

--- a/Projects/CoX/Common/GameData/DataStorage.cpp
+++ b/Projects/CoX/Common/GameData/DataStorage.cpp
@@ -91,7 +91,7 @@ bool BinStore::read_data_blocks( bool file_data_blocks )
     }
     quint64 read_end = m_str.pos();
     m_file_sizes.push_back(m_str.size()-read_end);
-    return (sz==(read_end-read_start));
+    return (static_cast<unsigned>(sz) == (read_end-read_start));
 }
 
 bool BinStore::open(const QString &name,uint32_t required_crc )

--- a/Projects/CoX/Common/GameData/entitydata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/entitydata_serializers.cpp
@@ -17,7 +17,7 @@
 #include "serialization_common.h"
 
 const constexpr uint32_t EntityData::class_version;
-CEREAL_CLASS_VERSION(EntityData, EntityData::class_version); // register EntityData class version
+CEREAL_CLASS_VERSION(EntityData, EntityData::class_version) // register EntityData class version
 
 template<class Archive>
 void serialize(Archive & archive, EntityData &ed, uint32_t const version)

--- a/Projects/CoX/Common/GameData/gui_serializers.cpp
+++ b/Projects/CoX/Common/GameData/gui_serializers.cpp
@@ -17,7 +17,7 @@
 #include "serialization_common.h"
 
 const constexpr uint32_t GUISettings::class_version;
-CEREAL_CLASS_VERSION(GUISettings, GUISettings::class_version); // register GUISettings class version
+CEREAL_CLASS_VERSION(GUISettings, GUISettings::class_version) // register GUISettings class version
 
 template<class Archive>
 void serialize(Archive &archive, GUIWindow &wnd)

--- a/Projects/CoX/Common/GameData/npc_definitions.h
+++ b/Projects/CoX/Common/GameData/npc_definitions.h
@@ -64,6 +64,6 @@ struct Parse_NPC
     int m_XP;
     std::vector<NPCPower_Desc> m_Powers;
     std::vector<Parse_Costume> m_Costumes;
-    bool has_variant(int idx) const { return idx<m_Costumes.size(); }
+    bool has_variant(int idx) const { return static_cast<unsigned>(idx) < m_Costumes.size(); }
 };
 using AllNpcs_Data = std::vector<Parse_NPC>;

--- a/Projects/CoX/Common/NetStructures/Costume.cpp
+++ b/Projects/CoX/Common/NetStructures/Costume.cpp
@@ -159,7 +159,7 @@ void serializeto(const Costume &costume,BitStream &bs,const ColorAndPartPacker *
     //m_num_parts = m_parts.size();
     assert(!costume.m_parts.empty());
     bs.StorePackedBits(4,costume.m_parts.size());
-    for(int costume_part=0; costume_part<costume.m_parts.size();costume_part++)
+    for(int costume_part = 0; static_cast<unsigned>(costume_part) < costume.m_parts.size(); costume_part++)
     {
         CostumePart part=costume.m_parts[costume_part];
         // TODO: this is bad code, it's purpose is to NOT send all part strings if m_non_default_costme_p is false

--- a/Projects/CoX/Common/NetStructures/Team.cpp
+++ b/Projects/CoX/Common/NetStructures/Team.cpp
@@ -51,10 +51,10 @@ void Team::removeTeamMember(Entity *e)
     qCDebug(logTeams) << "Searching team members for" << e->name() << "to remove them.";
     int id_to_find = e->m_db_id;
     auto iter = std::find_if( m_team_members.begin(), m_team_members.end(),
-                              [id_to_find](const TeamMember& t)->bool {return id_to_find==t.tm_idx;});
-    if(iter!=m_team_members.end())
+                              [id_to_find](const TeamMember& t)->bool {return static_cast<unsigned>(id_to_find) == t.tm_idx;});
+    if(iter != m_team_members.end())
     {
-        if(iter->tm_idx == m_team_leader_idx)
+        if(iter->tm_idx == static_cast<unsigned>(m_team_leader_idx))
             m_team_leader_idx = m_team_members.front().tm_idx;
 
         iter = m_team_members.erase(iter);
@@ -116,7 +116,7 @@ void Team::listTeamMembers()
 
 bool Team::isTeamLeader(Entity *e)
 {
-    return m_team_leader_idx == e->m_db_id;
+    return static_cast<unsigned>(m_team_leader_idx) == e->m_db_id;
 }
 
 bool sameTeam(Entity &src, Entity &tgt)
@@ -251,6 +251,7 @@ void addSidekick(Entity &tgt, Entity &src)
     Sidekick    &tgt_sk = tgt.m_char->m_char_data.m_sidekick;
     uint32_t    src_lvl = getLevel(*src.m_char);
     uint32_t    tgt_lvl = getLevel(*tgt.m_char);
+    Q_UNUSED(tgt_lvl);
 
     src_sk.m_has_sidekick = true;
     tgt_sk.m_has_sidekick = true;

--- a/Projects/CoX/Common/Servers/ClientManager.h
+++ b/Projects/CoX/Common/Servers/ClientManager.h
@@ -222,7 +222,7 @@ public:
         }
         void create_reaping_timer(EventProcessor *tgt, uint32_t id, ACE_Time_Value interval)
         {
-            m_session_reaper_timer.reset(new SEGSTimer(tgt, (void *)id, interval, false));
+            m_session_reaper_timer.reset(new SEGSTimer(tgt, (void *)(intptr_t)id, interval, false));
         }
         void mark_session_for_reaping(SESSION_CLASS *sess, uint64_t token)
         {

--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -89,6 +89,7 @@ static std::unique_ptr<MessageBusMonitor> s_bus_monitor;
 
 static void shutDownServers(const char *reason)
 {
+    Q_UNUSED(reason);
     if (GlobalTimerQueue::instance()->thr_count())
     {
         GlobalTimerQueue::instance()->deactivate();

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncEvents.h
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncEvents.h
@@ -155,14 +155,14 @@ struct GameAccountResponseCharacterData
         return 0==m_name.compare("EMPTY",Qt::CaseInsensitive);
     }
     GameAccountResponseCostumeData &current_costume() {
-        if(m_current_costume_idx>=0 && m_current_costume_idx<m_costumes.size() )
+        if(m_current_costume_idx >= 0 && static_cast<unsigned>(m_current_costume_idx) < m_costumes.size() )
             return m_costumes[m_current_costume_idx];
         assert(!m_costumes.empty());
         m_current_costume_idx = 0;
         return m_costumes.front();
     }
     const GameAccountResponseCostumeData &current_costume() const {
-        if(m_current_costume_idx>=0 && m_current_costume_idx<m_costumes.size() )
+        if(m_current_costume_idx >= 0 && static_cast<unsigned>(m_current_costume_idx) < m_costumes.size() )
             return m_costumes[m_current_costume_idx];
         assert(!m_costumes.empty());
         return m_costumes.front();

--- a/Projects/CoX/Servers/GameServer/GameEvents.cpp
+++ b/Projects/CoX/Servers/GameServer/GameEvents.cpp
@@ -82,7 +82,7 @@ void CharacterSlots::serializeto( BitStream &tgt ) const
     tgt.StorePackedBits(1, 2); //opcode
     tgt.StorePackedBits(1,static_cast<uint32_t>(m_data->m_max_slots));
     assert(m_data->m_max_slots>0);
-    for(size_t i=0; i<m_data->m_max_slots; i++)
+    for(size_t i = 0; i < static_cast<unsigned>(m_data->m_max_slots); i++)
     {
         Character converted;
         PlayerData player_data;

--- a/Projects/CoX/Servers/GameServer/GameHandler.cpp
+++ b/Projects/CoX/Servers/GameServer/GameHandler.cpp
@@ -196,6 +196,7 @@ void GameHandler::on_update_character(UpdateCharacter *ev)
 
 void GameHandler::on_idle(IdleEvent *ev)
 {
+    Q_UNUSED(ev);
     // idle for idle 'strategy'
 //    GameLink * lnk = (GameLink *)ev->src();
 //    lnk->putq(new IdleEvent);

--- a/Projects/CoX/Servers/GameServer/GameServer.cpp
+++ b/Projects/CoX/Servers/GameServer/GameServer.cpp
@@ -189,6 +189,8 @@ int GameServer::getMaxCharacterSlots() const
 
 int GameServer::handle_close(ACE_HANDLE handle, ACE_Reactor_Mask close_mask)
 {
+    Q_UNUSED(handle);
+    Q_UNUSED(close_mask);
     // after evfinish some other messages could have been added to the queue, release them
     d->ShutDown();
     assert(d->m_handler->msg_queue()->is_empty());

--- a/Projects/CoX/Servers/MapServer/EntityStorage.cpp
+++ b/Projects/CoX/Servers/MapServer/EntityStorage.cpp
@@ -103,6 +103,7 @@ void EntityManager::sendDeletes( BitStream &tgt,MapClientSession *client ) const
  */
 void EntityManager::sendEntities(BitStream& bs, MapClientSession *target, bool is_incremental) const
 {
+    Q_UNUSED(is_incremental);
     ACE_Guard<ACE_Thread_Mutex> guard_buffer(m_mutex);
     uint32_t self_idx = getIdx(*target->m_ent);
     int prev_idx = -1;

--- a/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
+++ b/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
@@ -127,7 +127,9 @@ bool storePosition(const Entity &src,BitStream &bs)
 
 bool update_rot(const Entity &src, int axis ) /* returns true if given axis needs updating */
 {
-    if(axis==axis) // FixMe: var compared against same var.
+    Q_UNUSED(src);
+    int axis_tmp = axis;
+    if(axis == axis_tmp) // FixMe: var compared against same var.
         return true;
     return false;
 }
@@ -211,6 +213,7 @@ void sendSeqMoveUpdate(const Entity &src,BitStream &bs)
 
 void sendSeqTriggeredMoves(const Entity &src,BitStream &bs)
 {
+    Q_UNUSED(src);
     PUTDEBUG("before sendSeqTriggeredMoves");
     uint32_t num_moves=0; // FixMe: num_moves is never modified and the body of the for loop below will never fire.
     //ACE_DEBUG ((LM_DEBUG,ACE_TEXT ("\tSending seq triggeted moves %d\n"),num_moves));
@@ -378,12 +381,14 @@ void sendWhichSideOfTheForce(const Entity &src,BitStream &bs)
 
 void sendEntCollision(const Entity &src,BitStream &bs)
 {
+    Q_UNUSED(src);
     // if 1 is sent, client will disregard it's own collision processing.
     bs.StoreBits(1,0); // 1/0 only
 }
 
 void sendNoDrawOnClient(const Entity &src,BitStream &bs)
 {
+    Q_UNUSED(src);
     bs.StoreBits(1,0); // 1/0 only
 }
 
@@ -433,6 +438,7 @@ void sendLogoutUpdate(const Entity &src,ClientEntityStateBelief &belief,BitStrea
 
 void sendBuffs(const Entity &src,BitStream &bs)
 {
+    Q_UNUSED(src);
     bs.StorePackedBits(5,0);
 }
 

--- a/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
@@ -398,6 +398,7 @@ void storePowerInfoUpdate(const EntitiesResponse &/*src*/,BitStream &bs)
     std::vector<Power> powers;
     for(Power &p : powers)
     {
+        Q_UNUSED(p);
         bs.StoreBits(1,1); // have power to send.
         uint32_t category_idx=0;
         uint32_t powerset_idx=0;

--- a/Projects/CoX/Servers/MapServer/Events/InputState.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/InputState.cpp
@@ -80,6 +80,7 @@ InputStateStorage &InputStateStorage::operator =(const InputStateStorage &other)
 
 void InputStateStorage::processDirectionControl(int dir,int prev_time,int press_release)
 {
+    Q_UNUSED(prev_time);
     if(press_release)
     {
         qCDebug(logInput, "pressed: %s", dir);
@@ -240,6 +241,7 @@ struct ControlState
     // recover actual ControlState from network data and previous entry
     void serializefrom_delta(BitStream &bs,const ControlState &prev)
     {
+        Q_UNUSED(prev);
         client_timenow   = bs.GetPackedBits(1); // field_0 diff next-current
         time_res = bs.GetPackedBits(1); // time to next state ?
         timestep = bs.GetFloat(); // next state's timestep

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -159,6 +159,7 @@ MapInstance::~MapInstance()
 
 void MapInstance::on_client_connected_to_other_server(ClientConnectedMessage *ev)
 {
+    Q_UNUSED(ev);
     assert(false);
 //    assert(ev->m_data.m_sub_server_id);
 //    MapClientSession &session(m_session_store.sessionFromEvent(ev));
@@ -544,6 +545,7 @@ void MapInstance::on_create_map_entity(NewEntity *ev)
 
         const MapServerData &data(g_GlobalMapServer->runtimeData());
         const Parse_AllKeyProfiles &default_profiles(data.m_keybind_profiles);
+        Q_UNUSED(default_profiles);
 
         fillEntityFromNewCharData(*e, ev->m_character_data, data.getPacker(),data.m_keybind_profiles);
         e->m_char->m_account_id = map_session.auth_id();
@@ -636,6 +638,7 @@ void MapInstance::sendState() {
     auto iter=m_session_store.begin();
     auto end=m_session_store.end();
     static bool only_first=true;
+    Q_UNUSED(only_first);
     static int resendtxt=0;
     resendtxt++;
 
@@ -1699,6 +1702,7 @@ void MapInstance::on_set_destination(SetDestination * ev)
 
 void MapInstance::on_abort_queued_power(AbortQueuedPower * ev)
 {
+    Q_UNUSED(ev);
     qCWarning(logMapEvents) << "Unhandled abort queued power request";
 }
 
@@ -1735,7 +1739,8 @@ void MapInstance::on_client_options(SaveClientOptions * ev)
 {
     // Save options/keybinds to character entity and entry in the database.
     MapClientSession &session(m_session_store.session_from_event(ev));
-    LinkBase * lnk = (LinkBase *)ev->src();
+    LinkBase *lnk = (LinkBase *)ev->src();
+    Q_UNUSED(lnk);
 
     Entity *ent = session.m_ent;
     markEntityForDbStore(ent,DbStoreFlags::Options);
@@ -1769,6 +1774,7 @@ void MapInstance::on_set_default_power_send(SetDefaultPowerSend *ev)
 
 void MapInstance::on_set_default_power(SetDefaultPower *ev)
 {
+    Q_UNUSED(ev);
     qCWarning(logMapEvents) << "Unhandled Set Default Power request.";
 }
 

--- a/Projects/CoX/Servers/MapServer/MapServerData.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServerData.cpp
@@ -247,13 +247,13 @@ bool MapServerData::read_runtime_data(const QString &directory_path)
 
 int MapServerData::expForLevel(int lev) const
 {
-    assert(lev>0 && lev<m_experience_and_debt_per_level.m_ExperienceRequired.size());
+    assert(lev > 0 && static_cast<unsigned>(lev) < m_experience_and_debt_per_level.m_ExperienceRequired.size());
     return m_experience_and_debt_per_level.m_ExperienceRequired.at(lev - 1);
 }
 
 int MapServerData::expDebtForLevel(int lev) const
 {
-    assert(lev>0 && lev<m_experience_and_debt_per_level.m_DefeatPenalty.size());
+    assert(lev > 0 && static_cast<unsigned>(lev) < m_experience_and_debt_per_level.m_DefeatPenalty.size());
     return m_experience_and_debt_per_level.m_DefeatPenalty.at(lev - 1);
 }
 

--- a/Projects/CoX/Servers/MapServer/NetCommandManager.cpp
+++ b/Projects/CoX/Servers/MapServer/NetCommandManager.cpp
@@ -123,6 +123,7 @@ NetCommand * NetCommandManager::getCommandByName( const QString &name )
 
 void NetCommandManager::serializeto(BitStream &tgt, const vNetCommand &commands, const vNetCommand &commands2 )
 {
+    Q_UNUSED(commands2);
     if(commands.size()==0)
     {
         tgt.StorePackedBits(1,~0u);//0xFFFFFFFF

--- a/Projects/CoX/Servers/MapServer/ScriptingEngine_Null.cpp
+++ b/Projects/CoX/Servers/MapServer/ScriptingEngine_Null.cpp
@@ -11,13 +11,47 @@
  */
 
 #include "ScriptingEngine.h"
+
+#include <QtGlobal>
+
 ScriptingEngine::ScriptingEngine() {}
 ScriptingEngine::~ScriptingEngine() {}
 void ScriptingEngine::registerTypes() {}
-int ScriptingEngine::runScript(const QString &script_contents, const char *script_name) {return -1;}
-int ScriptingEngine::runScript(MapClientSession * client, const QString &script_contents, const char *script_name) {return -1;}
-int ScriptingEngine::loadAndRunFile(const QString &path) { return -1; }
-std::string ScriptingEngine::callFunc(const char *name, int arg1) { return ""; }
-std::string ScriptingEngine::callFuncWithClientContext(MapClientSession *client, const char *name, int arg1) { return "";}
+
+int ScriptingEngine::runScript(const QString &script_contents, const char *script_name)
+{
+    Q_UNUSED(script_contents);
+    Q_UNUSED(script_name);
+    return -1;
+}
+
+int ScriptingEngine::runScript(MapClientSession * client, const QString &script_contents, const char *script_name)
+{
+    Q_UNUSED(client);
+    Q_UNUSED(script_contents);
+    Q_UNUSED(script_name);
+    return -1;
+}
+
+int ScriptingEngine::loadAndRunFile(const QString &path)
+{
+    Q_UNUSED(path);
+    return -1;
+}
+
+std::string ScriptingEngine::callFunc(const char *name, int arg1)
+{
+    Q_UNUSED(name);
+    Q_UNUSED(arg1);
+    return "";
+}
+
+std::string ScriptingEngine::callFuncWithClientContext(MapClientSession *client, const char *name, int arg1)
+{
+    Q_UNUSED(client);
+    Q_UNUSED(name);
+    Q_UNUSED(arg1);
+    return "";
+}
 
 //! @}

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -38,7 +38,9 @@ struct SlashCommand
     std::function<void(QString &,MapClientSession &)> m_handler;
     uint32_t m_required_access_level;
 };
-bool canAccessCommand(SlashCommand &cmd, const Entity &e);
+
+// FixMe: Define canAccessCommand()
+//bool canAccessCommand(SlashCommand &cmd, const Entity &e);
 
 // prototypes of all commands
 // Access Level 9 Commands (GMs)

--- a/Projects/CoX/Servers/MapServer/WorldSimulation.cpp
+++ b/Projects/CoX/Servers/MapServer/WorldSimulation.cpp
@@ -55,11 +55,12 @@ void World::physicsStep(Entity *e,uint32_t msec)
         // todo: take into account time between updates
         glm::mat3 za = static_cast<glm::mat3>(e->m_direction); // quat to mat4x4 conversion
         float vel_scale = e->inp_state.input_vel_scale/255.0f;
+        Q_UNUSED(vel_scale);
         e->m_entity_data.m_pos += ((za*e->inp_state.pos_delta)*float(msec))/50.0f;
         e->vel = za*e->inp_state.pos_delta;
     }
 
-    if(e->inp_state.pos_delta[1] == float(1.0f)) // Will set 'is flying' on jump event
+    if(e->inp_state.pos_delta[1] == 1.0f) // Will set 'is flying' on jump event
     {
      markFlying(*e, true);
     }

--- a/Utilities/slav/SLAVLogic.cpp
+++ b/Utilities/slav/SLAVLogic.cpp
@@ -69,6 +69,7 @@ void SLAVLogic::onManifestReceived(const QString &manifest_url,const QString &ma
 {
     AppVersionManifest pm;
     bool load_res = loadFrom(pm,manifestData);
+    Q_UNUSED(load_res);
     // we've got a project manifest, perform work based on the manifest type.
     if(manifest_url.contains("slav.manifest"))
     {

--- a/Utilities/slav/ServerConnection.cpp
+++ b/Utilities/slav/ServerConnection.cpp
@@ -36,6 +36,8 @@ void ServerConnection::onRequestManifest(const QString &manifestname) {
 
 void ServerConnection::onRequestFileList(const QString & base_path, const QStringList & files)
 {
+    Q_UNUSED(base_path);
+    Q_UNUSED(files);
     assert(false);
 }
 


### PR DESCRIPTION
This PR contains fixes to quell all compiler warnings (at least in recent versions of GCC and Clang) with the exception of casts related to SLAV for primarily function pointers. `Q_UNUSED` is employed where possible (all except a single case where `<QtGlobal>` was not in include path) considering it is Qt based and self documenting/easy to search and address in the future. If we know certain vars will always be positive during comparison operations, then we can use uints in each context opposed to static casting if desired.