### PR TITLE
Changing CharData::m_mapName to EntityData::m_current_map

### DIFF
--- a/Projects/CoX/Common/GameData/chardata_definitions.h
+++ b/Projects/CoX/Common/GameData/chardata_definitions.h
@@ -29,7 +29,7 @@ static const constexpr  uint32_t        class_version   = 1;
 
 struct CharacterData
 {
-static const constexpr  uint32_t    class_version       = 4;
+static const constexpr  uint32_t    class_version       = 5;    // v5: no more m_mapName
                         uint32_t    m_level             = 0;
                         uint32_t    m_combat_level      = 0; // might be different if player is sidekick or exemplar, or hasn't trained up.
                         uint32_t    m_experience_points = 0;
@@ -49,7 +49,6 @@ static const constexpr  uint32_t    class_version       = 4;
                         QString     m_last_online;
                         QString     m_class_name;
                         QString     m_origin_name;
-                        QString     m_mapName;
                         uint32_t    m_mapIdx;
                         bool        m_supergroup_costume;       // player has a sg costume
                         bool        m_using_sg_costume;         // player uses sg costume currently

--- a/Projects/CoX/Common/GameData/chardata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/chardata_serializers.cpp
@@ -42,6 +42,7 @@ void serialize(Archive &archive, Friend &fr, uint32_t const version)
     archive(cereal::make_nvp("FriendClass", fr.m_class_idx));
     archive(cereal::make_nvp("FriendOrigin", fr.m_origin_idx));
     archive(cereal::make_nvp("FriendMapIdx", fr.m_map_idx));
+    archive(cereal::make_nvp("FriendMapName", fr.m_mapname));
 }
 
 template<class Archive>

--- a/Projects/CoX/Common/GameData/chardata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/chardata_serializers.cpp
@@ -42,7 +42,7 @@ void serialize(Archive &archive, Friend &fr, uint32_t const version)
     archive(cereal::make_nvp("FriendClass", fr.m_class_idx));
     archive(cereal::make_nvp("FriendOrigin", fr.m_origin_idx));
     archive(cereal::make_nvp("FriendMapIdx", fr.m_map_idx));
-    archive(cereal::make_nvp("FriendMapName", fr.m_mapname));
+    archive(cereal::make_nvp("FriendMapname", fr.m_mapname));
 }
 
 template<class Archive>

--- a/Projects/CoX/Common/GameData/chardata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/chardata_serializers.cpp
@@ -42,7 +42,6 @@ void serialize(Archive &archive, Friend &fr, uint32_t const version)
     archive(cereal::make_nvp("FriendClass", fr.m_class_idx));
     archive(cereal::make_nvp("FriendOrigin", fr.m_origin_idx));
     archive(cereal::make_nvp("FriendMapIdx", fr.m_map_idx));
-    archive(cereal::make_nvp("FriendMapname", fr.m_mapname));
 }
 
 template<class Archive>
@@ -101,7 +100,6 @@ void serialize(Archive &archive, CharacterData &cd, uint32_t const version)
     archive(cereal::make_nvp("LastOnline",cd.m_last_online));
     archive(cereal::make_nvp("Class",cd.m_class_name));
     archive(cereal::make_nvp("Origin",cd.m_origin_name));
-    archive(cereal::make_nvp("MapName",cd.m_mapName));
     archive(cereal::make_nvp("SuperGroupCostume",cd.m_supergroup_costume));
     archive(cereal::make_nvp("UsingSGCostume",cd.m_using_sg_costume));
     archive(cereal::make_nvp("SideKick",cd.m_sidekick));

--- a/Projects/CoX/Common/GameData/entitydata_definitions.h
+++ b/Projects/CoX/Common/GameData/entitydata_definitions.h
@@ -13,11 +13,18 @@
 
 struct EntityData
 {
-static const constexpr  uint32_t    class_version       = 3;
+static const constexpr  uint32_t    class_version       = 4;    // v4: adds m_current_map
                         uint32_t    m_access_level      = 0;
                         uint8_t     m_origin_idx        = {0};
                         uint8_t     m_class_idx         = {0};
                         glm::vec3   m_pos;
                         glm::vec3   m_orientation_pyr;          // Stored in Radians
                         uint32_t    m_map_idx           = 1;    // only 1 map instance
+                        QString     m_current_map;
+
+                        void reset()
+                        {}
+
+                        void dump()
+                        {}
 };

--- a/Projects/CoX/Common/GameData/entitydata_definitions.h
+++ b/Projects/CoX/Common/GameData/entitydata_definitions.h
@@ -21,21 +21,4 @@ static const constexpr  uint32_t    class_version       = 4;    // v4: adds m_cu
                         glm::vec3   m_orientation_pyr;          // Stored in Radians
                         uint32_t    m_map_idx           = 1;    // only 1 map instance
                         QString     m_current_map;
-
-                        void reset()
-                        {}
-
-                        void dump()
-                        {}
-
-                        QString getMapName()
-                        {
-                            if (m_current_map.contains("City_00_01", Qt::CaseInsensitive))
-                                return "Outbreak";
-                            if (m_current_map.contains("City_01_01", Qt::CaseInsensitive))
-                                return "AtlasPark";
-
-                            // let's default to Outbreak in case things go wrong
-                            return "Outbreak";
-                        }
 };

--- a/Projects/CoX/Common/GameData/entitydata_definitions.h
+++ b/Projects/CoX/Common/GameData/entitydata_definitions.h
@@ -27,4 +27,15 @@ static const constexpr  uint32_t    class_version       = 4;    // v4: adds m_cu
 
                         void dump()
                         {}
+
+                        QString getMapName()
+                        {
+                            if (m_current_map.contains("City_00_01", Qt::CaseInsensitive))
+                                return "Outbreak";
+                            if (m_current_map.contains("City_01_01", Qt::CaseInsensitive))
+                                return "AtlasPark";
+
+                            // let's default to Outbreak in case things go wrong
+                            return "Outbreak";
+                        }
 };

