### PR TITLE
Make NetCommandManager send all commands to the client

### DIFF
--- a/Projects/CoX/Common/GameData/clientoptions_definitions.h
+++ b/Projects/CoX/Common/GameData/clientoptions_definitions.h
@@ -62,16 +62,21 @@ public:
 static const constexpr uint32_t class_version = 1;
 
     // Other Options
-    int32_t control_debug       = 0;
+    int32_t controldebug       = 0;
     int32_t no_strafe           = 0;
     int32_t alwaysmobile        = 0; // 1 - player is always mobile (can't be immobilized by powers)
     int32_t repredict           = 0; // 1 - client is out of sync with server, asking for new physics state info.
     int32_t neterrorcorrection  = 0;
     float   speed_scale         = 0;
 
-    int32_t svr_lag,svr_lag_vary,svr_pl,svr_oo_packets,client_pos_id;
+    int32_t svr_lag,svr_lag_vary,svr_pl,svr_oo_packets,client_pos_id,pause;
     int32_t atest0,atest1,atest2,atest3,atest4,atest5,atest6,atest7,atest8,atest9;
-    int32_t predict,notimeout,selected_ent_server_index;
+    int32_t predict,notimeout,selected_ent_server_index,disablegurneys,canlook;
+    int32_t camrotate,forward,backward,up,down,nocoll,nosync,turnleft,turnright;
+    int32_t zoomin,zoomout,lookup,lookdown,third,first,mouse_invert,autorun;
+    int32_t left,right,nostrafe;
+
+    float time,timescale,timestepscale,speed_turn,velscale,yaw,mouse_speed;
 
     // Options
     bool    m_first_person_view = false;

--- a/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
@@ -540,12 +540,18 @@ void sendControlState(const EntitiesResponse &src,BitStream &bs)
 
 void sendCommands(const EntitiesResponse &src,BitStream &tgt)
 {
+    bool m_pause = false;
+    bool m_gurney = false;
     tgt.StorePackedBits(1,1); // use 'time' shortcut
     tgt.StoreFloat(float(src.m_map_time_of_day)*10.0f);
     tgt.StorePackedBits(1,2); // use 'time scale' shortcut
     tgt.StoreFloat(4.0f);
     tgt.StorePackedBits(1,3); // use 'time step scale' shortcut
     tgt.StoreFloat(2.0f);
+    tgt.StorePackedBits(1,4); // use 'pause' shortcut
+    tgt.StorePackedBits(1, uint32_t(m_pause));
+    tgt.StorePackedBits(1,5); // use 'disablegurneys' shortcut
+    tgt.StorePackedBits(1, uint32_t(m_gurney));
     tgt.StorePackedBits(1,0);
 }
 

--- a/Projects/CoX/Servers/MapServer/Events/SaveClientOptions.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/SaveClientOptions.cpp
@@ -65,8 +65,37 @@ void SaveClientOptions::serializeto(BitStream &tgt) const
 void ClientOptions::init()
 {
     m_opts = {
-        CLIENT_OPT(ClientOption::t_int,control_debug),
-        CLIENT_OPT(ClientOption::t_int,no_strafe),
+        CLIENT_OPT(ClientOption::t_float,time),
+        CLIENT_OPT(ClientOption::t_float,timescale),
+        CLIENT_OPT(ClientOption::t_float,timestepscale),
+        CLIENT_OPT(ClientOption::t_int,pause),
+        CLIENT_OPT(ClientOption::t_int,disablegurneys),
+        CLIENT_OPT(ClientOption::t_int,canlook),
+        CLIENT_OPT(ClientOption::t_int,camrotate),
+        CLIENT_OPT(ClientOption::t_int,forward),
+        CLIENT_OPT(ClientOption::t_int,backward),
+        CLIENT_OPT(ClientOption::t_int,left),
+        CLIENT_OPT(ClientOption::t_int,right),
+        CLIENT_OPT(ClientOption::t_int,up),
+        CLIENT_OPT(ClientOption::t_int,down),
+        CLIENT_OPT(ClientOption::t_int,nocoll),
+        CLIENT_OPT(ClientOption::t_int,nosync),
+        CLIENT_OPT(ClientOption::t_float,speed_turn),
+        CLIENT_OPT(ClientOption::t_int,turnleft),
+        CLIENT_OPT(ClientOption::t_int,turnright),
+        CLIENT_OPT(ClientOption::t_int,zoomin),
+        CLIENT_OPT(ClientOption::t_int,zoomout),
+        CLIENT_OPT(ClientOption::t_int,lookup),
+        CLIENT_OPT(ClientOption::t_int,lookdown),
+        CLIENT_OPT(ClientOption::t_int,third),
+        CLIENT_OPT(ClientOption::t_int,first),
+        CLIENT_OPT(ClientOption::t_float,velscale),
+        CLIENT_OPT(ClientOption::t_float,yaw),
+        CLIENT_OPT(ClientOption::t_float,mouse_speed),
+        CLIENT_OPT(ClientOption::t_int,mouse_invert),
+        CLIENT_OPT(ClientOption::t_int,autorun),
+        CLIENT_OPT(ClientOption::t_int,controldebug),
+        CLIENT_OPT(ClientOption::t_int,nostrafe),
         CLIENT_OPT(ClientOption::t_int,alwaysmobile),
         CLIENT_OPT(ClientOption::t_int,repredict),
         CLIENT_OPT(ClientOption::t_int,neterrorcorrection),
@@ -91,6 +120,6 @@ void ClientOptions::init()
         CLIENT_OPT(ClientOption::t_int,selected_ent_server_index),
     };
 }
