### PR TITLE
Allowing DbHandler to get entity data using character name.

### DIFF
--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -389,15 +389,15 @@ bool GameDbSyncContext::getEntity(const GetEntityRequestData &data, GetEntityRes
 
 bool GameDbSyncContext::getEntityByName(const GetEntityByNameRequestData &data, GetEntityByNameResponseData &result)
 {
-    m_prepared_entity_select->bindValue(0, data.m_char_name);
+    m_prepared_entity_select_by_name->bindValue(0, data.m_char_name);
 
-    if(!doIt(*m_prepared_entity_select))
+    if(!doIt(*m_prepared_entity_select_by_name))
         return false;
-    if(!m_prepared_entity_select->next())
+    if(!m_prepared_entity_select_by_name->next())
         return false;
 
-    result.m_supergroup_id = m_prepared_entity_select->value("supergroup_id").toUInt();
-    result.m_ent_data = m_prepared_entity_select->value("entitydata").toString();
+    result.m_supergroup_id = m_prepared_entity_select_by_name->value("supergroup_id").toUInt();
+    result.m_ent_data = m_prepared_entity_select_by_name->value("entitydata").toString();
     return true;
 }
 

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -124,6 +124,7 @@ bool GameDbSyncContext::loadAndConfigure()
     m_prepared_account_insert = std::make_unique<QSqlQuery>(*m_db);
     m_prepared_account_select = std::make_unique<QSqlQuery>(*m_db);
     m_prepared_entity_select = std::make_unique<QSqlQuery>(*m_db);
+    m_prepared_entity_select_by_name = std::make_unique<QSqlQuery>(*m_db);
     m_prepared_char_select = std::make_unique<QSqlQuery>(*m_db);
     m_prepared_char_exists = std::make_unique<QSqlQuery>(*m_db);
     m_prepared_char_insert = std::make_unique<QSqlQuery>(*m_db);
@@ -173,6 +174,7 @@ bool GameDbSyncContext::loadAndConfigure()
                 "INSERT INTO costume (character_id,costume_index,skin_color,parts) VALUES "
                 "(:id,:costume_index,:skin_color,:parts)");
     prepQuery(*m_prepared_entity_select,"SELECT * FROM characters WHERE id=:id");
+    prepQuery(*m_prepared_entity_select_by_name, "SELECT * FROM characters WHERE char_name=:char_name");
     prepQuery(*m_prepared_char_select,"SELECT * FROM characters WHERE account_id=? AND slot_index=?");
     prepQuery(*m_prepared_char_exists,"SELECT exists (SELECT 1 FROM characters WHERE char_name = ? LIMIT 1)");
     prepQuery(*m_prepared_char_delete,"DELETE FROM characters WHERE account_id=? AND slot_index=?");
@@ -375,11 +377,25 @@ bool GameDbSyncContext::createNewChar(const CreateNewCharacterRequestData &data,
 
 bool GameDbSyncContext::getEntity(const GetEntityRequestData &data, GetEntityResponseData &result)
 {
-    m_prepared_entity_select->bindValue(0,data.m_char_id);
+    m_prepared_entity_select->bindValue(0, data.m_char_id);
     if(!doIt(*m_prepared_entity_select))
         return false;
     if(!m_prepared_entity_select->next())
         return false;
+    result.m_supergroup_id = m_prepared_entity_select->value("supergroup_id").toUInt();
+    result.m_ent_data = m_prepared_entity_select->value("entitydata").toString();
+    return true;
+}
+
+bool GameDbSyncContext::getEntityByName(const GetEntityByNameRequestData &data, GetEntityByNameResponseData &result)
+{
+    m_prepared_entity_select->bindValue(0, data.m_char_name);
+
+    if(!doIt(*m_prepared_entity_select))
+        return false;
+    if(!m_prepared_entity_select->next())
+        return false;
+
     result.m_supergroup_id = m_prepared_entity_select->value("supergroup_id").toUInt();
     result.m_ent_data = m_prepared_entity_select->value("entitydata").toString();
     return true;

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.h
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.h
@@ -22,6 +22,8 @@ struct CreateNewCharacterRequestData;
 struct CreateNewCharacterResponseData;
 struct GetEntityRequestData;
 struct GetEntityResponseData;
+struct GetEntityByNameRequestData;
+struct GetEntityByNameResponseData;
 struct SetClientOptionsData;
 
 ///
@@ -37,6 +39,7 @@ class GameDbSyncContext
     std::unique_ptr<QSqlQuery> m_prepared_account_select;
     std::unique_ptr<QSqlQuery> m_prepared_account_insert;
     std::unique_ptr<QSqlQuery> m_prepared_entity_select;
+    std::unique_ptr<QSqlQuery> m_prepared_entity_select_by_name;
     std::unique_ptr<QSqlQuery> m_prepared_get_char_slots;
     std::unique_ptr<QSqlQuery> m_prepared_char_insert;
     std::unique_ptr<QSqlQuery> m_prepared_char_exists;
@@ -60,6 +63,7 @@ public:
     bool checkNameClash(const WouldNameDuplicateRequestData &data,WouldNameDuplicateResponseData &result);
     bool createNewChar(const  CreateNewCharacterRequestData&data, CreateNewCharacterResponseData &result);
     bool getEntity(const  GetEntityRequestData&data, GetEntityResponseData &result);
+    bool getEntityByName(const GetEntityByNameRequestData &data, GetEntityByNameResponseData &result);
     bool updateClientOptions(const SetClientOptionsData &data);
 private:
     int64_t getDbVersion(QSqlDatabase &);

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncEvents.h
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncEvents.h
@@ -38,6 +38,9 @@ enum GameDBEventTypes : uint32_t
     // select by id for entity data only
     evGetEntityRequest,
     evGetEntityResponse,
+    // selecy by name for entity data
+    evGetEntityByNameRequest,
+    evGetEntityByNameResponse,
 
     evGameDbError
 };
@@ -224,6 +227,18 @@ struct GetEntityResponseData
     QString m_ent_data;
 };
 TWO_WAY_MESSAGE(GetEntity)
