### PR TITLE
Compiler warning fixes to address #352

### DIFF
--- a/Projects/CoX/Common/AuthProtocol/AuthLink.cpp
+++ b/Projects/CoX/Common/AuthProtocol/AuthLink.cpp
@@ -214,8 +214,9 @@ int AuthLink::handle_output( ACE_HANDLE /*= ACE_INVALID_HANDLE*/ )
     return 0;
 }
 
-void AuthLink::encode_buffer(const AuthLinkEvent *ev,size_t start)
+void AuthLink::encode_buffer(const AuthLinkEvent *ev, size_t start)
 {
+    (void)start; // temporary to quell unused var warning similar to Q_UNUSED
     assert(ev);
     if(ev==nullptr)
         return;

--- a/Projects/CoX/Common/NetStructures/StateInterpolator.cpp
+++ b/Projects/CoX/Common/NetStructures/StateInterpolator.cpp
@@ -261,6 +261,7 @@ int storeBinTreesResult(BitStream &bs,const std::array<BinTreeEntry,7> &bintree)
     static const uint8_t tree_depth_bits_mod[8] = { 1,2,2,3,3,3,3 };
     char num_bits;
     int val_sign;
+    Q_UNUSED(val_sign);
     char base_bitcount;
     int res=0;
     std::array<BinTreeEntry,7> tree_copy = bintree;

--- a/Projects/CoX/Common/NetStructures/Team.cpp
+++ b/Projects/CoX/Common/NetStructures/Team.cpp
@@ -251,6 +251,7 @@ void addSidekick(Entity &tgt, Entity &src)
     Sidekick    &tgt_sk = tgt.m_char->m_char_data.m_sidekick;
     uint32_t    src_lvl = getLevel(*src.m_char);
     uint32_t    tgt_lvl = getLevel(*tgt.m_char);
+    Q_UNUSED(tgt_lvl);
 
     src_sk.m_has_sidekick = true;
     tgt_sk.m_has_sidekick = true;

--- a/Projects/CoX/Common/NetStructures/Team.cpp
+++ b/Projects/CoX/Common/NetStructures/Team.cpp
@@ -250,8 +250,6 @@ void addSidekick(Entity &tgt, Entity &src)
     Sidekick    &src_sk = src.m_char->m_char_data.m_sidekick;
     Sidekick    &tgt_sk = tgt.m_char->m_char_data.m_sidekick;
     uint32_t    src_lvl = getLevel(*src.m_char);
-    uint32_t    tgt_lvl = getLevel(*tgt.m_char);
-    Q_UNUSED(tgt_lvl);
 
     src_sk.m_has_sidekick = true;
     tgt_sk.m_has_sidekick = true;

--- a/Projects/CoX/Common/Runtime/SceneGraph.cpp
+++ b/Projects/CoX/Common/Runtime/SceneGraph.cpp
@@ -225,7 +225,7 @@ QString groupRename(LoadingContext &ctx, const QString &oldname, bool is_def)
         return str;
     if ( !is_def && !str.contains("/grp",Qt::CaseInsensitive) && !str.contains("/map",Qt::CaseInsensitive) )
         return str;
-    QString querystring = QString(str).toLower();
+    QString querystring = str.toLower();
     auto str_iter = ctx.m_renamer.new_names.find(querystring);
 
     if ( str_iter!=ctx.m_renamer.new_names.end() )

--- a/Projects/CoX/Common/Servers/ClientManager.h
+++ b/Projects/CoX/Common/Servers/ClientManager.h
@@ -58,7 +58,7 @@ mutable std::mutex m_store_mutex;
         uint32_t create_cookie(const ACE_INET_Addr &from,uint64_t id)
         {
                 uint64_t res = ((from.hash()+id)&0xFFFFFFFF)^(id>>32);
-                qWarning("Create_cookie still needs a good algorithm. 0x%08x", res);
+                qWarning("Create_cookie still needs a good algorithm. 0x%" PRIx64, res);
                 return (uint32_t)res;
         }
 
@@ -221,7 +221,7 @@ public:
         }
         void create_reaping_timer(EventProcessor *tgt, uint32_t id, ACE_Time_Value interval)
         {
-            m_session_reaper_timer.reset(new SEGSTimer(tgt, (void *)id, interval, false));
+            m_session_reaper_timer.reset(new SEGSTimer(tgt, (void *)(intptr_t)id, interval, false));
         }
         void mark_session_for_reaping(SESSION_CLASS *sess, uint64_t token)
         {

--- a/Projects/CoX/Common/Servers/ClientManager.h
+++ b/Projects/CoX/Common/Servers/ClientManager.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 #include <vector>
 #include <cassert>
-
+#include <cinttypes>
 
 // TODO: consider storing all sessions in vector, and convert m_session_store to token->index map
 template <class SESSION_CLASS>

--- a/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
@@ -216,7 +216,7 @@ void AuthHandler::on_retrieve_account_response(RetrieveAccountResponse *msg)
         lnk->putq(s_auth_error_locked_account.shallow_copy());
         return;
     }
