### PR TITLE
[WIP] Initialize MapInstance::m_index correctly

### DIFF
--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -94,7 +94,8 @@ protected:
 
 using namespace std;
 MapInstance::MapInstance(const QString &mapdir_path, const ListenAndLocationAddresses &listen_addr)
-    : m_data_path(mapdir_path), m_world_update_timer(nullptr), m_addresses(listen_addr)
+  : m_data_path(mapdir_path), m_index(getMapIndex(mapdir_path.mid(mapdir_path.indexOf('/')))),
+    m_world_update_timer(nullptr), m_addresses(listen_addr)
 {
     m_world = new World(m_entities, serverData().m_player_fade_in);
     m_scripting_interface.reset(new ScriptingEngine);


### PR DESCRIPTION
Closes #491 .

Additions/modifications proposed in this pull request:
- Initialize MapInstance::m_index to the index value corresponding to map_name in `g_defined_map_datas`

Marked as WIP as I have not yet confirmed that the client agrees upon this map index usage.
