### PR TITLE
SEGSAdmin - Bug fix on 'Add User', not asking for access level

### DIFF
--- a/Projects/CoX/Utilities/SEGSAdmin/AddNewUserDialog.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/AddNewUserDialog.cpp
@@ -33,6 +33,8 @@ void AddNewUserDialog::on_add_user()
     ui->usernameedit->clear();
     ui->passedit->clear();
     ui->accleveledit->setValue(1);
+    ui->accleveledit->show();
+    ui->acclevel->show();
     show();
 }
 


### PR DESCRIPTION
Access level ui controls are hidden on 'create admin user' as it's set to level 9. However, if the user then tried to add a user through the normal 'Add User' flow, the access level ui control wasn't being shown. This is now fixed.

Bug fix for #285 
