### PR TITLE
Browser, BrowserClose, and updated `/cmdlist` to use Browser

### DIFF
--- a/Projects/CoX/Servers/MapServer/CMakeLists.txt
+++ b/Projects/CoX/Servers/MapServer/CMakeLists.txt
@@ -37,6 +37,7 @@ SET(target_INCLUDE
     EntityStorage.h
     EntityUpdateCodec.h
     Events/GameCommandList.h
+    Events/Browser.h
     Events/ChangeTitle.h
     Events/ChatDividerMoved.h
     Events/ChatMessage.h

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -236,8 +236,7 @@ void sendServerMOTD(MapClientSession *tgt)
     if(file.exists() && file.open(QIODevice::ReadOnly | QIODevice::Text))
     {
         QString contents(file.readAll());
-        StandardDialogCmd *dlg = new StandardDialogCmd(contents);
-        tgt->addCommandToSendNextUpdate(std::unique_ptr<StandardDialogCmd>(dlg));
+        tgt->addCommand<StandardDialogCmd>(contents);
     }
     else {
         QString errormsg = "Failed to load MOTD file. \'" + file.fileName() + "\' not found.";
@@ -501,6 +500,12 @@ void sendDoorMessage(MapClientSession &tgt, uint32_t delay_status, QString &msg)
 {
     qCDebug(logMapXfers) << QString("Sending Door Message; delay: %1 msg: %2").arg(delay_status).arg(msg);
     tgt.addCommand<DoorMessage>(DoorMessageStatus(delay_status), msg);
+}
+
+void sendBrowser(MapClientSession &tgt, QString &content)
+{
+    qCDebug(logMapEvents) << QString("Sending Browser");
+    tgt.addCommand<Browser>(content);
 }
 
 

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -123,6 +123,7 @@ void sendTeamOffer(Entity *src, Entity *tgt);
 void sendFaceEntity(Entity *src, uint8_t tgt_idx);
 void sendFaceLocation(Entity *src, glm::vec3 &location);
 void sendDoorMessage(MapClientSession &tgt, uint32_t delay_status, QString &msg);
+void sendBrowser(MapClientSession &tgt, QString &content);
 
 
 const QString &getGenericTitle(uint32_t val);

--- a/Projects/CoX/Servers/MapServer/Events/Browser.h
+++ b/Projects/CoX/Servers/MapServer/Events/Browser.h
@@ -1,0 +1,59 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.io/
+ * Copyright (c) 2006 - 2018 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+#pragma once
+
+#include "GameCommandList.h"
+#include "MapEvents.h"
+#include "MapLink.h"
+#include "NetStructures/Entity.h"
+
+#include <QtCore/QString>
+
+namespace SEGSEvents
+{
+
+    // [[ev_def:type]]
+    class Browser : public GameCommandEvent
+    {
+    public:
+        //  [[ev_def:field]]
+        QString m_content;
+
+        explicit Browser() : GameCommandEvent(MapEventTypes::evBrowser) {}
+        Browser(QString content) : GameCommandEvent(MapEventTypes::evBrowser),
+            m_content(content)
+        {}
+
+        // SerializableEvent interface
+        void serializefrom(BitStream &/*src*/) override
+        {}
+        void serializeto(BitStream &bs) const override {
+            bs.StorePackedBits(1,type()-MapEventTypes::evFirstServerToClient); // 76
+            bs.StoreString(m_content);
+        }
+        EVENT_IMPL(Browser)
+    };
+
+    // [[ev_def:type]]
+    class BrowserClose final : public MapLinkEvent
+    {
+    public:
+        BrowserClose() : MapLinkEvent(MapEventTypes::evBrowserClose)
+        {
+        }
+        void    serializeto(BitStream &bs) const override
+        {
+            bs.StorePackedBits(1,type()-MapEventTypes::evFirstServerToClient); // 77
+        }
+        void    serializefrom(BitStream &bs)
+        {
+            qCDebug(logMapEvents) << "Browser Close Event";
+        }
+         EVENT_IMPL(BrowserClose)
+    };
+
+} // end of SEGSEvents namespace

--- a/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
+++ b/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "Events/Browser.h"
 #include "Events/StandardDialogCmd.h"
 #include "Events/ChangeTitle.h"
 #include "Events/DeadNoGurney.h"

--- a/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
+++ b/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
@@ -88,6 +88,7 @@ enum MapEventTypes
     EVENT_DECL(MapEventTypes, evEmailMessageStatus         ,167)
     EVENT_DECL(MapEventTypes, evEntityInfoResponse         ,169) // Send entity info (description)
 //    EVENT_DECL(MapEventTypes, evClueUpdate               ,170)
+    EVENT_DECL(MapEventTypes, evBrowser                    ,176)
     EVENT_DECL(MapEventTypes, evTrayAdd                    ,182)
     EVENT_DECL(MapEventTypes, evCombineEnhanceResponse     ,183)
 // client -> server commands
@@ -133,6 +134,7 @@ enum MapEventTypes
     EVENT_DECL(MapEventTypes, evSaveClientOptions          ,265)
     EVENT_DECL(MapEventTypes, evRecvSelectedTitles         ,266)
     EVENT_DECL(MapEventTypes, evDescriptionAndBattleCry    ,267)
+    EVENT_DECL(MapEventTypes, evBrowserClose               ,277)
     END_EVENTS(MapEventTypes, 1500)
 };
 } // end of SEGSEvents namespace

