### PR TITLE
Add 'null' client patch.

### DIFF
--- a/Projects/CoX/Clients/Client_I0_Null/CMakeLists.txt
+++ b/Projects/CoX/Clients/Client_I0_Null/CMakeLists.txt
@@ -1,0 +1,46 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
+
+PROJECT(CoH_Null_Patch)
+IF(MSVC)
+    add_definitions( -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -DNOMINMAX -D_USE_MATH_DEFINES)
+    if (MSVC_VERSION GREATER_EQUAL "1900")
+        include(CheckCXXCompilerFlag)
+        CHECK_CXX_COMPILER_FLAG("/std:c++latest" _cpp_latest_flag_supported)
+        if (_cpp_latest_flag_supported)
+            add_compile_options("/std:c++latest")
+        endif()
+    endif()
+ELSE()
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++11"  )
+endif()
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+
+SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../../../CMakeScripts;${CMAKE_MODULE_PATH})
+MESSAGE(${CMAKE_SOURCE_DIR}/../../../../CMakeScripts)
+include(3rdparty_support)
+set(ThirdParty_Install_Dir ${CMAKE_CURRENT_BINARY_DIR}/3rd_party/built)
+
+add_subdirectory(3rd_party)
+
+link_directories(
+    ${ThirdParty_Install_Dir}/lib
+    ../patch_tools
+)
+include_directories(
+    ${ThirdParty_Install_Dir}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    include
+)
+set(SOURCES
+    ${DLL_SOURCES}
+    utils/dll_patcher.cpp
+    patch_all_the_things.cpp
+    dll_core.cpp
+)
+add_library(cohdll SHARED ${SOURCES})
+# enforce the dll prefix.
+SET_TARGET_PROPERTIES(cohdll PROPERTIES PREFIX "lib"
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/out)
+

--- a/Projects/CoX/Clients/Client_I0_Null/dll_core.cpp
+++ b/Projects/CoX/Clients/Client_I0_Null/dll_core.cpp
@@ -1,0 +1,31 @@
+#include "patch_all_the_things.h"
+
+#include <stdio.h>
+#include <windows.h>
+
+HMODULE coh_instance;
+extern "C" {
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
+
+    switch (fdwReason)
+    {
+    case DLL_PROCESS_ATTACH:
+        coh_instance = GetModuleHandle(nullptr);
+        patch_all_the_things();
+        break;
+
+    case DLL_PROCESS_DETACH:
+        break;
+
+    case DLL_THREAD_ATTACH:
+        break;
+
+    case DLL_THREAD_DETACH:
+        break;
+    }
+    return TRUE;
+}
+__declspec(dllexport) int test() {
+    return 0;
+}
+}

--- a/Projects/CoX/Clients/Client_I0_Null/patch_all_the_things.cpp
+++ b/Projects/CoX/Clients/Client_I0_Null/patch_all_the_things.cpp
@@ -1,0 +1,5 @@
+#include "patch_all_the_things.h"
+
+void patch_all_the_things()
+{
+}

--- a/Projects/CoX/Clients/Client_I0_Null/patch_all_the_things.h
+++ b/Projects/CoX/Clients/Client_I0_Null/patch_all_the_things.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern void patch_all_the_things();

--- a/Projects/CoX/Utilities/MapViewer/src/CohModelConverter.cpp
+++ b/Projects/CoX/Utilities/MapViewer/src/CohModelConverter.cpp
@@ -238,7 +238,10 @@ void convertMaterial(Urho3D::Context *ctx,CoHModel *mdl,StaticModel* boxObject)
             isAdditive = true;
         }
         if ( tflags & ColorOnly )
-            onlyColor = Color(model_trick->TintColor0.r/255.0f, model_trick->TintColor0.g/255.0f, model_trick->TintColor0.b/255.0f, model_trick->TintColor0.a/255.0f);
+            onlyColor = Color(model_trick->TintColor0.rgba.r/255.0f,
+                              model_trick->TintColor0.rgba.g/255.0f,
+                              model_trick->TintColor0.rgba.b/255.0f,
+                              model_trick->TintColor0.rgba.a/255.0f);
         if ( tflags & DoubleSided )
             targetCulling = CULL_NONE;
         if ( tflags & NoZTest )


### PR DESCRIPTION
This is useful when trying to debug the patched client crashes ( patched client has many named functions exported, so stack traces in debuggers that can use them, are much more readable )