--- a/Projects/CoX/Common/GameData/entitydata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/entitydata_serializers.cpp
@@ -36,6 +36,9 @@ void serialize(Archive & archive, EntityData &ed, uint32_t const version)
 
     if(version >= 3)
         archive(cereal::make_nvp("MapIdx",ed.m_map_idx));
+
+    if(version >= 4)
+        archive(cereal::make_nvp("CurrentMap", ed.m_current_map));
 }
 
 void saveTo(const EntityData & target, const QString & baseName, bool text_format)

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -179,7 +179,7 @@ void Character::SendCharBuildInfo(BitStream &bs) const
     PUTDEBUG("SendCharBuildInfo after boosts");
 }
 
-void Character::serializetoCharsel( BitStream &bs, const QString& m_current_map )
+void Character::serializetoCharsel( BitStream &bs, const QString& entity_map_name )
 {
     Character c = *this;
     bs.StorePackedBits(1,getLevel(c));
@@ -193,7 +193,7 @@ void Character::serializetoCharsel( BitStream &bs, const QString& m_current_map 
     }
     else
         m_costumes[m_current_costume_set].storeCharsel(bs);
-    bs.StoreString(m_current_map);
+    bs.StoreString(entity_map_name);
     bs.StorePackedBits(1,1);
 }
 

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -179,7 +179,7 @@ void Character::SendCharBuildInfo(BitStream &bs) const
     PUTDEBUG("SendCharBuildInfo after boosts");
 }
 
-void Character::serializetoCharsel( BitStream &bs )
+void Character::serializetoCharsel( BitStream &bs, const QString& m_current_map )
 {
     Character c = *this;
     bs.StorePackedBits(1,getLevel(c));
@@ -193,6 +193,7 @@ void Character::serializetoCharsel( BitStream &bs )
     }
     else
         m_costumes[m_current_costume_set].storeCharsel(bs);
+    bs.StoreString(m_current_map);
     bs.StorePackedBits(1,1);
 }
 

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -60,7 +60,6 @@ void Character::reset()
     m_char_data.m_class_name="EMPTY";
     m_char_data.m_origin_name="EMPTY";
     m_villain=false;
-    m_char_data.m_mapName="OFFLINE";
     m_multiple_costumes=false;
     m_current_costume_idx=0;
     m_current_costume_set=false;
@@ -194,7 +193,6 @@ void Character::serializetoCharsel( BitStream &bs )
     }
     else
         m_costumes[m_current_costume_set].storeCharsel(bs);
-    bs.StoreString(getMapName(c));
     bs.StorePackedBits(1,1);
 }
 
@@ -274,7 +272,6 @@ void Character::DumpBuildInfo()
             + getName()
             + "\n  " + getOrigin(c)
             + "\n  " + getClass(c)
-            + "\n  map: " + getMapName(c)
             + "\n  db_id: " + QString::number(m_db_id)
             + "\n  acct: " + QString::number(getAccountId())
             + "\n  lvl/clvl: " + QString::number(getLevel(c)) + "/" + QString::number(getCombatLevel(c))
@@ -483,7 +480,8 @@ void fromActualCostume(const Costume &src,GameAccountResponseCostumeData &tgt)
     }
 }
 