-#undef ADD_OPT
+#undef CLIENT_OPT
 
 //! @}

--- a/Projects/CoX/Servers/MapServer/NetCommandManager.cpp
+++ b/Projects/CoX/Servers/MapServer/NetCommandManager.cpp
@@ -14,6 +14,7 @@
 #include "MapClientSession.h"
 
 #include <vector>
+#include <algorithm>
 
 static void FillCommands()
 {
@@ -24,40 +25,61 @@ static void FillCommands()
     args.push_back(arg1);
     std::vector<NetCommand::Argument> fargs;
     fargs.push_back(arg_1float);
-//    cmd_manager->addCommand(new NetCommand(9,"controldebug",args));
-//    cmd_manager->addCommand(new NetCommand(9,"nostrafe",args));
-//    cmd_manager->addCommand(new NetCommand(9,"alwaysmobile",args));
-//    cmd_manager->addCommand(new NetCommand(9,"repredict",args));
-//    cmd_manager->addCommand(new NetCommand(9,"neterrorcorrection",args));
-//    cmd_manager->addCommand(new NetCommand(9,"speed_scale",fargs));
-//    cmd_manager->addCommand(new NetCommand(9,"svr_lag",args));
-//    cmd_manager->addCommand(new NetCommand(9,"svr_lag_vary",args));
-//    cmd_manager->addCommand(new NetCommand(9,"svr_pl",args));
-//    cmd_manager->addCommand(new NetCommand(9,"svr_oo_packets",args));
-//    cmd_manager->addCommand(new NetCommand(9,"client_pos_id",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest0",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest1",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest2",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest3",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest4",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest5",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest6",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest7",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest8",args));
-//    cmd_manager->addCommand(new NetCommand(9,"atest9",args));
-//    cmd_manager->addCommand(new NetCommand(9,"predict",args));
-//    cmd_manager->addCommand(new NetCommand(9,"notimeout",args)); // unknown-10,argtype-1
-//    cmd_manager->addCommand(new NetCommand(9,"selected_ent_server_index",args));
-//    cmd_manager->addCommand(new NetCommand(9,"record_motion",args));
-
+    // The following five netcommands need to be sent in this order.
     cmd_manager->addCommand(new NetCommand(3,"time",fargs));
     cmd_manager->addCommand(new NetCommand(3,"timescale",fargs));
     cmd_manager->addCommand(new NetCommand(3,"timestepscale",fargs));
     cmd_manager->addCommand(new NetCommand(3,"pause",args));
     cmd_manager->addCommand(new NetCommand(3,"disablegurneys",args));
-//    cmd_manager->addCommand(new NetCommand(9,"nodynamiccollisions",args));
-//    cmd_manager->addCommand(new NetCommand(9,"noentcollisions",args));
-//    cmd_manager->addCommand(new NetCommand(9,"pvpmap",args));
+    // Following commands are "optional".
+    cmd_manager->addCommand(new NetCommand(0,"canlook",args));
+    cmd_manager->addCommand(new NetCommand(0,"camrotate",args));
+    cmd_manager->addCommand(new NetCommand(0,"forward",args));
+    cmd_manager->addCommand(new NetCommand(0,"backward",args));
+    cmd_manager->addCommand(new NetCommand(0,"left",args));
+    cmd_manager->addCommand(new NetCommand(0,"right",args));
+    cmd_manager->addCommand(new NetCommand(0,"up",args));
+    cmd_manager->addCommand(new NetCommand(0,"down",args));
+    cmd_manager->addCommand(new NetCommand(1,"nocoll",args));
+    cmd_manager->addCommand(new NetCommand(1,"nosync",args));
+    cmd_manager->addCommand(new NetCommand(0,"speed_turn",fargs));
+    cmd_manager->addCommand(new NetCommand(0,"turnleft",args));
+    cmd_manager->addCommand(new NetCommand(0,"turnright",args));
+    cmd_manager->addCommand(new NetCommand(0,"zoomin",args));
+    cmd_manager->addCommand(new NetCommand(0,"zoomout",args));
+    cmd_manager->addCommand(new NetCommand(0,"lookup",args));
+    cmd_manager->addCommand(new NetCommand(0,"lookdown",args));
+    cmd_manager->addCommand(new NetCommand(0,"third",args));
+    cmd_manager->addCommand(new NetCommand(0,"first",args));
+    cmd_manager->addCommand(new NetCommand(9,"velscale",fargs));
+    cmd_manager->addCommand(new NetCommand(9,"yaw",fargs));
+    cmd_manager->addCommand(new NetCommand(0,"mouse_speed",fargs));
+    cmd_manager->addCommand(new NetCommand(0,"mouse_invert",args));
+    cmd_manager->addCommand(new NetCommand(0,"autorun",args));
+    cmd_manager->addCommand(new NetCommand(9,"controldebug",args));
+    cmd_manager->addCommand(new NetCommand(9,"nostrafe",args));
+    cmd_manager->addCommand(new NetCommand(9,"alwaysmobile",args));
+    cmd_manager->addCommand(new NetCommand(0,"repredict",args));
+    cmd_manager->addCommand(new NetCommand(0,"neterrorcorrection",args));
+    cmd_manager->addCommand(new NetCommand(1,"speed_scale",fargs));
+    cmd_manager->addCommand(new NetCommand(1,"svr_lag",args));
+    cmd_manager->addCommand(new NetCommand(1,"svr_lag_vary",args));
+    cmd_manager->addCommand(new NetCommand(1,"svr_pl",args));
+    cmd_manager->addCommand(new NetCommand(1,"svr_oo_packets",args));
+    cmd_manager->addCommand(new NetCommand(0,"client_pos_id",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest0",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest1",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest2",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest3",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest4",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest5",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest6",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest7",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest8",args));
+    cmd_manager->addCommand(new NetCommand(9,"atest9",args));
+    cmd_manager->addCommand(new NetCommand(0,"predict",args));
+    cmd_manager->addCommand(new NetCommand(9,"notimeout",args));
+    cmd_manager->addCommand(new NetCommand(0,"selected_ent_server_index",args));
 }
 
 int NetCommand::serializefrom( BitStream &bs )
@@ -113,7 +135,7 @@ void NetCommandManager::addCommand( NetCommand *cmd )
 {
     assert(m_name_to_command.find(cmd->m_name)==m_name_to_command.end());
     m_name_to_command[cmd->m_name]=cmd;
-    m_commands_level0.push_back(cmd);
+    m_access_level_commands.push_back(cmd);
 }
 
 NetCommand * NetCommandManager::getCommandByName( const QString &name )
@@ -149,32 +171,21 @@ void NetCommandManager::serializeto(BitStream &tgt, const vNetCommand &commands,
 void NetCommandManager::SendCommandShortcuts( MapClientSession *client,BitStream &tgt,const std::vector<NetCommand *> &commands2 )
 {
     static bool initialized=false;
+    size_t cmd_iterator = 0;
+
     if(!initialized)  {
         initialized=true;
         FillCommands();
     }
 
-    switch(client->m_access_level)
-    {
-        case 0:
-        case 1:
-            // add shortcuts to client's shortcut map.
-            for(size_t i=0; i<m_commands_level0.size(); ++i)
-                client->AddShortcut(i,m_commands_level0[i]);
-            serializeto(tgt,m_commands_level0,commands2);
-            break;
-        case 9:
-            // add shortcuts to client's shortcut map.
-            for(size_t i=0; i<m_commands_level0.size(); ++i)
-                client->AddShortcut(i,m_commands_level0[i]);
-            serializeto(tgt,m_commands_level0,commands2);
-            break;
-        default:
-            // add shortcuts to client's shortcut map.
-            for (size_t i = 0; i<m_commands_level0.size(); ++i)
-                client->AddShortcut(i, m_commands_level0[i]);
-            serializeto(tgt, m_commands_level0, commands2);
-    }
+    std::for_each(begin(m_access_level_commands),
+                  end(m_access_level_commands),
+                  [&client, &cmd_iterator](NetCommand *nc)
+                  {
+		      client->AddShortcut(cmd_iterator, nc);
+		      cmd_iterator++;
+		  });
+    serializeto(tgt, m_access_level_commands, commands2);
 }
 
 //! @}

--- a/Projects/CoX/Servers/MapServer/NetCommandManager.h
+++ b/Projects/CoX/Servers/MapServer/NetCommandManager.h
@@ -12,7 +12,6 @@
 #include <ace/Thread_Mutex.h>
 #include <QtCore/QString>
 #include <QtCore/QHash>
-#include <map>
 #include <vector>
 
 struct MapClientSession;
@@ -49,7 +48,7 @@ class NetCommandManager
 {
     typedef std::vector<NetCommand *> vNetCommand;
     QHash<QString,NetCommand *> m_name_to_command;
-    vNetCommand m_commands_level0;
+    vNetCommand m_access_level_commands;
     void            serializeto(BitStream &tgt,
                                 const vNetCommand &commands,
                                 const vNetCommand &commands2);


### PR DESCRIPTION
Closes #376 & #420 .

Additions/modifications proposed in this pull request:
- NetCommandManager::SendCommandShortcuts now sends all known netcommands.
