### PR TITLE
Fix Typos

### DIFF
--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -1701,7 +1701,7 @@ void MapInstance::on_client_resumed(ClientResumedRendering *ev)
         session.m_in_map = true;
     char buf[256];
     std::string welcome_msg = std::string("Welcome to SEGS ") + VersionInfo::getAuthVersion()+"\n";
-    std::snprintf(buf, 256, "There are %zu active entites and %zu clients", m_entities.active_entities(),
+    std::snprintf(buf, 256, "There are %zu active entities and %zu clients", m_entities.active_entities(),
                   m_session_store.num_sessions());
     welcome_msg += buf;
     sendInfoMessage(MessageChannel::SERVER,QString::fromStdString(welcome_msg),&session);

--- a/Projects/CoX/Servers/MapServer/MapSceneGraph.cpp
+++ b/Projects/CoX/Servers/MapServer/MapSceneGraph.cpp
@@ -119,15 +119,15 @@ struct NpcCreator
     NpcGeneratorStore *generators;
     QSet<QString> m_reported_generators;
 
-    bool checkPersistant(SceneNode *n, const glm::mat4 &v)
+    bool checkPersistent(SceneNode *n, const glm::mat4 &v)
     {
         bool has_npc = false;
-        QString persistant_name;
+        QString persistent_name;
         for (GroupProperty_Data &prop : *n->properties)
         {
             if(prop.propName=="PersistentNPC")
             {
-                persistant_name = prop.propValue;
+                persistent_name = prop.propValue;
             }
             if (prop.propName.contains("NPC", Qt::CaseInsensitive))
             {
@@ -137,9 +137,9 @@ struct NpcCreator
         }
         if(has_npc && map_instance)
         {
-            qCDebug(logNPCs) << "Attempting to spawn npc" << persistant_name << "at" << v[3][0] << v[3][1] << v[3][2];
+            qCDebug(logNPCs) << "Attempting to spawn npc" << persistent_name << "at" << v[3][0] << v[3][1] << v[3][2];
             const NPCStorage & npc_store(map_instance->serverData().getNPCDefinitions());
-            QString npc_costume_name = convertNpcName(persistant_name);
+            QString npc_costume_name = convertNpcName(persistent_name);
             const Parse_NPC * npc_def = npc_store.npc_by_name(&npc_costume_name);
             if (npc_def)
             {
@@ -151,7 +151,7 @@ struct NpcCreator
                 glm::vec3 angles = glm::eulerAngles(valquat);
                 angles.y += glm::pi<float>();
                 valquat = glm::quat(angles);
-                e->m_char->setName(makeReadableName(persistant_name));
+                e->m_char->setName(makeReadableName(persistent_name));
                 e->m_direction = valquat;
                 e->m_entity_data.m_orientation_pyr = {angles.x,angles.y,angles.z};
                 e->m_velocity = { 0,0,0 };
@@ -189,7 +189,7 @@ struct NpcCreator
     {
         if (!n->properties)
             return true;
-        checkPersistant(n,v);
+        checkPersistent(n,v);
         checkGenerators(n,v);
         return true;
     }

--- a/Projects/CoX/Servers/MapServer/MapSceneGraph.cpp
+++ b/Projects/CoX/Servers/MapServer/MapSceneGraph.cpp
@@ -151,7 +151,7 @@ struct NpcCreator
                 glm::vec3 angles = glm::eulerAngles(valquat);
                 angles.y += glm::pi<float>();
                 valquat = glm::quat(angles);
-                e->m_char->setName(makeReadableName(npc_costume_name));
+                e->m_char->setName(makeReadableName(persistant_name));
                 e->m_direction = valquat;
                 e->m_entity_data.m_orientation_pyr = {angles.x,angles.y,angles.z};
                 e->m_velocity = { 0,0,0 };

--- a/Projects/CoX/Servers/MapServer/NpcGenerator.cpp
+++ b/Projects/CoX/Servers/MapServer/NpcGenerator.cpp
@@ -9,6 +9,7 @@
 
 QString makeReadableName(QString &name)
 {
+    // remove filepaths and extensions then replace underscores with spaces
     return name.remove(QRegularExpression(".*\\\\")).remove(QRegularExpression("\\..*")).replace("_"," ");
 }
 


### PR DESCRIPTION
Additions/modifications proposed in this pull request:
- Entities has two `i`'s in it and the internet KNOWS
- Use `persistant_name` in NpcCreator
- Add comment to `makeReadableName()` to detail what regex does
