### PR TITLE
Improve readability in several MapServer files

### DIFF
--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -197,7 +197,7 @@ bool MapInstance::spin_up_for(uint8_t game_server_id,uint32_t owner_id,uint32_t 
     if (m_endpoint->open() == -1) // will register notifications with current reactor
         ACE_ERROR_RETURN ((LM_ERROR, "(%P|%t) MapInstance: ServerEndpoint::open\n"),false);
 
-    qDebug() << "Spun up MapInstance" << m_instance_id "for MapServer" << m_owner_id;
+    qInfo() << "Spun up MapInstance" << m_instance_id << "for MapServer" << m_owner_id;
 
     return true;
 }

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -191,11 +191,13 @@ bool MapInstance::spin_up_for(uint8_t game_server_id,uint32_t owner_id,uint32_t 
     m_instance_id = instance_id;
     if (ACE_Reactor::instance()->register_handler(m_endpoint,ACE_Event_Handler::READ_MASK) == -1)
     {
-        qWarning() << "MapInstance::spin_up_for faile to register_handler, port already open";
+        qWarning() << "MapInstance::spin_up_for failed to register_handler, port already open";
         return false;
     }
     if (m_endpoint->open() == -1) // will register notifications with current reactor
         ACE_ERROR_RETURN ((LM_ERROR, "(%P|%t) MapInstance: ServerEndpoint::open\n"),false);
+
+    qDebug() << "Spun up MapInstance" << m_instance_id "for MapServer" << m_owner_id;
 
     return true;
 }