-bool toActualCharacter(const GameAccountResponseCharacterData &src, Character &tgt,PlayerData &player)
+bool toActualCharacter(const GameAccountResponseCharacterData &src,
+                       Character &tgt,PlayerData &player, EntityData &entity)
 {
     CharacterData &  cd(tgt.m_char_data);
 
@@ -495,6 +493,7 @@ bool toActualCharacter(const GameAccountResponseCharacterData &src, Character &t
     {
         serializeFromQString(cd,src.m_serialized_chardata);
         serializeFromQString(player,src.m_serialized_player_data);
+        serializeFromQString(entity, src.m_serialized_entity_data);
     }
     catch(cereal::RapidJSONException &e)
     {
@@ -518,7 +517,8 @@ bool toActualCharacter(const GameAccountResponseCharacterData &src, Character &t
     return true;
 }
 
-bool fromActualCharacter(const Character &src,const PlayerData &player, GameAccountResponseCharacterData &tgt)
+bool fromActualCharacter(const Character &src,const PlayerData &player,
+                         const EntityData &entity, GameAccountResponseCharacterData &tgt)
 {
     const CharacterData &  cd(src.m_char_data);
 
@@ -530,6 +530,7 @@ bool fromActualCharacter(const Character &src,const PlayerData &player, GameAcco
     {
         serializeToQString(cd, tgt.m_serialized_chardata);
         serializeToQString(player, tgt.m_serialized_player_data);
+        serializeToQString(entity, tgt.m_serialized_entity_data);
     }
     catch(cereal::RapidJSONException &e)
     {

--- a/Projects/CoX/Common/NetStructures/Character.h
+++ b/Projects/CoX/Common/NetStructures/Character.h
@@ -11,6 +11,7 @@
 #include "Powers.h"
 #include "Common/GameData/attrib_definitions.h"
 #include "Common/GameData/chardata_definitions.h"
+#include "Common/GameData/entitydata_definitions.h"
 #include "Common/GameData/clientoptions_definitions.h"
 #include "Common/GameData/gui_definitions.h"
 #include "Common/GameData/keybind_definitions.h"
@@ -63,8 +64,8 @@ class Character
         PowerTrayGroup          m_trays;
         uint64_t                m_owner_account_id;
         uint8_t                 m_player_collisions=0;
-        friend bool toActualCharacter(const struct GameAccountResponseCharacterData &src, Character &tgt,PlayerData &player);
-        friend bool fromActualCharacter(const Character &src,const PlayerData &player, GameAccountResponseCharacterData &tgt);
+        friend bool toActualCharacter(const struct GameAccountResponseCharacterData &src, Character &tgt,PlayerData &player, EntityData &entity);
+        friend bool fromActualCharacter(const Character &src,const PlayerData &player, const EntityData &entity, GameAccountResponseCharacterData &tgt);
 public:
                         Character();
 //////////////////////////////////////////////////////////////////////////
@@ -132,5 +133,5 @@ protected:
 
 void serializeStats(const Character &src, BitStream &bs, bool sendAbsolute);
 bool initializeCharacterFromCreator();
-bool toActualCharacter(const GameAccountResponseCharacterData &src, Character &tgt, PlayerData &player);
-bool fromActualCharacter(const Character &src, const PlayerData &player, GameAccountResponseCharacterData &tgt);
+bool toActualCharacter(const GameAccountResponseCharacterData &src, Character &tgt, PlayerData &player, EntityData &entity);
+bool fromActualCharacter(const Character &src, const PlayerData &player, const EntityData &entity, GameAccountResponseCharacterData &tgt);

--- a/Projects/CoX/Common/NetStructures/Character.h
+++ b/Projects/CoX/Common/NetStructures/Character.h
@@ -85,7 +85,7 @@ const   QString &       getName() const { return m_name; }
         void            serializefrom(BitStream &buffer);
         void            serializeto(BitStream &buffer) const;
         void            serialize_costumes(BitStream &buffer, const ColorAndPartPacker *packer, bool all_costumes=true) const;
-        void            serializetoCharsel(BitStream &bs);
+        void            serializetoCharsel(BitStream &bs, const QString& m_current_map);
         void            GetCharBuildInfo(BitStream &src); // serialize from char creation
         void            SendCharBuildInfo(BitStream &bs) const;
         void            recv_initial_costume(BitStream &src, const ColorAndPartPacker *packer);

--- a/Projects/CoX/Common/NetStructures/Character.h
+++ b/Projects/CoX/Common/NetStructures/Character.h
@@ -85,7 +85,7 @@ const   QString &       getName() const { return m_name; }
         void            serializefrom(BitStream &buffer);
         void            serializeto(BitStream &buffer) const;
         void            serialize_costumes(BitStream &buffer, const ColorAndPartPacker *packer, bool all_costumes=true) const;
-        void            serializetoCharsel(BitStream &bs, const QString& m_current_map);
+        void            serializetoCharsel(BitStream &bs, const QString& entity_map_name);
         void            GetCharBuildInfo(BitStream &src); // serialize from char creation
         void            SendCharBuildInfo(BitStream &bs) const;
         void            recv_initial_costume(BitStream &src, const ColorAndPartPacker *packer);

--- a/Projects/CoX/Common/NetStructures/Entity.cpp
+++ b/Projects/CoX/Common/NetStructures/Entity.cpp
@@ -165,7 +165,6 @@ void initializeNewPlayerEntity(Entity &e)
     e.m_player.reset(new PlayerData);
     e.m_player->reset();
     e.m_entity.reset(new EntityData);
-    e.m_entity->reset();
     e.might_have_rare = e.m_rare_bits   = true;
 }
 

--- a/Projects/CoX/Common/NetStructures/Entity.cpp
+++ b/Projects/CoX/Common/NetStructures/Entity.cpp
@@ -164,6 +164,8 @@ void initializeNewPlayerEntity(Entity &e)
     e.m_char.reset(new Character);
     e.m_player.reset(new PlayerData);
     e.m_player->reset();
+    e.m_entity.reset(new EntityData);
+    e.m_entity->reset();
     e.might_have_rare = e.m_rare_bits   = true;
 }
 
@@ -187,6 +189,7 @@ void initializeNewNpcEntity(Entity &e,const Parse_NPC *src,int idx,int variant)
     e.m_char.reset(new Character);
     e.m_npc.reset(new NPCData{false,src,idx,variant});
     e.m_player.reset();
+    e.m_entity.reset(new EntityData);
     e.might_have_rare = e.m_rare_bits   = true;
 }
 

--- a/Projects/CoX/Common/NetStructures/Entity.h
+++ b/Projects/CoX/Common/NetStructures/Entity.h
@@ -147,6 +147,7 @@ class Entity
     friend std::array<Entity,10240>;
     using CharacterPtr = std::unique_ptr<Character>;
     using PlayerPtr = std::unique_ptr<PlayerData>;
+    using EntityPtr = std::unique_ptr<EntityData>;
     using NPCPtr = std::unique_ptr<NPCData>;
 private:
                             Entity();
@@ -164,6 +165,7 @@ public:
         CharacterPtr        m_char;
         // And not all entities are players
         PlayerPtr           m_player;
+        EntityPtr           m_entity;
         NPCPtr              m_npc;
 
         int                 m_full_update_count     = 10; // TODO: remove this after we have proper physics

--- a/Projects/CoX/Common/NetStructures/Friend.cpp
+++ b/Projects/CoX/Common/NetStructures/Friend.cpp
@@ -44,7 +44,7 @@ void addFriend(Entity &src, Entity &tgt)
     f.m_class_idx       = tgt.m_entity_data.m_class_idx;
     f.m_origin_idx      = tgt.m_entity_data.m_origin_idx;
     f.m_map_idx         = tgt.m_entity_data.m_map_idx;
-    f.m_mapname         = tgt.m_entity_data.m_current_map;
+    f.m_mapname         = getEntityMapName(tgt.m_entity_data);
 
     // add to friendlist
     src_data->m_friends.emplace_back(f);

--- a/Projects/CoX/Common/NetStructures/Friend.cpp
+++ b/Projects/CoX/Common/NetStructures/Friend.cpp
@@ -44,7 +44,7 @@ void addFriend(Entity &src, Entity &tgt)
     f.m_class_idx       = tgt.m_entity_data.m_class_idx;
     f.m_origin_idx      = tgt.m_entity_data.m_origin_idx;
     f.m_map_idx         = tgt.m_entity_data.m_map_idx;
-    f.m_mapname         = tgt.m_char->m_char_data.m_mapName;
+    f.m_mapname         = tgt.m_entity_data.m_current_map;
 
     // add to friendlist
     src_data->m_friends.emplace_back(f);

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -255,6 +255,7 @@ bool GameDbSyncContext::getAccount(const GameAccountRequestData &data,GameAccoun
         character.m_name =  name.isEmpty() ? "EMPTY" : name;
         character.m_serialized_chardata = m_prepared_char_select->value("chardata").toString();
         character.m_serialized_player_data = m_prepared_char_select->value("player_data").toString();
+        character.m_serialized_entity_data = m_prepared_char_select->value("entitydata").toString();
 
         GameAccountResponseCostumeData costume;
         // appearance related.

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncEvents.h
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncEvents.h
@@ -137,6 +137,7 @@ struct GameAccountResponseCharacterData
     QString m_name;
     QString m_serialized_chardata;
     QString m_serialized_player_data;
+    QString m_serialized_entity_data;
 
     uint32_t m_db_id;
     uint32_t m_account_id;

--- a/Projects/CoX/Servers/GameServer/GameEvents.cpp
+++ b/Projects/CoX/Servers/GameServer/GameEvents.cpp
@@ -87,7 +87,7 @@ void CharacterSlots::serializeto( BitStream &tgt ) const
         PlayerData player_data;
         EntityData entity_data;
         toActualCharacter(m_data->m_characters[i],converted,player_data, entity_data);
-        converted.serializetoCharsel(tgt);
+        converted.serializetoCharsel(tgt, entity_data.getMapName());
     }
     //tgt.StoreBitArray(m_clientinfo,128);
 }

--- a/Projects/CoX/Servers/GameServer/GameEvents.cpp
+++ b/Projects/CoX/Servers/GameServer/GameEvents.cpp
@@ -15,6 +15,7 @@
 #include "NetStructures/Costume.h"
 #include "GameDatabase/GameDBSyncEvents.h"
 #include "GameData/playerdata_definitions.h"
+#include "MapServer/DataHelpers.h"
 
 #include <QtCore/QDebug>
 
@@ -87,7 +88,7 @@ void CharacterSlots::serializeto( BitStream &tgt ) const
         PlayerData player_data;
         EntityData entity_data;
         toActualCharacter(m_data->m_characters[i],converted,player_data, entity_data);
-        converted.serializetoCharsel(tgt, entity_data.getMapName());
+        converted.serializetoCharsel(tgt, getEntityMapName(entity_data));
     }
     //tgt.StoreBitArray(m_clientinfo,128);
 }

