### PR TITLE
Fixed "character select list" query.

### DIFF
--- a/Projects/CoX/Data/mysql/segs_game_mysql_create.sql
+++ b/Projects/CoX/Data/mysql/segs_game_mysql_create.sql
@@ -6,15 +6,18 @@ SET time_zone = "+00:00";
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8mb4 */;
 
-
+DROP TABLE IF EXISTS `table_versions`;
+DROP TABLE IF EXISTS `supergroups`;
+DROP TABLE IF EXISTS `progress`;
+DROP TABLE IF EXISTS `costume`;
+DROP TABLE IF EXISTS `characters`;
 DROP TABLE IF EXISTS `accounts`;
+
 CREATE TABLE `accounts` (
   `id` int(11) NOT NULL,
-  `account_id` int(11) DEFAULT NULL,
   `max_slots` int(11) NOT NULL DEFAULT '8'
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-DROP TABLE IF EXISTS `characters`;
 CREATE TABLE `characters` (
   `id` int(11) NOT NULL,
   `account_id` int(11) NOT NULL,
@@ -25,13 +28,10 @@ CREATE TABLE `characters` (
   `bodytype` int(11) NOT NULL DEFAULT '4',
   `height` double NOT NULL DEFAULT '0',
   `physique` double NOT NULL DEFAULT '0',
-  `hitpoints` int(11) DEFAULT '0',
-  `endurance` int(11) DEFAULT '0',
   `supergroup_id` int(11) NOT NULL DEFAULT '0',
   `player_data` mediumblob
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-DROP TABLE IF EXISTS `costume`;
 CREATE TABLE `costume` (
   `id` int(11) NOT NULL,
   `character_id` int(11) NOT NULL,
@@ -40,20 +40,8 @@ CREATE TABLE `costume` (
   `parts` blob
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-DROP TABLE IF EXISTS `progress`;
-CREATE TABLE `progress` (
-  `id` int(11) NOT NULL,
-  `character_id` int(11) DEFAULT NULL,
-  `badges` blob,
-  `clues` blob,
-  `contacts` blob,
-  `souvenirs` blob
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-DROP TABLE IF EXISTS `supergroups`;
 CREATE TABLE `supergroups` (
   `id` int(11) NOT NULL,
-  `supergroup_id` int(11) DEFAULT NULL,
   `sg_name` text NOT NULL,
   `sg_motto` text,
   `sg_motd` text,
@@ -64,7 +52,6 @@ CREATE TABLE `supergroups` (
   `sg_members` blob
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-DROP TABLE IF EXISTS `table_versions`;
 CREATE TABLE `table_versions` (
   `id` int(11) NOT NULL,
   `table_name` varchar(20) NOT NULL,
@@ -73,18 +60,16 @@ CREATE TABLE `table_versions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 INSERT INTO `table_versions` (`id`, `table_name`, `version`, `last_update`) VALUES
-(1, 'db_version', 6, '2018-04-19 00:55:01'),
+(1, 'db_version', 7, '2018-05-03 17:54:32'),
 (2, 'table_versions', 0, '2017-11-11 08:57:42'),
-(3, 'accounts', 0, '2017-11-11 08:57:43'),
-(4, 'characters', 7, '2018-04-19 00:54:27'),
+(3, 'accounts', 1, '2018-05-03 12:52:03'),
+(4, 'characters', 8, '2018-05-04 14:58:27'),
 (5, 'costume', 0, '2017-11-11 08:57:43'),
-(6, 'progress', 0, '2017-11-11 08:57:43'),
-(7, 'supergroups', 0, '2018-01-23 10:16:43');
+(7, 'supergroups', 1, '2018-05-03 12:52:53');
 
 
 ALTER TABLE `accounts`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `account_id` (`account_id`);
+  ADD PRIMARY KEY (`id`);
 
 ALTER TABLE `characters`
   ADD PRIMARY KEY (`id`),
@@ -94,25 +79,16 @@ ALTER TABLE `costume`
   ADD PRIMARY KEY (`id`),
   ADD UNIQUE KEY `character_id` (`character_id`,`costume_index`);
 
-ALTER TABLE `progress`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `character_id` (`character_id`);
-
 ALTER TABLE `supergroups`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `supergroup_id` (`supergroup_id`);
+  ADD PRIMARY KEY (`id`);
 
 ALTER TABLE `table_versions`
   ADD PRIMARY KEY (`id`);
 
 
-ALTER TABLE `accounts`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
 ALTER TABLE `characters`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 ALTER TABLE `costume`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
-ALTER TABLE `progress`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 ALTER TABLE `supergroups`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
@@ -120,13 +96,10 @@ ALTER TABLE `table_versions`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=8;
 
 ALTER TABLE `characters`
-  ADD CONSTRAINT `characters_ibfk_1` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`account_id`) ON DELETE CASCADE;
+  ADD CONSTRAINT `characters_ibfk_1` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE;
 
 ALTER TABLE `costume`
   ADD CONSTRAINT `costume_ibfk_1` FOREIGN KEY (`character_id`) REFERENCES `characters` (`id`) ON DELETE CASCADE;
-
-ALTER TABLE `progress`
-  ADD CONSTRAINT `progress_ibfk_1` FOREIGN KEY (`character_id`) REFERENCES `characters` (`id`) ON DELETE CASCADE;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/Projects/CoX/Data/mysql/segs_mysql_create.sql
+++ b/Projects/CoX/Data/mysql/segs_mysql_create.sql
@@ -7,6 +7,9 @@ SET time_zone = "+00:00";
 /*!40101 SET NAMES utf8mb4 */;
 
 
+DROP TABLE IF EXISTS `table_versions`;
+DROP TABLE IF EXISTS `game_servers`;
+DROP TABLE IF EXISTS `bans`;
 DROP TABLE IF EXISTS `accounts`;
 CREATE TABLE `accounts` (
   `id` int(11) NOT NULL,
@@ -17,7 +20,6 @@ CREATE TABLE `accounts` (
   `salt` blob NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-DROP TABLE IF EXISTS `bans`;
 CREATE TABLE `bans` (
   `id` int(11) NOT NULL,
   `account_id` int(11) NOT NULL,
@@ -26,7 +28,6 @@ CREATE TABLE `bans` (
   `reason` text NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-DROP TABLE IF EXISTS `game_servers`;
 CREATE TABLE `game_servers` (
   `id` int(11) NOT NULL,
   `addr` varchar(20) NOT NULL,
@@ -35,7 +36,6 @@ CREATE TABLE `game_servers` (
   `token` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-DROP TABLE IF EXISTS `table_versions`;
 CREATE TABLE `table_versions` (
   `id` int(11) NOT NULL,
   `table_name` varchar(20) NOT NULL,

--- a/Projects/CoX/Data/pgsql/segs_game_postgres_create.sql
+++ b/Projects/CoX/Data/pgsql/segs_game_postgres_create.sql
@@ -8,26 +8,21 @@ CREATE TABLE "table_versions" (
   OIDS=FALSE
 );
 
-INSERT INTO table_versions VALUES(1,'db_version',6,'2018-04-19 00:55:01');
+INSERT INTO table_versions VALUES(1,'db_version',7,'2018-05-03 17:52:33');
 INSERT INTO table_versions VALUES(2,'table_versions',0,'2017-11-11 08:57:42');
-INSERT INTO table_versions VALUES(3,'accounts',0,'2017-11-11 08:57:43');
-INSERT INTO table_versions VALUES(4,'characters',7,'2018-04-19 00:54:27');
+INSERT INTO table_versions VALUES(3,'accounts',1,'2018-05-03 14:06:03');
+INSERT INTO table_versions VALUES(4,'characters',8,'2018-05-04 14:58:27');
 INSERT INTO table_versions VALUES(5,'costume',0,'2017-11-11 08:57:43');
-INSERT INTO table_versions VALUES(6,'progress',0,'2017-11-11 08:57:43');
-INSERT INTO table_versions VALUES(7,'supergroups',0,'2018-01-23 10:16:43');
+INSERT INTO table_versions VALUES(7,'supergroups',1,'2018-05-03 14:06:43');
 
 
 CREATE TABLE "accounts" (
-    "id" serial NOT NULL,
-    "account_id" integer NOT NULL,
+    "id" integer NOT NULL,
     "max_slots" integer NOT NULL DEFAULT '8',
     CONSTRAINT accounts_pk PRIMARY KEY ("id")
 ) WITH (
   OIDS=FALSE
 );
-
-
-INSERT INTO accounts VALUES(1,1,8);
 
 
 CREATE TABLE "costumes" (
@@ -54,8 +49,6 @@ CREATE TABLE "characters" (
     "body_type" integer NOT NULL DEFAULT '4',
     "height" real NOT NULL DEFAULT '0.0',
     "physique" real NOT NULL DEFAULT '0.0',
-    "hitpoints" integer NOT NULL DEFAULT '0',
-    "endurance" integer NOT NULL DEFAULT '0',
     "supergroup_id" integer NOT NULL DEFAULT '0',
     "player_data" bytea NOT NULL,
     CONSTRAINT characters_pk PRIMARY KEY ("id")
@@ -67,7 +60,6 @@ CREATE TABLE "characters" (
 
 CREATE TABLE "supergroups" (
     "id" serial NOT NULL,
-    "supergroup_id" serial NOT NULL,
     "sg_name" varchar(30) NOT NULL,
     "sg_motto" varchar(128) NOT NULL,
     "sg_motd" varchar(1024) NOT NULL,
@@ -83,25 +75,7 @@ CREATE TABLE "supergroups" (
 
 
 
-CREATE TABLE "progress" (
-    "id" serial NOT NULL,
-    "character_id" integer NOT NULL,
-    "badges" bytea NOT NULL,
-    "clues" bytea NOT NULL,
-    "contacts" bytea NOT NULL,
-    "souvenirs" bytea NOT NULL,
-    CONSTRAINT progress_pk PRIMARY KEY ("id")
-) WITH (
-  OIDS=FALSE
-);
-
-
-
-
 
 ALTER TABLE "costumes" ADD CONSTRAINT "costumes_fk0" FOREIGN KEY ("character_id") REFERENCES "characters"("id");
 
 ALTER TABLE "characters" ADD CONSTRAINT "characters_fk0" FOREIGN KEY ("account_id") REFERENCES "accounts"("id");
-
-ALTER TABLE "progress" ADD CONSTRAINT "progress_fk0" FOREIGN KEY ("character_id") REFERENCES "characters"("id");
-

--- a/Projects/CoX/Data/sqlite/segs_game_sqlite_create.sql
+++ b/Projects/CoX/Data/sqlite/segs_game_sqlite_create.sql
@@ -7,21 +7,17 @@ CREATE TABLE `table_versions` (
     `last_update` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-INSERT INTO table_versions VALUES(1,'db_version',6,'2018-04-19 00:55:01');
+INSERT INTO table_versions VALUES(1,'db_version',7,'2018-05-03 17:52:33');
 INSERT INTO table_versions VALUES(2,'table_versions',0,'2017-11-11 08:57:42');
-INSERT INTO table_versions VALUES(3,'accounts',0,'2017-11-11 08:57:43');
-INSERT INTO table_versions VALUES(4,'characters',7,'2018-04-19 00:54:27');
+INSERT INTO table_versions VALUES(3,'accounts',1,'2017-05-03 12:56:03');
+INSERT INTO table_versions VALUES(4,'characters',8,'2018-05-04 14:58:27');
 INSERT INTO table_versions VALUES(5,'costume',0,'2017-11-11 08:57:43');
-INSERT INTO table_versions VALUES(6,'progress',0,'2017-11-11 08:57:43');
-INSERT INTO table_versions VALUES(7,'supergroups',0,'2018-01-23 10:16:43');
+INSERT INTO table_versions VALUES(7,'supergroups',1,'2018-05-03 12:56:43');
 
 CREATE TABLE `accounts` (
-    `id`	INTEGER PRIMARY KEY AUTOINCREMENT,
-    `account_id`	INTEGER UNIQUE,
-    `max_slots`	INTEGER NOT NULL DEFAULT 8
+    `id` INTEGER PRIMARY KEY,
+    `max_slots` INTEGER NOT NULL DEFAULT 8
 );
-
-INSERT INTO accounts VALUES(1,1,8);
 
 CREATE TABLE `characters` (
     `id`	INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -33,11 +29,9 @@ CREATE TABLE `characters` (
     `bodytype`	INTEGER NOT NULL DEFAULT 4,
     `height` real NOT NULL DEFAULT 0.0,
     `physique` real NOT NULL DEFAULT 0.0,
-    `hitpoints`	INTEGER DEFAULT 0,
-    `endurance`	INTEGER DEFAULT 0,
     `supergroup_id`	INTEGER NOT NULL DEFAULT 0,
     `player_data` BLOB,
-    FOREIGN KEY(`account_id`) REFERENCES accounts ( account_id ) ON DELETE CASCADE
+    FOREIGN KEY(`account_id`) REFERENCES accounts ( id ) ON DELETE CASCADE
 );
 
 CREATE TABLE `costume` (
@@ -50,20 +44,8 @@ CREATE TABLE `costume` (
     UNIQUE (character_id, costume_index)
 );
 
-CREATE TABLE `progress` (
-    `id` integer PRIMARY KEY AUTOINCREMENT,
-    `character_id` integer,
-    `badges` blob,
-    `clues` blob,
-    `contacts` blob,
-    `souvenirs` blob,
-    FOREIGN KEY(`character_id`) REFERENCES characters ( id ) ON DELETE CASCADE,
-    UNIQUE (character_id)
-);
-
 CREATE TABLE `supergroups` (
     `id`	INTEGER PRIMARY KEY AUTOINCREMENT,
-    `supergroup_id`	INTEGER UNIQUE,
     `sg_name`	TEXT NOT NULL,
     `sg_motto`	TEXT,
     `sg_motd`	TEXT,

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -150,8 +150,8 @@ bool GameDbSyncContext::loadAndConfigure()
               "WHERE id=:id ");
 
     prepQuery(*m_prepared_fill,"SELECT * FROM costume WHERE character_id=? AND costume_index=?");
-    prepQuery(*m_prepared_account_select,"SELECT * FROM accounts WHERE account_id=?");
-    prepQuery(*m_prepared_account_insert,"INSERT INTO accounts  (account_id,max_slots) VALUES (?,?)");
+    prepQuery(*m_prepared_account_select,"SELECT * FROM accounts WHERE id=?");
+    prepQuery(*m_prepared_account_insert,"INSERT INTO accounts  (id,max_slots) VALUES (?,?)");
     prepQuery(*m_prepared_char_insert,
                 "INSERT INTO characters  ("
                 "slot_index, account_id, char_name, chardata, entitydata, "
@@ -221,7 +221,7 @@ bool GameDbSyncContext::getAccount(const GameAccountRequestData &data,GameAccoun
         if(!m_prepared_account_select->next() && !data.create_if_does_not_exist)
             return false;
     }
-    result.m_game_server_acc_id = m_prepared_account_select->value("id").toULongLong();
+    result.m_game_server_acc_id = data.m_auth_account_id;
     result.m_max_slots = m_prepared_account_select->value("max_slots").toULongLong();
     result.m_characters.resize(result.m_max_slots);
     int idx=0;

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.h
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.h
@@ -28,7 +28,7 @@ struct SetClientOptionsData;
 ///
 class GameDbSyncContext
 {
-    static constexpr int required_db_version = 6;
+    static constexpr int required_db_version = 7;
     std::unique_ptr<QSqlDatabase> m_db;
     std::unique_ptr<QSqlQuery> m_prepared_char_update;
     std::unique_ptr<QSqlQuery> m_prepared_costume_update;


### PR DESCRIPTION
Characters are created/stored with 'account_id' value of
chardb->accounts->account_id, whereas they are/were looked up with the
chardb->accounts->id value. Those two values are not necessarily the same.

Update: So, a lot of stuff happened.
- Progress table was removed as it fits in nicely inside the characters table as a blob.
- #393 was taken care of as the scripts are already modified anyways.
- MySQL creation scripts were fixed, as they would complain/error out if the database was already populated due to foreign key constraints.
- CharDB->accounts table lost its 'id' entry as it's not used. account_id from the same table has since been renamed 'id'.
- Supergroups now only have one id column.