-    qDebug("Server Account Id : %d", acc_inf.m_acc_server_acc_id);
+    qDebug("Server Account Id : %" PRIu64, acc_inf.m_acc_server_acc_id);
     // step 3d: checking if this account is blocked
     if(isClientConnectedAnywhere(acc_inf.m_acc_server_acc_id))
     {

--- a/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
+++ b/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
@@ -117,7 +117,8 @@ bool storePosition(const Entity &src,BitStream &bs)
 
 bool update_rot(const Entity &/*src*/, int axis ) /* returns true if given axis needs updating */
 {
-    if(axis==axis) // FixMe: var compared against same var.
+    int axis_tmp = axis;
+    if(axis==axis_tmp) // FixMe: var compared against same var.
         return true;
     return false;
 }

--- a/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
+++ b/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
@@ -117,8 +117,8 @@ bool storePosition(const Entity &src,BitStream &bs)
 
 bool update_rot(const Entity &/*src*/, int axis ) /* returns true if given axis needs updating */
 {
-    int axis_tmp = axis;
-    if(axis==axis_tmp) // FixMe: var compared against same var.
+    int axis_tmp = axis; // Used to quell tautological comparison warning
+    if(axis==axis_tmp)   // FixMe: var compared against same var.
         return true;
     return false;
 }

--- a/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
@@ -399,6 +399,7 @@ void storePowerInfoUpdate(const EntitiesResponse &/*src*/,BitStream &bs)
     std::vector<Power> powers;
     for(Power &p : powers)
     {
+        Q_UNUSED(p);
         bs.StoreBits(1,1); // have power to send.
         uint32_t category_idx=0;
         uint32_t powerset_idx=0;

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -133,6 +133,7 @@ void MapInstance::start(const QString &scenegraph_path)
         m_npc_generators.m_generators["Door_Left_Ind_01"] = {"Door_Left_Ind_01",EntType::DOOR,{}};
 
         bool scene_graph_loaded = false;
+        Q_UNUSED(scene_graph_loaded);
         TIMED_LOG({
                 m_map_scenegraph = new MapSceneGraph;
                 scene_graph_loaded = m_map_scenegraph->loadFromFile("./data/geobin/" + scenegraph_path);
@@ -1923,6 +1924,7 @@ const MapServerData &MapInstance::serverData() const
 
 glm::vec3 MapInstance::closest_safe_location(glm::vec3 v) const
 {
+    Q_UNUSED(v);
     if(!m_new_player_spawns.empty())
     {
         return m_new_player_spawns.front()[3];

--- a/Projects/CoX/Servers/MapServer/NetCommandManager.cpp
+++ b/Projects/CoX/Servers/MapServer/NetCommandManager.cpp
@@ -71,7 +71,7 @@ int NetCommand::serializefrom( BitStream &bs )
                 int res=bs.GetPackedBits(1);
                 if(m_arguments[i].targetvar)
                     *((int *)m_arguments[i].targetvar) = res;
-                qDebug("CommRecv %s:arg%d : %d", qPrintable(m_name),i,res);
+                qDebug("CommRecv %s:arg%zu : %d", qPrintable(m_name),i,res);
                 break;
             }
             case 2:
@@ -79,19 +79,19 @@ int NetCommand::serializefrom( BitStream &bs )
             {
                 QString res;
                 bs.GetString(res); // postprocessed
-                qDebug("CommRecv %s:arg%d : %s", qPrintable(m_name),i,qPrintable(res));
+                qDebug("CommRecv %s:arg%zu : %s", qPrintable(m_name),i,qPrintable(res));
                 break;
             }
             case 3:
             {
                 float res = bs.GetFloat();
-                qDebug("CommRecv %s:arg%d : %f", qPrintable(m_name),i,res);
+                qDebug("CommRecv %s:arg%zu : %f", qPrintable(m_name),i,res);
                 break;
             }
             case 5:
             {
                 float res1 = normalizedCircumferenceToFloat(bs.GetBits(14),14);
-                qDebug("CommRecv %s:arg%d : %s", qPrintable(m_name),i,res1);
+                qDebug("CommRecv %s:arg%zu : %f", qPrintable(m_name),i,res1);
                 break;
             }
             case 6:
@@ -101,7 +101,7 @@ int NetCommand::serializefrom( BitStream &bs )
                 float res1 = bs.GetFloat();
                 float res2 = bs.GetFloat();
                 float res3 = bs.GetFloat();
-                qDebug("CommRecv %s:arg%d : %f,%f,%f", qPrintable(m_name),i,res1,res2,res3);
+                qDebug("CommRecv %s:arg%zu : %f,%f,%f", qPrintable(m_name),i,res1,res2,res3);
                 break;
             }
         }

--- a/Projects/CoX/Servers/MapServer/ScriptingEngine_Null.cpp
+++ b/Projects/CoX/Servers/MapServer/ScriptingEngine_Null.cpp
@@ -11,13 +11,47 @@
  */
 
 #include "ScriptingEngine.h"
+
+#include <QtGlobal>
+
 ScriptingEngine::ScriptingEngine() {}
 ScriptingEngine::~ScriptingEngine() {}
 void ScriptingEngine::registerTypes() {}
-int ScriptingEngine::runScript(const QString &script_contents, const char *script_name) {return -1;}
-int ScriptingEngine::runScript(MapClientSession * client, const QString &script_contents, const char *script_name) {return -1;}
-int ScriptingEngine::loadAndRunFile(const QString &path) { return -1; }
-std::string ScriptingEngine::callFunc(const char *name, int arg1) { return ""; }
-std::string ScriptingEngine::callFuncWithClientContext(MapClientSession *client, const char *name, int arg1) { return "";}
+
+int ScriptingEngine::runScript(const QString &script_contents, const char *script_name)
+{
+    Q_UNUSED(script_contents);
+    Q_UNUSED(script_name);
+    return -1;
+}
+
+int ScriptingEngine::runScript(MapClientSession * client, const QString &script_contents, const char *script_name)
+{
+    Q_UNUSED(client);
+    Q_UNUSED(script_contents);
+    Q_UNUSED(script_name);
+    return -1;
+}
+
+int ScriptingEngine::loadAndRunFile(const QString &path)
+{
+    Q_UNUSED(path);
+    return -1;
+}
+
+std::string ScriptingEngine::callFunc(const char *name, int arg1)
+{
+    Q_UNUSED(name);
+    Q_UNUSED(arg1);
+    return "";
+}
+
+std::string ScriptingEngine::callFuncWithClientContext(MapClientSession *client, const char *name, int arg1)
+{
+    Q_UNUSED(client);
+    Q_UNUSED(name);
+    Q_UNUSED(arg1);
+    return "";
+}
 
 //! @}

--- a/Utilities/slav/SLAVLogic.cpp
+++ b/Utilities/slav/SLAVLogic.cpp
@@ -69,6 +69,7 @@ void SLAVLogic::onManifestReceived(const QString &manifest_url,const QString &ma
 {
     AppVersionManifest pm;
     bool load_res = loadFrom(pm,manifestData);
+    Q_UNUSED(load_res);
     // we've got a project manifest, perform work based on the manifest type.
     if(manifest_url.contains("slav.manifest"))
     {

--- a/Utilities/slav/ServerConnection.cpp
+++ b/Utilities/slav/ServerConnection.cpp
@@ -36,6 +36,8 @@ void ServerConnection::onRequestManifest(const QString &manifestname) {
 
 void ServerConnection::onRequestFileList(const QString & base_path, const QStringList & files)
 {
+    Q_UNUSED(base_path);
+    Q_UNUSED(files);
     assert(false);
 }
 


### PR DESCRIPTION
This pull request addresses any remaining compiler warnings outlined in #352 with the exception of those stemming from Qt GUI-related casts pertaining to callback functions. As a result, SEGSAdmin and SLAV will remain affected until the Qt developers address the reported casting issues up to 5.9. `Q_UNUSED` is employed as self-documenting way to quell unused var warnings. It is easily searchable and can be used to locate and address each finding in the future. Various casts and format specifiers were also fixed which should help with truncation in certain cases.