--- a/Projects/CoX/Servers/GameServer/GameEvents.cpp
+++ b/Projects/CoX/Servers/GameServer/GameEvents.cpp
@@ -85,7 +85,8 @@ void CharacterSlots::serializeto( BitStream &tgt ) const
     {
         Character converted;
         PlayerData player_data;
-        toActualCharacter(m_data->m_characters[i],converted,player_data);
+        EntityData entity_data;
+        toActualCharacter(m_data->m_characters[i],converted,player_data, entity_data);
         converted.serializetoCharsel(tgt);
     }
     //tgt.StoreBitArray(m_clientinfo,128);
@@ -112,7 +113,8 @@ void CharacterResponse::serializeto( BitStream &bs ) const
     GameAccountResponseCharacterData indexed_character(m_data->get_character(m_index));
     Character converted;
     PlayerData player_data;
-    toActualCharacter(indexed_character,converted,player_data);
+    EntityData entity_data;
+    toActualCharacter(indexed_character,converted,player_data, entity_data);
     bs.StorePackedBits(1,6); // opcode
 
     if(indexed_character.m_name.compare("EMPTY")!=0)// actual character was read from db

--- a/Projects/CoX/Servers/GameServer/GameHandler.cpp
+++ b/Projects/CoX/Servers/GameServer/GameHandler.cpp
@@ -368,13 +368,7 @@ void GameHandler::on_map_req(MapServerAddrRequest *ev)
     QString map_path = ed.m_current_map;
 
     if (!map_path.isEmpty())
-    {
-        switch(checkMap(map_path))
-        {
-            case Outbreak: map_path = "maps/city_zones/city_00_01/city_00_01.txt"; break;
-            case AtlasPark: map_path = "maps/city_zones/city_01_01/city_01_01.txt"; break;
-        }
-    }
+        map_path = getMapPath(ed);
     else
     {
         switch(ev->m_mapnumber)
@@ -465,16 +459,4 @@ void GameHandler::reap_stale_links()
                                          tgt->putq(new ClientDisconnectedMessage({tok}));
                                      });
 }
-
-MapName GameHandler::checkMap(const QString& map_path)
-{
-    if (map_path.contains("City_00_01", Qt::CaseInsensitive))
-        return Outbreak;
-    if (map_path.contains("City_01_01", Qt::CaseInsensitive))
-        return AtlasPark;
-
-    // let's default to Outbreak in case things go wrong
-    return Outbreak;
-}
-
 //! @}

--- a/Projects/CoX/Servers/GameServer/GameHandler.cpp
+++ b/Projects/CoX/Servers/GameServer/GameHandler.cpp
@@ -350,10 +350,10 @@ void GameHandler::on_map_req(MapServerAddrRequest *ev)
         return; // TODO:  return some kind of error.
 
     GameAccountResponseCharacterData *selected_slot = &session.m_game_account.get_character(ev->m_character_index);
