### PR TITLE
Fix full_update when we run in de-sync mode

### DIFF
--- a/Projects/CoX/Common/NetStructures/Entity.cpp
+++ b/Projects/CoX/Common/NetStructures/Entity.cpp
@@ -200,4 +200,9 @@ void unmarkEntityForDbStore(Entity *e, DbStoreFlags f)
     e->m_db_store_flags &= ~uint32_t(f);
 }
 
+void forcePosition(Entity &e, glm::vec3 pos)
+{
+    e.m_entity_data.m_pos = pos;
+    e.m_full_update_count = 10;
+}
 //! @}

--- a/Projects/CoX/Common/NetStructures/Entity.h
+++ b/Projects/CoX/Common/NetStructures/Entity.h
@@ -166,7 +166,7 @@ public:
         PlayerPtr           m_player;
         NPCPtr              m_npc;
 
-
+        int                 m_full_update_count     = 10; // TODO: remove this after we have proper physics
         bool                m_has_supergroup        = true;
         SuperGroup          m_supergroup;                       // client has this in entity class, but maybe move to Character class?
         bool                m_has_team              = false;
@@ -269,4 +269,5 @@ void unmarkEntityForDbStore(Entity *e, DbStoreFlags f);
 void initializeNewPlayerEntity(Entity &e);
 void initializeNewNpcEntity(Entity &e, const Parse_NPC *src, int idx, int variant);
 void fillEntityFromNewCharData(Entity &e, BitStream &src, const ColorAndPartPacker *packer, const Parse_AllKeyProfiles &default_profiles);
+void forcePosition(Entity &e,glm::vec3 pos);
 extern void abortLogout(Entity *e);

--- a/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
@@ -508,6 +508,10 @@ void sendServerControlState(const EntitiesResponse &src,BitStream &bs)
 void sendServerPhysicsPositions(const EntitiesResponse &src,BitStream &bs)
 {
     Entity * target = src.m_client->m_ent;
+    //TODO: remove this after we have proper physics processing
+    if(target->m_full_update_count>0)
+        target->m_full_update_count--;
+    target->m_full_update = target->m_full_update_count!=0;
 
     bs.StoreBits(1,target->m_full_update);
     if( !target->m_full_update )

--- a/Projects/CoX/Servers/MapServer/Events/GameCommandList.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/GameCommandList.cpp
@@ -12,4 +12,20 @@
 
 #include "GameCommandList.h"
 
+
+void PreUpdateCommand::serializeto(BitStream &bs) const
+{
+    bs.StorePackedBits(1, 13);
+    for(const auto &command : m_contents)
+        command->serializeto(bs);
+    bs.StorePackedBits(1,0); // finalize the command list
+}
+
+void PreUpdateCommand::serializefrom(BitStream &)
+{
+    assert(false);
+    // TODO: trouble, we need a second GameCommand Factory at this point !
+    //uint32_t game_command = src.GetPackedBits(1);
+}
+
 //! @}

--- a/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
+++ b/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
@@ -26,28 +26,16 @@ class PreUpdateCommand : public MapLinkEvent
 {
     std::vector<std::unique_ptr<GameCommand> > m_contents;
 public:
-    PreUpdateCommand() : MapLinkEvent(MapEventTypes::evPreUpdateCommand) {}
-    template <typename... Commands>
-    PreUpdateCommand(Commands &&... items) : PreUpdateCommand()
-    {
-        std::unique_ptr<GameCommand> cmdArr[] = {std::unique_ptr<GameCommand>(std::move(items))...};
-        m_contents = std::vector<std::unique_ptr<GameCommand>>{std::make_move_iterator(std::begin(cmdArr)),
-                                                               std::make_move_iterator(std::end(cmdArr))};
-    }
-
-    void serializeto(BitStream &bs) const
-    {
-        bs.StorePackedBits(1, 13);
-        for(const auto &command : m_contents)
-            command->serializeto(bs);
-        bs.StorePackedBits(1,0); // finalize the command list
-    }
-    void serializefrom(BitStream &/*src*/)
-    {
-        assert(false);
-        // TODO: trouble, we need a second GameCommand Factory at this point !
-        //uint32_t game_command = src.GetPackedBits(1);
-    }
+                PreUpdateCommand() : MapLinkEvent(MapEventTypes::evPreUpdateCommand) {}
+                template <typename... Commands>
+                PreUpdateCommand(Commands &&... items) : PreUpdateCommand()
+                {
+                    std::unique_ptr<GameCommand> cmdArr[] = {std::unique_ptr<GameCommand>(std::move(items))...};
+                    m_contents = std::vector<std::unique_ptr<GameCommand>>{std::make_move_iterator(std::begin(cmdArr)),
+                                                                           std::make_move_iterator(std::end(cmdArr))};
+                }
+        void    serializeto(BitStream &bs) const;
+        void    serializefrom(BitStream &/*src*/);
 };
 #include "Events/ChatMessage.h"
 #include "Events/StandardDialogCmd.h"

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -638,10 +638,10 @@ void MapInstance::on_create_map_entity(NewEntity *ev)
         e->m_char->m_account_id = map_session.auth_id();
         e->m_client = &map_session;
         map_session.m_ent = e;
-        if(m_new_player_spawns.empty())
-            e->m_entity_data.m_pos = glm::vec3(128.0f,16.0f,-198.0f); // Atlas Park Starting Location
-        else
-            e->m_entity_data.m_pos = glm::vec3(m_new_player_spawns[rand()%m_new_player_spawns.size()][3]);
+        glm::vec3 spawn_pos = glm::vec3(128.0f,16.0f,-198.0f);
+        if(!m_new_player_spawns.empty())
+            spawn_pos = glm::vec3(m_new_player_spawns[rand()%m_new_player_spawns.size()][3]);
+        forcePosition(*e,spawn_pos);
         e->m_entity_data.m_access_level = map_session.m_access_level;
         // new characters are transmitted nameless, use the name provided in on_expect_client
         e->m_char->setName(map_session.m_name);

--- a/Projects/CoX/Servers/MapServer/MapSceneGraph.cpp
+++ b/Projects/CoX/Servers/MapServer/MapSceneGraph.cpp
@@ -145,7 +145,7 @@ struct NpcCreator
             {
                 int idx = npc_store.npc_idx(npc_def);
                 Entity *e = map_instance->m_entities.CreateNpc(*npc_def, idx, 0);
-                e->m_entity_data.m_pos = glm::vec3(v[3]);
+                forcePosition(*e,glm::vec3(v[3]));
                 auto valquat = glm::quat_cast(v);
 
                 glm::vec3 angles = glm::eulerAngles(valquat);

--- a/Projects/CoX/Servers/MapServer/NpcGenerator.cpp
+++ b/Projects/CoX/Servers/MapServer/NpcGenerator.cpp
@@ -23,7 +23,7 @@ void NpcGenerator::generate(MapInstance *map_instance)
     {
         int idx = npc_store.npc_idx(npc_def);
         Entity *e = map_instance->m_entities.CreateGeneric(*npc_def, idx, 0,type);
-        e->m_entity_data.m_pos = glm::vec3(v[3]);
+        forcePosition(*e,glm::vec3(v[3]));
         auto valquat = glm::quat_cast(v);
 
         glm::vec3 angles = glm::eulerAngles(valquat);

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -744,7 +744,7 @@ void addNpc(const QString &cmd, MapClientSession &sess)
     glm::vec3 offset = glm::vec3 {2,0,1};
     int idx = npc_store.npc_idx(npc_def);
     Entity *e = sess.m_current_map->m_entities.CreateNpc(*npc_def,idx,variation);
-    e->m_entity_data.m_pos = gm_loc + offset;
+    forcePosition(*e,gm_loc + offset);
     e->m_velocity = {0,0,0};
     sendInfoMessage(MessageChannel::DEBUG_INFO, QString("Created npc with ent idx:%1").arg(e->m_idx), &sess);
 }
@@ -763,7 +763,7 @@ void moveTo(const QString &cmd, MapClientSession &sess)
       parts[2].toFloat(),
       parts[3].toFloat()
     };
-    sess.m_ent->m_entity_data.m_pos = new_pos;
+    forcePosition(*sess.m_ent,new_pos);
     sendInfoMessage(MessageChannel::DEBUG_INFO, QString("New position set"), &sess);
 
 }