--- a/Projects/CoX/Servers/MapServer/MapEventFactory.cpp
+++ b/Projects/CoX/Servers/MapServer/MapEventFactory.cpp
@@ -96,6 +96,7 @@ MapLinkEvent *MapEventFactory::CommandEventFromStream(BitStream & bs)
         case 65: return new SaveClientOptions;
         case 66: return new RecvSelectedTitles;
         case 67: return new DescriptionAndBattleCry;
+        case 77: return new BrowserClose;
     }
     qCWarning(logMapEvents, "Unhandled command event type %d", opcode);
     return nullptr;

--- a/Projects/CoX/Servers/MapServer/MapEvents.h
+++ b/Projects/CoX/Servers/MapServer/MapEvents.h
@@ -895,6 +895,7 @@ public:
 };
 } // end of SEGSEvents namespace
 
+#include "Events/Browser.h"
 #include "Events/ChatDividerMoved.h"
 #include "Events/EntitiesResponse.h"
 #include "Events/FriendsListUpdate.h"

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -481,6 +481,9 @@ void MapInstance::dispatch( Event *ev )
         case evAwaitingDeadNoGurney:
             on_awaiting_dead_no_gurney(static_cast<AwaitingDeadNoGurney *>(ev));
             break;
+        case evBrowserClose:
+            on_browser_close(static_cast<BrowserClose *>(ev));
+            break;
         default:
             qCWarning(logMapEvents, "Unhandled MapEventTypes %u\n", ev->type()-MapEventTypes::base_MapEventTypes);
     }
@@ -2348,6 +2351,13 @@ void MapInstance::on_awaiting_dead_no_gurney(AwaitingDeadNoGurney *ev)
 {
     MapClientSession &session(m_session_store.session_from_event(ev));
     session.m_ent->m_client->addCommandToSendNextUpdate(std::unique_ptr<DeadNoGurney>(new DeadNoGurney()));
+}
+
+void MapInstance::on_browser_close(BrowserClose *ev)
+{
+    MapClientSession &session(m_session_store.session_from_event(ev));
+
+    qCDebug(logMapEvents) << "Entity: " << session.m_ent->m_idx << "has received BrowserClose";
 }
 
 

--- a/Projects/CoX/Servers/MapServer/MapInstance.h
+++ b/Projects/CoX/Servers/MapServer/MapInstance.h
@@ -85,6 +85,7 @@ class MapXferComplete;
 class InitiateMapXfer;
 struct ClientMapXferMessage;
 class AwaitingDeadNoGurney;
+class BrowserClose;
 // server<-> server event types
 struct ExpectMapClientRequest;
 struct WouldNameDuplicateResponse;
@@ -221,4 +222,5 @@ protected:
         void on_buy_enhancement_slot(SEGSEvents::BuyEnhancementSlot *ev);
         void on_recv_new_power(SEGSEvents::RecvNewPower *ev);
         void on_awaiting_dead_no_gurney(SEGSEvents::AwaitingDeadNoGurney *ev);
+        void on_browser_close(SEGSEvents::BrowserClose *ev);
 };

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -13,10 +13,7 @@
 #include "SlashCommand.h"
 
 #include "DataHelpers.h"
-#include "Events/ClientStates.h"
-#include "Events/StandardDialogCmd.h"
-#include "Events/DoorMessage.h"
-#include "Events/InfoMessageCmd.h"
+#include "Events/GameCommandList.h"
 #include "Events/MapXferWait.h"
 #include "GameData/GameDataStore.h"
 #include "GameData/playerdata_definitions.h"