--- a/Projects/CoX/Servers/MapServer/MapManager.cpp
+++ b/Projects/CoX/Servers/MapServer/MapManager.cpp
@@ -45,7 +45,8 @@ MapManager::~MapManager()
 bool MapManager::load_templates(const QString &template_directory, uint8_t game_id, uint32_t map_id,
                                 const ListenAndLocationAddresses &loc)
 {
-    qCDebug(logSettings) << "Starting the search for maps in" << template_directory;
+    qDebug() << "Starting the search for maps in:" << template_directory;
+
     QDirIterator map_dir_visitor(template_directory, QDir::Dirs|QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
     while (map_dir_visitor.hasNext())
     {
@@ -55,7 +56,8 @@ bool MapManager::load_templates(const QString &template_directory, uint8_t game_
             auto tpl = new MapTemplate(map_dir_visitor.fileInfo().filePath(), game_id, map_id, loc);
             m_templates[s_map_name_to_id[tpl->base_name()]] = tpl;
             m_name_to_template[tpl->client_filename()] = tpl;
-            qCDebug(logSettings) << "Detected a map"<<map_dir_visitor.fileInfo().filePath();
+
+            qDebug() << "Detected map:" << map_dir_visitor.fileInfo().filePath();
         }
     }
     // (template_directory / "tutorial.bin")

--- a/Projects/CoX/Servers/MapServer/MapManager.cpp
+++ b/Projects/CoX/Servers/MapServer/MapManager.cpp
@@ -45,7 +45,7 @@ MapManager::~MapManager()
 bool MapManager::load_templates(const QString &template_directory, uint8_t game_id, uint32_t map_id,
                                 const ListenAndLocationAddresses &loc)
 {
-    qDebug() << "Starting the search for maps in:" << template_directory;
+    qInfo() << "Searching for maps in:" << template_directory;
 
     QDirIterator map_dir_visitor(template_directory, QDir::Dirs|QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
     while (map_dir_visitor.hasNext())
@@ -57,7 +57,7 @@ bool MapManager::load_templates(const QString &template_directory, uint8_t game_
             m_templates[s_map_name_to_id[tpl->base_name()]] = tpl;
             m_name_to_template[tpl->client_filename()] = tpl;
 
-            qDebug() << "Detected map:" << map_dir_visitor.fileInfo().filePath();
+            qInfo() << "Found map:" << map_dir_visitor.fileInfo().filePath();
         }
     }
     // (template_directory / "tutorial.bin")

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -66,14 +66,16 @@ MapServer::~MapServer()
 
 bool MapServer::Run()
 {
-    assert(m_owner_game_server_id!=255);
-    if(!d->m_runtime_data.read_runtime_data("./data/bin/"))
-    {
-        return false;
-    }
-    assert(d->m_manager.num_templates()>0); // we have to have a world to run
+    assert(m_owner_game_server_id != kInvalidGameServerId);
 
-    qInfo() << "Server running... awaiting client connections."; // best place for this?
+    if (!d->m_runtime_data.read_runtime_data(kRuntimeDataPath))
+        return false;
+
+    assert(d->m_manager.num_templates() > 0);
+
+    qInfo() << "MapServer" << m_id << "now listening on" << m_base_listen_point.get_host_addr() << ":"
+            << m_base_listen_point.get_port_number();
+
     return true;
 }
 

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -66,9 +66,9 @@ MapServer::~MapServer()
 
 bool MapServer::Run()
 {
-    assert(m_owner_game_server_id != kInvalidGameServerId);
+    assert(m_owner_game_server_id != INVALID_GAME_SERVER_ID);
 
-    if (!d->m_runtime_data.read_runtime_data(kRuntimeDataPath))
+    if (!d->m_runtime_data.read_runtime_data(RUNTIME_DATA_PATH))
         return false;
 
     assert(d->m_manager.num_templates() > 0);

--- a/Projects/CoX/Servers/MapServer/MapServer.h
+++ b/Projects/CoX/Servers/MapServer/MapServer.h
@@ -21,8 +21,8 @@ class MapInstance;
 class MapServerData;
 class MapManager;
 
-static constexpr uint8_t kInvalidGameServerId= {255};
-static constexpr char kRuntimeDataPath[] = {"./data/bin/"};
+static constexpr uint8_t INVALID_GAME_SERVER_ID = 255;
+static constexpr char RUNTIME_DATA_PATH[] = "./data/bin/";
 
 class MapServer : public EventProcessor
 {
@@ -45,8 +45,8 @@ private:
 
         std::unique_ptr<PrivateData> d;
 
-        uint8_t                 m_id = {1};
-        uint8_t                 m_owner_game_server_id = {kInvalidGameServerId};
+        uint8_t                 m_id = 1;
+        uint8_t                 m_owner_game_server_id = INVALID_GAME_SERVER_ID;
         ACE_INET_Addr           m_base_location; //! this is the base map instance address
         ACE_INET_Addr           m_base_listen_point; //! this is used as a base map listening endpoint
 };

--- a/Projects/CoX/Servers/MapServer/MapServer.h
+++ b/Projects/CoX/Servers/MapServer/MapServer.h
@@ -21,6 +21,9 @@ class MapInstance;
 class MapServerData;
 class MapManager;
 
+static constexpr uint8_t kInvalidGameServerId= {255};
+static constexpr char kRuntimeDataPath[] = {"./data/bin/"};
+
 class MapServer : public EventProcessor
 {
         class PrivateData;
@@ -42,10 +45,10 @@ private:
 
         std::unique_ptr<PrivateData> d;
 
-        uint8_t                 m_id = 1;
-        uint8_t                 m_owner_game_server_id = 255;
-        QString                 m_serverName;
+        uint8_t                 m_id = {1};
+        uint8_t                 m_owner_game_server_id = {kInvalidGameServerId};
         ACE_INET_Addr           m_base_location; //! this is the base map instance address
         ACE_INET_Addr           m_base_listen_point; //! this is used as a base map listening endpoint
 };
+
 extern MapServer *g_GlobalMapServer;


### PR DESCRIPTION
Additions/modifications proposed in this pull request:
- Add more detailed startup message in MapServer and some refactoring to use constants. Removed an member field.
- Fix a typo in MapInstance::spin_up_for() and add a startup message.
- Convert qCDebug() statements to qDebug() statements in MapManager to print them in the console.