@@ -864,7 +864,7 @@ void cmdHandler_SetTitles(const QString &cmd, MapClientSession &sess)
 void cmdHandler_Stuck(const QString &cmd, MapClientSession &sess)
 {
     // TODO: Implement true move-to-safe-location-nearby logic
-    sess.m_ent->m_entity_data.m_pos = sess.m_current_map->closest_safe_location(sess.m_ent->m_entity_data.m_pos);
+    forcePosition(*sess.m_ent,sess.m_current_map->closest_safe_location(sess.m_ent->m_entity_data.m_pos));
 
     QString msg = QString("Resetting location to default spawn (%1,%2,%3)")
                       .arg(sess.m_ent->m_entity_data.m_pos.x)

--- a/Projects/CoX/Utilities/MapViewer/CMakeLists.txt
+++ b/Projects/CoX/Utilities/MapViewer/CMakeLists.txt
@@ -1,5 +1,5 @@
 #FIND_PACKAGE(ACE REQUIRED)
-find_package(Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
 
 set(CMAKE_AUTOUIC TRUE)
 set(CMAKE_AUTOMOC TRUE)
@@ -29,8 +29,8 @@ TARGET_LINK_LIBRARIES(mapviewer
     lutefisk3d_IMP
     ace_IMP
     gameData common_runtime cereal_IMP
+    Qt5::Core Qt5::Widgets
 )
-qt5_use_modules(mapviewer Core Widgets  )
 
 add_custom_command(TARGET mapviewer POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory ${EXECUTABLE_OUTPUT_PATH}/mapviewer_data


### PR DESCRIPTION
/moveTo, /stuck and spawn locations are now properly reflected client-side,
even when we start in de-synced mode ( 0.5.0 release specific )

Closes #402