@@ -104,6 +101,7 @@ void cmdHandler_FaceLocation(const QString &cmd, MapClientSession &sess);
 void cmdHandler_MoveZone(const QString &cmd, MapClientSession &sess);
 void cmdHandler_TestDeadNoGurney(const QString &cmd, MapClientSession &sess);
 void cmdHandler_DoorMessage(const QString &cmd, MapClientSession &sess);
+void cmdHandler_Browser(const QString &cmd, MapClientSession &sess);
 
 // Access Level 2[GM] Commands
 void addNpc(const QString &cmd, MapClientSession &sess);
@@ -196,6 +194,7 @@ static const SlashCommand g_defined_slash_commands[] = {
     {{"movezone", "mz"}, "Move to a map id", cmdHandler_MoveZone, 9},
     {{"deadnogurney"}, "Test Dead No Gurney. Fakes sending the client packet.", cmdHandler_TestDeadNoGurney, 9},
     {{"doormsg"}, "Test Door Message. Fakes sending the client packet.", cmdHandler_DoorMessage, 9},
+    {{"browser"}, "Test Browser. Sends content to a browser window", cmdHandler_Browser, 9},
 
     /* Access Level 2 Commands */
     {{"addNpc"},"add <npc_name> with costume [variation] in front of gm", addNpc, 2},
@@ -960,6 +959,14 @@ void cmdHandler_DoorMessage(const QString &cmd, MapClientSession &sess)
     sendDoorMessage(sess, DoorMessageStatus(delay_status), msg);
 }
 
+void cmdHandler_Browser(const QString &cmd, MapClientSession &sess)
+{
+    int space = cmd.indexOf(' ');
+    QString content = cmd.mid(space+1);
+    sendBrowser(sess, content);
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Access Level 2 Commands
 void addNpc(const QString &cmd, MapClientSession &sess)
@@ -1027,7 +1034,7 @@ void cmdHandler_CmdList(const QString &cmd, MapClientSession &sess)
 {
 
     QString msg = "Below is a list of all slash commands that your account can access. They are not case sensitive.\n";
-    QString msg_dlg = "<face heading><span align=center><color #ff0000>Command List</color></span></face><br>\n<br>\n";
+    QString content = "<face heading><span align=center><color #ff0000>Command List</color></span></face><br>\n<br>\n";
 
     for (const auto &sc : g_defined_slash_commands)
     {
@@ -1042,15 +1049,14 @@ void cmdHandler_CmdList(const QString &cmd, MapClientSession &sess)
         // Use msg for std out, msg_dlg for ingame dialog box
         msg += "\t" + sc.m_valid_prefixes.join(", ") + " [" + QString::number(sc.m_required_access_level) +
                "]:\t" + sc.m_help_text + "\n";
-        msg_dlg += QString("<color #ffCC99><i>%1</i></color>[<color #66ffff>%2</color>]: %3<br>")
+        content += QString("<color #ffCC99><i>%1</i></color>[<color #66ffff>%2</color>]: %3<br>")
                        .arg(sc.m_valid_prefixes.join(", "))
                        .arg(sc.m_required_access_level)
                        .arg(sc.m_help_text);
     }
 
-    // Dialog output
-    StandardDialogCmd *dlg = new StandardDialogCmd(msg_dlg);
-    sess.addCommandToSendNextUpdate(std::unique_ptr<StandardDialogCmd>(dlg));
+    // Browser output
+    sess.addCommand<Browser>(content);
     // CMD line (debug) output
     qCDebug(logSlashCommand).noquote() << cmd << ":\n" << msg;
 }

--- a/Projects/CoX/Servers/MapServer/UnitTests/MapEventRegistry.cpp
+++ b/Projects/CoX/Servers/MapServer/UnitTests/MapEventRegistry.cpp
@@ -12,6 +12,8 @@ namespace
         "ActivateInspiration",
         "ActivatePower",
         "ActivatePowerAtLocation",
+        "Browser",
+        "BrowserClose",
         "BuyEnhancementSlot",
         "ChangeStance",
         "ChangeTitle",


### PR DESCRIPTION
## Summary
Implements Browser, which is a scrollable dialog with the Paragon City logo in the background.

As described in #519 

### Features
- Implement `Browser` event
- Implement `BrowserClose` event
- Implement `/browser {content}` slash command
- Change `/cmdlist` to use new Browser window
