### PR TITLE
Added DefaultMapInstances to the cmake structure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,4 +91,7 @@ add_subdirectory(Components)
 add_subdirectory(Utilities)
 add_subdirectory(Projects)
 file(MAKE_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}/data)
+file(MAKE_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}/DefaultMapInstances/City_00_01)
+file(MAKE_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}/DefaultMapInstances/City_01_01)
+file(MAKE_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}/DefaultMapInstances/City_02_01)
 

--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -132,6 +132,7 @@ void Settings::setDefaultSettings()
     config.beginGroup("MapServer");
         config.setValue("listen_addr","127.0.0.1:7003");
         config.setValue("location_addr","127.0.0.1:7003");
+        config.setValue("maps","DefaultMapInstances");
         config.setValue("player_fade_in", "380.0");
     config.endGroup();
     config.beginGroup("Logging");

--- a/Projects/CoX/CMakeLists.txt
+++ b/Projects/CoX/CMakeLists.txt
@@ -13,10 +13,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Data/scripts/motd.smlx DESTINATION ${EXECU
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Data/scripts/test.smlx DESTINATION ${EXECUTABLE_OUTPUT_PATH}/scripts)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Data/scripts/tutorial.smlx DESTINATION ${EXECUTABLE_OUTPUT_PATH}/scripts)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Data/settings.cfg ${EXECUTABLE_OUTPUT_PATH}/default_dbs/settings.cfg COPYONLY)
-if(NOT EXISTS ${EXECUTABLE_OUTPUT_PATH}/settings.cfg)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Data/settings.cfg ${EXECUTABLE_OUTPUT_PATH}/settings.cfg COPYONLY)
-endif()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Data/settings_template.cfg ${EXECUTABLE_OUTPUT_PATH}/settings_template.cfg COPYONLY)
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Data/mysql DESTINATION ${EXECUTABLE_OUTPUT_PATH}/default_dbs)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Data/pgsql DESTINATION ${EXECUTABLE_OUTPUT_PATH}/default_dbs)

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -49,7 +49,7 @@ max_character_slots = 8
 [MapServer]  
 listen_addr         = 127.0.0.1:7003
 location_addr       = 127.0.0.1:7003
-maps                = MapInstances
+maps                = DefaultMapInstances
 player_fade_in      = 380.0
 
 [Logging]

--- a/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
@@ -93,7 +93,7 @@ void SettingsDialog::read_config_file(QString filePath)
     QStringList map_listen_addr_portip = map_listen_addr.split(':');
     QString map_loc_addr = config_file.value("location_addr","").toString();
     QStringList map_loc_addr_portip = map_loc_addr.split(':');
-    QString maps_loc = config_file.value("maps","").toString();
+    QString maps_loc = config_file.value("maps","DefaultMapInstances").toString();
     QString player_fade_in = config_file.value("player_fade_in", "").toString();
     ui->map_listen_ip->setText(map_listen_addr_portip[0]);
     ui->map_listen_port->setText(map_listen_addr_portip[1]);
@@ -161,7 +161,7 @@ void SettingsDialog::generate_default_config_file(QString server_name, QString i
     config_file_write.beginGroup("MapServer");
     config_file_write.setValue("listen_addr",ip+":7003");
     config_file_write.setValue("location_addr",ip+":7003");
-    config_file_write.setValue("maps","maps");
+    config_file_write.setValue("maps","DefaultMapInstances");
     config_file_write.setValue("player_fade_in", "380.0");
     config_file_write.endGroup();
     config_file_write.beginGroup("Logging");


### PR DESCRIPTION
Now an empty directory structure which is required by the server is added by cmake.
The default setting in settings.cfg is changed, too.
~~Not ready for merge yet~~: 
default value changed: 
- [x] SEGSAdmin
- [ ] authserver - Currently set to ".", might as well stay that way
- [x] settings::setDefaultSettings()
- [x] settings.cfg
- [x] cmake file structure

And while I was at it, I renamed the settings.cfg created by cmake to settings_template.cfg