### PR TITLE
Added missing "libwinpthread-1.dll" library to MINGW build.

### DIFF
--- a/CMakeScripts/Windeployqt.cmake
+++ b/CMakeScripts/Windeployqt.cmake
@@ -91,7 +91,7 @@ function(windeployqt target directory)
     if( MINGW )
         message( STATUS "    Installing system-libraries: MinGW DLLs." )
         get_filename_component( Mingw_Path ${CMAKE_CXX_COMPILER} PATH )
-        set( CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS ${Mingw_Path}/libgcc_s_dw2-1.dll ${Mingw_Path}/libstdc++-6.dll )
+        set( CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS ${Mingw_Path}/libgcc_s_dw2-1.dll ${Mingw_Path}/libstdc++-6.dll ${Mingw_Path}/libwinpthread-1.dll )
     endif( MINGW )
     # windeployqt doesn't work correctly with the system runtime libraries,
     # so we fall back to one of CMake's own modules for copying them over


### PR DESCRIPTION
This change makes it possible to run the executables in the "out" directory without using QtCreator.

Closes nothing as I have not opened any issue for this.
If you want me to create an issue first, then I will do so.

Additions/modifications proposed in this pull request:
- When I tried to run any built executable in my Win8/MINGW development environment it failed with an error message telling me that it could not find the "libwinpthread-1.dll" library. Running from QtCreator works fine though. This change adds the missing library to the "out" directory, just as the other MINGW specific files are.