-    CharacterData cd;
+    /*EntityData ed;
     try
     {
-        serializeFromQString(cd,selected_slot->m_serialized_chardata);
+        serializeFromQString(ed,selected_slot->m_serialized_entity_data);
     }
     catch(cereal::RapidJSONException &e)
     {
@@ -364,7 +364,7 @@ void GameHandler::on_map_req(MapServerAddrRequest *ev)
         qCritical() << e.what();
     }
 
-    QString map_path = cd.m_mapName;
+    QString map_path = ed.m_current_map;
 
     if (!map_path.isEmpty())
     {
@@ -413,7 +413,7 @@ void GameHandler::on_map_req(MapServerAddrRequest *ev)
     qInfo("Telling map server to expect a client with character %s, %d\n", qPrintable(ev->m_char_name),
             ev->m_character_index);
     session.m_direction = GameSession::EXITING_TO_MAP;
-    map_handler->putq(expect_client);
+    map_handler->putq(expect_client);*/
 }
 
 void GameHandler::on_unknown_link_event(GameUnknownRequest *)

--- a/Projects/CoX/Servers/GameServer/GameHandler.cpp
+++ b/Projects/CoX/Servers/GameServer/GameHandler.cpp
@@ -18,6 +18,7 @@
 #include "GameData/chardata_serializers.h"
 #include "Common/Servers/InternalEvents.h"
 #include "GameData/serialization_common.h"
+#include "GameData/entitydata_serializers.h"
 #include "GameLink.h"
 #include "GameServer.h"
 #include "NetStructures/Character.h"
@@ -350,7 +351,7 @@ void GameHandler::on_map_req(MapServerAddrRequest *ev)
         return; // TODO:  return some kind of error.
 
     GameAccountResponseCharacterData *selected_slot = &session.m_game_account.get_character(ev->m_character_index);
-    /*EntityData ed;
+    EntityData ed;
     try
     {
         serializeFromQString(ed,selected_slot->m_serialized_entity_data);
@@ -413,7 +414,7 @@ void GameHandler::on_map_req(MapServerAddrRequest *ev)
     qInfo("Telling map server to expect a client with character %s, %d\n", qPrintable(ev->m_char_name),
             ev->m_character_index);
     session.m_direction = GameSession::EXITING_TO_MAP;
-    map_handler->putq(expect_client);*/
+    map_handler->putq(expect_client);
 }
 
 void GameHandler::on_unknown_link_event(GameUnknownRequest *)

--- a/Projects/CoX/Servers/GameServer/GameHandler.h
+++ b/Projects/CoX/Servers/GameServer/GameHandler.h
@@ -17,12 +17,6 @@ class CharacterClient;
 class GameServer;
 class SEGSTimer;
 
