### PR TITLE
Removed automatic admin from dbtool and included text about adduser

### DIFF
--- a/Projects/CoX/Utilities/dbtool/main.cpp
+++ b/Projects/CoX/Utilities/dbtool/main.cpp
@@ -429,7 +429,15 @@ int main(int argc, char **argv)
                 qWarning() << "Forced flag used '-f'. Existing databases may be overwritten.";
 
             createDatabases(configs);
-            addAccount(configs[0], "segsadmin", "segs123", 9);
+
+            /*!
+             * @brief Replaced default admin user creation with a warning that no admin account was created.
+             * @brief Also added text to show them the proper format in which to enter to submit an admin account.
+             */
+
+            qInfo() << "\nNO ADMIN USER ACCOUNTS CREATED IN DATABASE!"
+                    << "\nUse the following example to add an admin account to the database:"
+                    << "\ndbtool -l <username> -p <password> -a 9 adduser";
             break;
         }
         case 1:


### PR DESCRIPTION
Issue #408

I removed the automatic creation of admin when creating new databases or forcing the creation of new databases. In it's place, use qInfo to insert 3 lines of text. The first line warns the user that no admin account was created. The next line lets the user know that to create an admin, follow the schema on the next line. The final line is the schema to follow to add a user. I have included two brief comments above this small block listing what was changed.

Closes # .

Additions/modifications proposed in this pull request:
- 
- 
- 
