### PR TITLE
Remove `setMapName()` from MapInstance

### DIFF
--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -645,7 +645,6 @@ void MapInstance::on_entity_by_name_response(GetEntityByNameResponse *ev)
     tgt->putq(new ClientConnectedMessage({ev->session_token(),m_owner_id,m_instance_id}));
 
     map_session.m_current_map->enqueue_client(&map_session);
-    setMapName(*map_session.m_ent, name());
     setMapIdx(*map_session.m_ent, index());
     map_session.link()->putq(new MapInstanceConnected(this, 1, ""));
 }


### PR DESCRIPTION
Current develop HEAD is broken due to a merge miss.

Additions/modifications proposed in this pull request:
- Remove the last reference to "setMapName()" in MapInstance.cpp