+
+struct GetEntityByNameRequestData
+{
+    QString m_char_name;
+};
+
+struct GetEntityByNameResponseData
+{
+    uint32_t m_supergroup_id;
+    QString m_ent_data;
+};
+TWO_WAY_MESSAGE(GetEntityByName)
 
 struct WouldNameDuplicateRequestData
 {

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncHandler.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncHandler.cpp
@@ -49,6 +49,8 @@ void GameDBSyncHandler::dispatch(SEGSEvent *ev)
         on_create_new_char(static_cast<CreateNewCharacterRequest *>(ev)); break;
     case GameDBEventTypes::evGetEntityRequest:
         on_get_entity(static_cast<GetEntityRequest *>(ev)); break;
+    case GameDBEventTypes::evGetEntityByNameRequest:
+        on_get_entity_by_name(static_cast<GetEntityByNameRequest *>(ev)); break;
     default: assert(false); break;
     }
 }
@@ -133,6 +135,17 @@ void GameDBSyncHandler::on_get_entity(GetEntityRequest *ev)
 
     if(db_ctx.getEntity(ev->m_data,resp))
         ev->src()->putq(new GetEntityResponse(std::move(resp),ev->session_token()));
+    else
+        ev->src()->putq(new GameDbErrorMessage({"Game db error"},ev->session_token()));
+}
+
+void GameDBSyncHandler::on_get_entity_by_name(GetEntityByNameRequest *ev)
+{
+    GameDbSyncContext &db_ctx(m_db_context.localData());
+    GetEntityByNameResponseData resp;
+
+    if (db_ctx.getEntityByName(ev->m_data, resp))
+        ev->src()->putq(new GetEntityByNameResponse(std::move(resp), ev->session_token()));
     else
         ev->src()->putq(new GameDbErrorMessage({"Game db error"},ev->session_token()));
 }

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncHandler.h
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncHandler.h
@@ -24,6 +24,7 @@ struct RemoveCharacterRequest;
 struct WouldNameDuplicateRequest;
 struct CreateNewCharacterRequest;
 struct GetEntityRequest;
+struct GetEntityByNameRequest;
 
 class GameDBSyncHandler final : public EventProcessor
 {
@@ -42,6 +43,7 @@ class GameDBSyncHandler final : public EventProcessor
     void on_check_name_clash(WouldNameDuplicateRequest *ev);
     void on_create_new_char(CreateNewCharacterRequest *ev);
     void on_get_entity(GetEntityRequest *ev);
+    void on_get_entity_by_name(GetEntityByNameRequest *ev);
     // This is an unique ID that links this DB with it's Game Server
     uint8_t m_id;
 public:

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -696,10 +696,10 @@ void MapInstance::on_create_map_entity(NewEntity *ev)
         assert(map_session.m_ent);
 
         // this is just to test if GetEntityByNameRequest is working, the plan is for other EventProcessors to use this event
-        game_db->putq(new GetEntityByNameRequest({map_session.m_ent->m_char->getName()}, lnk->session_token(), this));
+        // game_db->putq(new GetEntityByNameRequest({map_session.m_ent->m_char->getName()}, lnk->session_token(), this));
 
         // this is what should be used
-        //game_db->putq(new GetEntityRequest({map_session.m_ent->m_char->m_db_id},lnk->session_token(),this));
+        game_db->putq(new GetEntityRequest({map_session.m_ent->m_char->m_db_id},lnk->session_token(),this));
     }
     // while we wait for db response, mark session as waiting for reaping
     m_session_store.locked_mark_session_for_reaping(&map_session,lnk->session_token());

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -264,7 +264,7 @@ void MapInstance::enqueue_client(MapClientSession *clnt)
     m_entities.InsertPlayer(clnt->m_ent);
 
     // m_sync_service has its own entity mgr, so add to its own mgr separately
-    m_sync_service->addPlayer(clnt->m_ent);
+    // m_sync_service->addPlayer(clnt->m_ent);
 
     //m_queued_clients.push_back(clnt); // enter this client on the waiting list
 }
