### PR TITLE
Update projects pane image link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Finally, click `Configure Project`.
 **3. Build All**
 
 If everything went well, you'll see the SEGS file tree in the _Projects Pane_ of QTCreator.
-![Projects Pane](https://segs.io/user/pages/02.developers/ProjectConfiguration.png "Projects Pane")
+![Projects Pane](https://segs.io/user/pages/02.developers/ConfiguredProject.png "Projects Pane")
 
 Now, select `Build > Build All` from the menu at the top of QTCreator. The bottom half of the window will show compiling output as SEGS builds. The first time you build SEGS it may take several minutes and the output window may show hundreds of warnings, but if compiled successfully, you'll see the following in the _Compile Output_ window.
 ```


### PR DESCRIPTION
Closes #488  .

Readme erroneously linked to the [ProjectConfiguration.png](https://segs.io/user/pages/02.developers/ProjectConfiguration.png) image for illustrating the projects pane in the `build all` section.  This PR updates the link to point to [ConfiguredProject.png](https://segs.io/user/pages/02.developers/ConfiguredProject.png) instead (link taken from [developers page on segs io](https://segs.io/developers))


Previously the `build all` section of the readme looked like:
> **3. Build All**
> If everything went well, you'll see the SEGS file tree in the _Projects Pane_ of QTCreator.
> ![Projects Pane](https://segs.io/user/pages/02.developers/ProjectConfiguration.png "Projects Pane")

now it will look like:
> **3. Build All**
> If everything went well, you'll see the SEGS file tree in the _Projects Pane_ of QTCreator.
> ![Projects Pane](https://segs.io/user/pages/02.developers/ConfiguredProject.png "Projects Pane")