-enum MapName
-{
-    Outbreak,
-    AtlasPark
-};
-
 struct GameSession
 {
     enum eTravelDirection
@@ -100,7 +94,6 @@ protected:
         void        on_game_db_error(GameDbErrorMessage *ev);
         void        on_account_data(GameAccountResponse *ev);
         void        on_character_deleted(RemoveCharacterResponse *ev);
-        MapName     checkMap(const QString& map_path);
     //////////////////////////////////////////////////////////////////////////
         sIds        waiting_for_client; // this hash_set holds all client cookies we wait for
         GameServer *m_server;

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -328,9 +328,9 @@ const QString &     getAlignment(const Character &c) { return c.m_char_data.m_al
 
 static const std::vector<MapData> g_defined_map_datas =
 {
-    {0, "City_00_01", "maps/city_zones/city_00_01/city_00_01.txt", "Outbreak", {0, 0, 0}},
-    {1, "City_01_01", "maps/city_zones/city_01_01/city_01_01.txt", "Atlas Park", {0, 0, 0}},
-    {23, "City_23_01", "maps/city_zones/city_23_01/city_23_01.txt", "Galaxy City", {0, 0, 0}}
+    {0, "City_00_01", "maps/city_zones/city_00_01/city_00_01.txt", "Outbreak"},
+    {1, "City_01_01", "maps/city_zones/city_01_01/city_01_01.txt", "Atlas Park"},
+    {23, "City_23_01", "maps/city_zones/city_23_01/city_23_01.txt", "Galaxy City"}
 };
 
 const QString getMapName(const QString &map_name)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -329,8 +329,8 @@ const QString &     getAlignment(const Character &c) { return c.m_char_data.m_al
 static const std::vector<MapData> g_defined_map_datas =
 {
     {0, "City_00_01", "maps/city_zones/city_00_01/city_00_01.txt", "Outbreak", {0, 0, 0}},
-    {1, "City_01_01", "maps/city_zones/city_00_01/city_01_01.txt", "Atlas Park", {0, 0, 0}},
-    {2, "City_23_01", "maps/city_zones/city_00_01/city_23_01.txt", "Galaxy City", {0, 0, 0}}
+    {1, "City_01_01", "maps/city_zones/city_01_01/city_01_01.txt", "Atlas Park", {0, 0, 0}},
+    {23, "City_23_01", "maps/city_zones/city_23_01/city_23_01.txt", "Galaxy City", {0, 0, 0}}
 };
 
 const QString getMapName(const QString &map_name)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -315,7 +315,6 @@ float               getEnd(const Character &c) { return c.m_char_data.m_current_
 uint64_t            getLastCostumeId(const Character &c) { return c.m_char_data.m_last_costume_id; }
 const QString &     getOrigin(const Character &c) { return c.m_char_data.m_origin_name; }
 const QString &     getClass(const Character &c) { return c.m_char_data.m_class_name; }
-const QString &     getMapName(const Entity &e) { return e.m_entity_data.m_current_map; }
 uint32_t            getXP(const Character &c) { return c.m_char_data.m_experience_points; }
 uint32_t            getDebt(const Character &c) { return c.m_char_data.m_experience_debt; }
 uint32_t            getPatrolXP(const Character &c) { return c.m_char_data.m_experience_patrol; }
@@ -326,6 +325,42 @@ uint32_t            getInf(const Character &c) { return c.m_char_data.m_influenc
 const QString &     getDescription(const Character &c) { return c.m_char_data.m_character_description ; }
 const QString &     getBattleCry(const Character &c) { return c.m_char_data.m_battle_cry; }
 const QString &     getAlignment(const Character &c) { return c.m_char_data.m_alignment; }
+
+const QString getMapName(const QString &map_name)
+{
+    if (map_name.contains("City_00_01", Qt::CaseInsensitive))
+        return "Outbreak";
+    if (map_name.contains("City_01_01", Qt::CaseInsensitive))
+        return "AtlasPark";
+
+    // let's default to Outbreak in case things go wrong
+    return "Outbreak";
+}
+
+const QString getEntityMapName(const EntityData &ed)
+{
+    return getMapName(ed.m_current_map);
+}
+
+const QString getFriendMapName(const Friend &f)
+{
+    if (!f.m_online_status)
+        return "OFFLINE";
+    return getMapName(f.m_mapname);
+}
+
+const QString getMapPath(const EntityData &ed)
+{
+    // Outbreak
+    if (ed.m_current_map.contains("City_00_01", Qt::CaseInsensitive))
+        return "maps/city_zones/city_00_01/city_00_01.txt";
+    // Atlas Park
+    if (ed.m_current_map.contains("City_01_01", Qt::CaseInsensitive))
+        return "maps/city_zones/city_01_01/city_01_01.txt";
+
+    // let's default to Outbreak in case things go wrong
+    return "maps/city_zones/city_00_01/city_00_01.txt";
+}
 
 // Setters
 void setLevel(Character &c, uint32_t val)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -315,7 +315,7 @@ float               getEnd(const Character &c) { return c.m_char_data.m_current_
 uint64_t            getLastCostumeId(const Character &c) { return c.m_char_data.m_last_costume_id; }
 const QString &     getOrigin(const Character &c) { return c.m_char_data.m_origin_name; }
 const QString &     getClass(const Character &c) { return c.m_char_data.m_class_name; }
-const QString &     getMapName(const Character &c) { return c.m_char_data.m_mapName; }
+const QString &     getMapName(const Entity &e) { return e.m_entity_data.m_current_map; }
 uint32_t            getXP(const Character &c) { return c.m_char_data.m_experience_points; }
 uint32_t            getDebt(const Character &c) { return c.m_char_data.m_experience_debt; }
 uint32_t            getPatrolXP(const Character &c) { return c.m_char_data.m_experience_patrol; }
@@ -356,7 +356,7 @@ void setEnd(Character &c, float val)
 }
 
 void    setLastCostumeId(Character &c, uint64_t val) { c.m_char_data.m_last_costume_id = val; }
-void    setMapName(Character &c, const QString &val) { c.m_char_data.m_mapName = val; }
+void    setMapName(Entity &e, const QString &val) { e.m_entity_data.m_current_map = val; }
 
 void setXP(Character &c, uint32_t val)
 {

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -335,13 +335,17 @@ static const std::vector<MapData> g_defined_map_datas =
 
 const QString getMapName(const QString &map_name)
 {
-    for (uint32_t i = 0; i < g_defined_map_datas.size(); i++)
+    for (const auto &map_data : g_defined_map_datas)
     {
-        if (map_name.contains(g_defined_map_datas[i].m_map_name))
-            return g_defined_map_datas[i].m_display_map_name;
+        if (map_name.contains(map_data.m_map_name))
+            return map_data.m_map_name;
     }
 
-    // defaulting to Outbreak's map name if things went wrong
+    // log a warning because this part of the code is called when things went wrong
+    qWarning() << "No matching map name in struct g_defined_map_datas to sent map name."
+        << " Returning Outbreak's display map name as default...";
+
+    // defaulting to Outbreak's map name
     return g_defined_map_datas[0].m_display_map_name;
 }
 
@@ -359,13 +363,17 @@ const QString getFriendMapName(const Friend &f)
 
 const QString getMapPath(const EntityData &ed)
 {
-    for (uint32_t i = 0; i < g_defined_map_datas.size(); i++)
+    for (const auto &map_data : g_defined_map_datas)
     {
-        if (ed.m_current_map.contains(g_defined_map_datas[i].m_map_name))
-            return g_defined_map_datas[i].m_map_path;
+        if (ed.m_current_map.contains(map_data.m_map_name))
+            return map_data.m_map_path;
     }
 
-    // defaulting to Outbreak's map path if things went wrong
+    // log a warning because this part of the code is called when things went wrong
+    qWarning() << "No matching map name in struct g_defined_map_datas to EntityData's m_map_name."
+        << " Returning Outbreak's map path as default...";
+
+    // defaulting to Outbreak's map path
     return g_defined_map_datas[0].m_map_path;
 }
 

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -326,15 +326,30 @@ const QString &     getDescription(const Character &c) { return c.m_char_data.m_
 const QString &     getBattleCry(const Character &c) { return c.m_char_data.m_battle_cry; }
 const QString &     getAlignment(const Character &c) { return c.m_char_data.m_alignment; }
 
-const QString getMapName(const QString &map_name)
+MapData getMapData(const QString &map_name)
 {
     if (map_name.contains("City_00_01", Qt::CaseInsensitive))
-        return "Outbreak";
+        return Outbreak;
     if (map_name.contains("City_01_01", Qt::CaseInsensitive))
-        return "AtlasPark";
+        return AtlasPark;
+    if (map_name.contains("City_23_01", Qt::CaseInsensitive))
+        return GalaxyCity;
 
     // let's default to Outbreak in case things go wrong
-    return "Outbreak";
+    return Outbreak;
+}
+
+const QString getMapName(const QString &map_name)
+{
+    switch (getMapData(map_name))
+    {
+        case Outbreak: return "Outbreak";
+        case AtlasPark: return "Atlas Park";
+        case GalaxyCity: return "Galaxy City";
+
+        // default to Outbreak if something weird happens
+        default: return "Outbreak";
+    }
 }
 
 const QString getEntityMapName(const EntityData &ed)
@@ -351,15 +366,15 @@ const QString getFriendMapName(const Friend &f)
 
 const QString getMapPath(const EntityData &ed)
 {
-    // Outbreak
-    if (ed.m_current_map.contains("City_00_01", Qt::CaseInsensitive))
-        return "maps/city_zones/city_00_01/city_00_01.txt";
-    // Atlas Park
-    if (ed.m_current_map.contains("City_01_01", Qt::CaseInsensitive))
-        return "maps/city_zones/city_01_01/city_01_01.txt";
+    switch (getMapData(ed.m_current_map))
+    {
+        case Outbreak: return "maps/city_zones/city_00_01/city_00_01.txt";
+        case AtlasPark: return "maps/city_zones/city_01_01/city_01_01.txt";
+        case GalaxyCity: return "maps/city_zones/city_23_01/city_23_01.txt";
 
-    // let's default to Outbreak in case things go wrong
-    return "maps/city_zones/city_00_01/city_00_01.txt";
+        // default to Outbreak's map path if something weird happens
+        default: return "maps/city_zones/city_00_01/city_00_01.txt";
+    }
 }
 
 // Setters

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -326,30 +326,23 @@ const QString &     getDescription(const Character &c) { return c.m_char_data.m_
 const QString &     getBattleCry(const Character &c) { return c.m_char_data.m_battle_cry; }
 const QString &     getAlignment(const Character &c) { return c.m_char_data.m_alignment; }
 
-MapData getMapData(const QString &map_name)
+static const std::vector<MapData> g_defined_map_datas =
 {
-    if (map_name.contains("City_00_01", Qt::CaseInsensitive))
-        return Outbreak;
-    if (map_name.contains("City_01_01", Qt::CaseInsensitive))
-        return AtlasPark;
-    if (map_name.contains("City_23_01", Qt::CaseInsensitive))
-        return GalaxyCity;
-
-    // let's default to Outbreak in case things go wrong
-    return Outbreak;
-}
+    {0, "City_00_01", "maps/city_zones/city_00_01/city_00_01.txt", "Outbreak", {0, 0, 0}},
+    {1, "City_01_01", "maps/city_zones/city_00_01/city_01_01.txt", "Atlas Park", {0, 0, 0}},
+    {2, "City_23_01", "maps/city_zones/city_00_01/city_23_01.txt", "Galaxy City", {0, 0, 0}}
+};
 
 const QString getMapName(const QString &map_name)
 {
-    switch (getMapData(map_name))
+    for (uint32_t i = 0; i < g_defined_map_datas.size(); i++)
     {
-        case Outbreak: return "Outbreak";
-        case AtlasPark: return "Atlas Park";
-        case GalaxyCity: return "Galaxy City";
-
-        // default to Outbreak if something weird happens
-        default: return "Outbreak";
+        if (map_name.contains(g_defined_map_datas[i].m_map_name))
+            return g_defined_map_datas[i].m_display_map_name;
     }
+
+    // defaulting to Outbreak's map name if things went wrong
+    return g_defined_map_datas[0].m_display_map_name;
 }
 
 const QString getEntityMapName(const EntityData &ed)
@@ -366,15 +359,14 @@ const QString getFriendMapName(const Friend &f)
 
 const QString getMapPath(const EntityData &ed)
 {
-    switch (getMapData(ed.m_current_map))
+    for (uint32_t i = 0; i < g_defined_map_datas.size(); i++)
     {
-        case Outbreak: return "maps/city_zones/city_00_01/city_00_01.txt";
-        case AtlasPark: return "maps/city_zones/city_01_01/city_01_01.txt";
-        case GalaxyCity: return "maps/city_zones/city_23_01/city_23_01.txt";
-
-        // default to Outbreak's map path if something weird happens
-        default: return "maps/city_zones/city_00_01/city_00_01.txt";
+        if (ed.m_current_map.contains(g_defined_map_datas[i].m_map_name))
+            return g_defined_map_datas[i].m_map_path;
     }
+
+    // defaulting to Outbreak's map path if things went wrong
+    return g_defined_map_datas[0].m_map_path;
 }
 
 // Setters

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -338,7 +338,7 @@ const QString getMapName(const QString &map_name)
     for (const auto &map_data : g_defined_map_datas)
     {
         if (map_name.contains(map_data.m_map_name))
-            return map_data.m_map_name;
+            return map_data.m_display_map_name;
     }
 
     // log a warning because this part of the code is called when things went wrong

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -20,6 +20,11 @@ struct Friend;
 struct FriendsList;
 struct MapClientSession;
 
+enum MapData
+{
+    Outbreak, AtlasPark, GalaxyCity
+};
+
 /*
  * Entity Methods
  */
@@ -83,6 +88,7 @@ float getEnd(const Character &c);
 uint64_t            getLastCostumeId(const Character &c);
 const QString &     getOrigin(const Character &c);
 const QString &     getClass(const Character &c);
+MapData             getMapData(const QString &map_name);
 const QString       getMapName(const QString &map_name);
 const QString       getMapPath(const EntityData &ed);
 const QString       getEntityMapName(const EntityData &ed);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -14,7 +14,9 @@ class QString;
 class Entity;
 class Character;
 struct PlayerData;
+struct EntityData;
 
+struct Friend;
 struct FriendsList;
 struct MapClientSession;
 
@@ -81,7 +83,10 @@ float getEnd(const Character &c);
 uint64_t            getLastCostumeId(const Character &c);
 const QString &     getOrigin(const Character &c);
 const QString &     getClass(const Character &c);
-const QString &     getMapName(const Character &c);
+const QString       getMapName(const QString &map_name);
+const QString       getMapPath(const EntityData &ed);
+const QString       getEntityMapName(const EntityData &ed);
+const QString       getFriendMapName(const Friend &f);
 uint32_t            getXP(const Character &c);
 uint32_t            getDebt(const Character &c);
 uint32_t            getPatrolXP(const Character &c);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -100,7 +100,7 @@ void    setCombatLevel(Character &c, uint32_t val);
 void    setHP(Character &c, float val);
 void    setEnd(Character &c, float val);
 void    setLastCostumeId(Character &c, uint64_t val);
-void    setMapName(Character &c, const QString &val);
+void    setMapName(Entity &e, const QString &val);
 void    setXP(Character &c, uint32_t val);
 void    setDebt(Character &c, uint32_t val);
 void    setTitles(Character &c, bool prefix = false, QString generic = "", QString origin = "", QString special = "");

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -20,9 +20,13 @@ struct Friend;
 struct FriendsList;
 struct MapClientSession;
 
-enum MapData
+struct MapData
 {
-    Outbreak, AtlasPark, GalaxyCity
+    uint32_t m_map_idx;
+    QString m_map_name;             // City_00_01, City_01_01, etc...
+    QString m_map_path;             // The ones ending with .txt
+    QString m_display_map_name;     // Outbreak, Atlas Park...
+    glm::vec3 m_spawn_location;
 };
 
 /*

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -26,7 +26,6 @@ struct MapData
     QString m_map_name;             // City_00_01, City_01_01, etc...
     QString m_map_path;             // The ones ending with .txt
     QString m_display_map_name;     // Outbreak, Atlas Park...
-    glm::vec3 m_spawn_location;
 };
 
 /*

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -554,7 +554,7 @@ void MapInstance::on_expect_client( ExpectMapClientRequest *ev )
 
     // existing character
     Entity *ent = m_entities.CreatePlayer();
-    toActualCharacter(*request_data.char_from_db, *ent->m_char,*ent->m_player);
+    toActualCharacter(*request_data.char_from_db, *ent->m_char,*ent->m_player, *ent->m_entity);
     ent->fillFromCharacter();
     ent->m_client = &map_session;
     map_session.m_ent = ent;
@@ -610,7 +610,7 @@ void MapInstance::on_entity_response(GetEntityResponse *ev)
     tgt->putq(new ClientConnectedMessage({ev->session_token(),m_owner_id,m_instance_id}));
 
     map_session.m_current_map->enqueue_client(&map_session);
-    setMapName(*map_session.m_ent->m_char, name());
+    setMapName(*map_session.m_ent, name());
     setMapIdx(*map_session.m_ent, index());
     map_session.link()->putq(new MapInstanceConnected(this, 1, ""));
 }
@@ -646,7 +646,7 @@ void MapInstance::on_create_map_entity(NewEntity *ev)
         // new characters are transmitted nameless, use the name provided in on_expect_client
         e->m_char->setName(map_session.m_name);
         GameAccountResponseCharacterData char_data;
-        fromActualCharacter(*e->m_char,*e->m_player,char_data);
+        fromActualCharacter(*e->m_char,*e->m_player, *e->m_entity, char_data);
         serializeToDb(e->m_entity_data,ent_data);
         // create the character from the data.
         //fillGameAccountData(map_session.m_client_id, map_session.m_game_account);

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -453,7 +453,7 @@ void cmdHandler_DebugChar(const QString &/*cmd*/, MapClientSession &sess)
     QString msg = "DebugChar: " + sess.m_ent->name()
             + "\n  " + chardata.m_char_data.m_origin_name
             + "\n  " + chardata.m_char_data.m_class_name
-            + "\n  map: " + chardata.m_char_data.m_mapName
+            + "\n  map: " + sess.m_ent->m_entity_data.m_current_map
             + "\n  db_id: " + QString::number(sess.m_ent->m_db_id) + ":" + QString::number(chardata.m_db_id)
             + "\n  idx: " + QString::number(sess.m_ent->m_idx)
             + "\n  access: " + QString::number(sess.m_ent->m_entity_data.m_access_level)

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -453,7 +453,7 @@ void cmdHandler_DebugChar(const QString &/*cmd*/, MapClientSession &sess)
     QString msg = "DebugChar: " + sess.m_ent->name()
             + "\n  " + chardata.m_char_data.m_origin_name
             + "\n  " + chardata.m_char_data.m_class_name
-            + "\n  map: " + sess.m_ent->m_entity_data.m_current_map
+            + "\n  map: " + getEntityMapName(sess.m_ent->m_entity_data)
             + "\n  db_id: " + QString::number(sess.m_ent->m_db_id) + ":" + QString::number(chardata.m_db_id)
             + "\n  idx: " + QString::number(sess.m_ent->m_idx)
             + "\n  access: " + QString::number(sess.m_ent->m_entity_data.m_access_level)


### PR DESCRIPTION
I didn't expect to make so many changes... To summarize, this is about removing m_mapName from CharData and creating m_current_map in EntityData. I might be making too much changes at one go here.

This is compilable but untested, I will be awaiting your inputs before going in further.
- Updated serializers for CharData and EntityData
- Incremented class versions for affected structs
- Character::from/toActualCharacter now takes in EntityData as parameter, where it is going to be serialized to/from QString
- Character::reset and getCurrentCostume no longer deals with map names
- Created uniquePtr for EntityData in Entity
- GameAccountResponseCharacterData now has m_serialized_entity_data, which will be used by GameHandler
- GameHandler::on_map_req now gets the map name from EntityData.m_current_map
- DataHelpers::getMapName and setMapName now takes in Entity as parameter

Some things to do off the top of my head:

- Test da ting (I feel a little scared to test this now tbh, with all the changes made :P)
- Fill up EntityData::reset and dump functions with something
- DataHelpers::getMapName is now unused, call it from somewhere else

Closes #302 .