@@ -292,6 +292,9 @@ void MapInstance::dispatch( SEGSEvent *ev )
             break;
         case GameDBEventTypes::evGetEntityResponse:
             on_entity_response(static_cast<GetEntityResponse *>(ev));
+            break;
+        case GameDBEventTypes::evGetEntityByNameResponse:
+            on_entity_by_name_response(static_cast<GetEntityByNameResponse *>(ev));
             break;
         case MapEventTypes::evIdle:
             on_idle(static_cast<IdleEvent *>(ev));
@@ -618,6 +621,36 @@ void MapInstance::on_entity_response(GetEntityResponse *ev)
     map_session.link()->putq(new MapInstanceConnected(this, 1, ""));
 }
 
+void MapInstance::on_entity_by_name_response(GetEntityByNameResponse *ev)
+{
+    // exactly the same function as above, this is just a test to see if getting entitydata by name is working
+    MapClientSession &map_session(m_session_store.session_from_event(ev));
+    m_session_store.locked_unmark_session_for_reaping(&map_session);
+    Entity * e = map_session.m_ent;
+
+    e->m_db_id              = e->m_char->m_db_id;
+    e->m_supergroup.m_SG_id = ev->m_data.m_supergroup_id;
+    serializeFromDb(e->m_entity_data, ev->m_data.m_ent_data);
+
+    // Can't pass direction through cereal, so let's update it here.
+    e->m_direction = fromCoHYpr(e->m_entity_data.m_orientation_pyr);
+
+    if (logSpawn().isDebugEnabled())
+    {
+        qCDebug(logSpawn).noquote() << "Dumping Entity Data during spawn:\n";
+        map_session.m_ent->dump();
+    }
+
+    // Tell our game server we've got the client
+    EventProcessor *tgt = HandlerLocator::getGame_Handler(m_game_server_id);
+    tgt->putq(new ClientConnectedMessage({ev->session_token(),m_owner_id,m_instance_id}));
+
+    map_session.m_current_map->enqueue_client(&map_session);
+    setMapName(*map_session.m_ent, name());
+    setMapIdx(*map_session.m_ent, index());
+    map_session.link()->putq(new MapInstanceConnected(this, 1, ""));
+}
+
 void MapInstance::on_create_map_entity(NewEntity *ev)
 {
     // TODO: At this point we should pre-process the NewEntity packet and let the proper CoXMapInstance handle the rest
@@ -653,7 +686,7 @@ void MapInstance::on_create_map_entity(NewEntity *ev)
         serializeToDb(e->m_entity_data,ent_data);
         // create the character from the data.
         //fillGameAccountData(map_session.m_client_id, map_session.m_game_account);
-        // FixMe: char_data members index, m_current_costume_idx, and m_villain are not initialized.
+        // FixMe: char_data members index, m_current_costume_idx, and m_villain are not initialized.      
         game_db->putq(new CreateNewCharacterRequest({char_data,ent_data, map_session.m_requested_slot_idx,
                                                      map_session.m_max_slots,map_session.m_client_id},
                                                     token,this));
@@ -661,7 +694,12 @@ void MapInstance::on_create_map_entity(NewEntity *ev)
     else
     {
         assert(map_session.m_ent);
-        game_db->putq(new GetEntityRequest({map_session.m_ent->m_char->m_db_id},lnk->session_token(),this));
+
+        // this is just to test if GetEntityByNameRequest is working, the plan is for other EventProcessors to use this event
+        game_db->putq(new GetEntityByNameRequest({map_session.m_ent->m_char->getName()}, lnk->session_token(), this));
+
+        // this is what should be used
+        //game_db->putq(new GetEntityRequest({map_session.m_ent->m_char->m_db_id},lnk->session_token(),this));
     }
     // while we wait for db response, mark session as waiting for reaping
     m_session_store.locked_mark_session_for_reaping(&map_session,lnk->session_token());

--- a/Projects/CoX/Servers/MapServer/MapInstance.h
+++ b/Projects/CoX/Servers/MapServer/MapInstance.h
@@ -83,6 +83,7 @@ protected:
         void                    on_name_clash_check_result(WouldNameDuplicateResponse *ev);
         void                    on_character_created(CreateNewCharacterResponse *ev);
         void                    on_entity_response(GetEntityResponse *ev);
+        void                    on_entity_by_name_response(GetEntityByNameResponse *ev);
         // Server->Server messages
         void on_expect_client(ExpectMapClientRequest *ev);
 


### PR DESCRIPTION
It should work almost exactly like GetEntityRequest and GetEntityResponse, the only thing is using a character's name instead of db_id as the search criteria. I think my EmailHandler can use this, and perhaps other handlers that are made for player to player interactions can, as well. In the end, it is possible that we might not use this at all though :P

This is untested atm, and I have made nothing that would use these changes in this PR (so far). To test this, I will change up MapInstance's on_create_map_entity so that it queues GetEntityByNameRequest instead of the standard GetEntityRequest. I don't think I should commit this change to MapInstance, because the default way is already correct, and thus changing it is unnecessary.