### PR TITLE
Fixed green reticle issue and corrected Target Assist

### DIFF
--- a/Projects/CoX/Common/NetStructures/Entity.cpp
+++ b/Projects/CoX/Common/NetStructures/Entity.cpp
@@ -158,6 +158,8 @@ void initializeNewPlayerEntity(Entity &e)
     e.m_has_supergroup                  = false;
     e.m_has_team                        = false;
     e.m_pchar_things                    = true;
+    e.m_target_idx                      = 0;
+    e.m_assist_target_idx               = 0;
 
     e.m_char.reset(new Character);
     e.m_player.reset(new PlayerData);
@@ -179,6 +181,8 @@ void initializeNewNpcEntity(Entity &e,const Parse_NPC *src,int idx,int variant)
     e.m_has_supergroup                  = false;
     e.m_has_team                        = false;
     e.m_pchar_things                    = false;
+    e.m_target_idx                      = 0;
+    e.m_assist_target_idx               = 0;
 
     e.m_char.reset(new Character);
     e.m_npc.reset(new NPCData{false,src,idx,variant});

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -100,7 +100,32 @@ void    setSuperGroup(Entity &e, int sg_id, QString sg_name, uint32_t sg_rank)
              << "\n  Rank:" << e.m_supergroup.m_SG_rank;
 }
 
-void    setAssistTarget(Entity &e) { e.m_target_idx = getAssistTargetIdx(e); }
+void setTarget(Entity &e, uint32_t target_idx)
+{
+    e.m_target_idx = target_idx;
+    setAssistTarget(e);
+}
+
+void setAssistTarget(Entity &e)
+{
+    if(getTargetIdx(e) == 0)
+    {
+        e.m_assist_target_idx = 0;
+        return;
+    }
+
+    Entity *target_ent = getEntity(e.m_client, getTargetIdx(e));
+    if(target_ent == nullptr)
+    {
+        e.m_assist_target_idx = 0;
+        return;
+    }
+
+    // TODO: are there any entity types that are invalid assist targets?
+    e.m_assist_target_idx = getTargetIdx(*target_ent);
+
+    qCDebug(logTarget) << "Assist Target is:" << getAssistTargetIdx(e);
+}
 
 // For live debugging
 void    setu1(Entity &e, int val) { e.u1 = val; }

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -41,6 +41,7 @@ void    setJumpHeight(Entity &e, float val);
 void    setUpdateID(Entity &e, uint8_t val);
 void    setTeamID(Entity &e, uint8_t team_id);
 void    setSuperGroup(Entity &e, int sg_id = 0, QString sg_name = "", uint32_t sg_rank = 3);
+void    setTarget(Entity &e, uint32_t target_idx);
 void    setAssistTarget(Entity &e);
 
 // For live debugging

--- a/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
+++ b/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
@@ -331,6 +331,7 @@ void sendTargetUpdate(const Entity &src,BitStream &bs)
     bs.StoreBits(1,has_target);
     if(!has_target)
         return;
+
     bs.StoreBits(1,target_id!=0);
     if(target_id!=0)
         bs.StorePackedBits(12,target_id);

--- a/Projects/CoX/Servers/MapServer/Events/InputState.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/InputState.cpp
@@ -284,11 +284,11 @@ void InputState::serializefrom(BitStream &bs)
 
     m_has_target = bs.GetBits(1);
     m_target_idx = bs.GetPackedBits(14); // targeted entity server_index
-    int ctrl_idx=0;
 
     if(m_has_target)
         qCDebug(logTarget, "Has Target? %d | TargetIdx: %d", m_has_target, m_target_idx);
 
+    int ctrl_idx=0;
     ControlState prev_fld;
     while(bs.GetBits(1)) // receive control state array entries ?
     {

--- a/Projects/CoX/Servers/MapServer/Events/InputState.h
+++ b/Projects/CoX/Servers/MapServer/Events/InputState.h
@@ -15,7 +15,6 @@ public:
     InputStateStorage   m_data;
     bool                m_has_target;
     uint32_t            m_target_idx;
-    uint32_t            m_assist_target_idx;
 
 public:
     InputState() : MapLinkEvent(MapEventTypes::evInputState),m_user_commands(0)

--- a/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
+++ b/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
@@ -76,7 +76,6 @@ public:
 // client -> server commands
     EVENT_DECL(evConsoleCommand             ,200)
     EVENT_DECL(evMiniMapState               ,201)
-//    EVENT_DECL(evRefreshWindows             ,203) // TODO: Refresh Windows? Issue #268
     EVENT_DECL(evClientResumedRendering     ,204)
     EVENT_DECL(evCookieRequest              ,206)
     EVENT_DECL(evInteractWithEntity         ,207)

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -753,9 +753,11 @@ void MapInstance::on_input_state(InputState *st)
     if (st->m_data.has_input_commit_guess)
         ent->m_input_ack = st->m_data.m_send_id;
     ent->inp_state = st->m_data;
+
     // Set Target
-    ent->m_target_idx = st->m_target_idx;
-    ent->m_assist_target_idx = st->m_assist_target_idx;
+    if(st->m_has_target && (getTargetIdx(*ent) != st->m_target_idx))
+        setTarget(*ent, st->m_target_idx);
+
     // Set Orientation
     if(st->m_data.m_orientation_pyr.p || st->m_data.m_orientation_pyr.y || st->m_data.m_orientation_pyr.r)
     {

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -1014,12 +1014,19 @@ void cmdHandler_MakeLeader(const QString &cmd, MapClientSession &sess)
 
 void cmdHandler_SetAssistTarget(const QString &/*cmd*/, MapClientSession &sess)
 {
-    QString msg = "Setting assist target.";
+    Entity *target_ent = getEntity(&sess, getTargetIdx(*sess.m_ent));
+    if(target_ent == nullptr)
+        return;
 
-    setAssistTarget(*sess.m_ent);
+    uint32_t new_target = getTargetIdx(*target_ent);
+    if(new_target == 0)
+        return;
 
+    setTarget(*sess.m_ent, new_target);
+
+    QString msg = "Now targeting " + target_ent->name() + "'s target";
+    sendInfoMessage(MessageChannel::TEAM, msg, &sess);
     qCDebug(logSlashCommand).noquote() << msg;
-    sendInfoMessage(MessageChannel::USER_ERROR, msg, &sess);
 }
 
 void cmdHandler_Sidekick(const QString &cmd, MapClientSession &sess)


### PR DESCRIPTION
Fixed green reticle issue and corrected Target Assist IDX

Closes #392 

Additions/modifications proposed in this pull request:
- Fixed issues with sending Targets to the Client (fixing #392)
- Set `m_assist_target_idx` server side since the client never sends us this information

Outstanding:
- TODO: Outstanding issue with `/assist` because target is overwritten by client to old value
