### PR TITLE
Fixed a crash in "addNpc" slash command when executing it without any parameters.

### DIFF
--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -732,6 +732,7 @@ void addNpc(const QString &cmd, MapClientSession &sess)
     {
         qCDebug(logSlashCommand) << "Bad invocation:"<<cmd;
         sendInfoMessage(MessageChannel::USER_ERROR, "Bad invocation:"+cmd, &sess);
+        return;
     }
     glm::vec3 gm_loc = sess.m_ent->m_entity_data.m_pos;
     const NPCStorage & npc_store(sess.m_current_map->serverData().getNPCDefinitions());


### PR DESCRIPTION
Closes nothing as I have not opened any issue for this.
If you want me to, then I will do so.

Additions/modifications proposed in this pull request:
- Fixed a crash in "addNpc" slash command when executing it without any parameters. There was a missing "return" statement after a sanity check.
