### PR TITLE
Remove hitpoints and endurance from GameDBSyncContext.cpp

### DIFF
--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -156,12 +156,10 @@ bool GameDbSyncContext::loadAndConfigure()
                 "INSERT INTO characters  ("
                 "slot_index, account_id, char_name, chardata, entitydata, "
                 "bodytype, height, physique, "
-                "hitpoints, endurance, "
                 "supergroup_id, player_data"
                 ") VALUES ("
                 ":slot_index, :account_id, :char_name, :chardata, :entitydata, "
                 ":bodytype, :height, :physique, "
-                ":hitpoints, :endurance, "
                 ":supergroup_id, :player_data"
                 ")");
     prepQuery(*m_prepared_costume_insert,


### PR DESCRIPTION
Some relics of a distant past had emerged to the surface. They don't belong, we must get rid of them!

Or, as a sane person would put it, we forgot a few mentions of two database columns which has been removed and as they couldn't be found, the server crashed.
This PR fixes that.