### PR TITLE
 Starting character infromation read from settings.cfg 

### DIFF
--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -169,7 +169,7 @@ void Settings::setDefaultSettings()
         config.setValue("inherent_powers","Brawl");
         config.setValue("starting_temps","EMP_Glove");
         config.setValue("starting_inspirations","Resurgence");
-        config.setValue("level_bonus", 0);
+        config.setValue("starting_level", 1);
         config.setValue("starting_inf", 0);
     config.endGroup();
 

--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -165,6 +165,13 @@ void Settings::setDefaultSettings()
         config.setValue("log_npcs","false");
         config.setValue("log_animations","false");
     config.endGroup();
+    config.beginGroup("StartingCharacter");
+        config.setValue("inherent_powers","Brawl");
+        config.setValue("starting_temps","EMP_Glove");
+        config.setValue("starting_inspirations","Resurgence");
+        config.setValue("level_bonus", 0);
+        config.setValue("starting_inf", 0);
+    config.endGroup();
 
     config.sync(); // sync changes or they wont be saved to file.
 }

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -28,6 +28,7 @@
 #include "Logging.h"
 #include <QtCore/QString>
 #include <QtCore/QDebug>
+#include "Settings.h"
 
 using namespace SEGSEvents;
 
@@ -127,14 +128,8 @@ void Character::finalizeLevel(const GameDataStore &data)
     m_char_data.m_powers_updated = false;
 }
 
-void Character::addStartingInspirations(const GameDataStore &data)
+void Character::addStartingInspirations(const GameDataStore &data, QStringList starting_insps)
 {
-    // TODO: We can make this configurable in settings.cfg
-    QStringList starting_insps = {
-        "Resurgence",       // 25.2.3
-        "Phenomenal_Luck",  // 25.2.0
-    };
-
     for (QString &name : starting_insps)
         addInspirationByName(data,m_char_data, name);
 }
@@ -168,37 +163,30 @@ void Character::getPowerFromBuildInfo(const GameDataStore &data,BitStream &src)
 
 void Character::GetCharBuildInfo(BitStream &src, const GameDataStore &data)
 {
-    m_char_data.m_level = 0;
-    m_char_data.m_combat_level = m_char_data.m_level + 1;
     src.GetString(m_char_data.m_class_name);
     src.GetString(m_char_data.m_origin_name);
 
-    // TODO: Make these configurable in settings.cfg?
-    QStringList starting_temps =
-    {
-        "EMP_Glove",                    // 27.0.0
-        "Cryoprojection_Bracers",       // 27.0.1
-    };
+    qInfo() << "Loading Starting Character Settings...";
+    QSettings config(Settings::getSettingsPath(),QSettings::IniFormat,nullptr);
 
-    // TODO: Make these configurable in settings.cfg?
-    QStringList inherent_and_preorders =
-    {
-        "Brawl",                        // 26.0.0
-        "prestige_generic_Sprintp",     // 26.0.1
-        //"prestige_preorder_Sprintp",    // 26.0.2
-        //"prestige_BestBuy_Sprintp",     // 26.0.3
-        //"prestige_EB_Sprintp",          // 26.0.4
-        //"prestige_Gamestop_Sprintp",    // 26.0.5
-        "Sprint",                       // 26.0.6
-        "Rest",                         // 26.0.7
-    };
+    config.beginGroup("StartingCharacter");
+        QStringList inherent_and_preorders = config.value("inherent_powers","Brawl").toString().split(',');
+        QStringList starting_temps = config.value("starting_temps","EMP_Glove").toString().split(',');
+        QStringList starting_insps = config.value("starting_inspirations","Resurgence").toString().split(',');
+        int startlevel = config.value(QStringLiteral("level_bonus"), "0").toInt();
+        int startinf = config.value(QStringLiteral("starting_inf"), "0").toInt();
+    config.endGroup();
+
+    m_char_data.m_level = startlevel; //combat level is m_level +1
+    m_char_data.m_influence = startinf;
 
     // Temporary Powers MUST come first (must be idx 0)
     getStartingPowers(data,QStringLiteral("Temporary_Powers"), QStringLiteral("Temporary_Powers"), starting_temps);
     getStartingPowers(data,QStringLiteral("Inherent"), QStringLiteral("Inherent"), inherent_and_preorders);
+
     getPowerFromBuildInfo(data,src);     // primary, secondary
     finalizeLevel(data);
-    addStartingInspirations(data);      // resurgence and phenomenal_luck
+    addStartingInspirations(data, starting_insps);
 
     m_char_data.m_trays.serializefrom(src);
 }

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -101,7 +101,7 @@ void Character::sendTray(BitStream &bs) const
 void Character::finalizeLevel(const GameDataStore &data)
 {
     uint32_t max_xp = data.expMaxLevel();
-
+    if (m_char_data.m_level == 4294967295){m_char_data.m_level = 0;}// /levelup can set this negative, need to bring it up
     m_char_data.m_combat_level = m_char_data.m_level + 1; // m_combat_level is display level?
 
     if(m_char_data.m_combat_level >= max_xp)
@@ -128,7 +128,7 @@ void Character::finalizeLevel(const GameDataStore &data)
     m_char_data.m_powers_updated = false;
 }
 
-void Character::addStartingInspirations(const GameDataStore &data, QStringList starting_insps)
+void Character::addStartingInspirations(const GameDataStore &data, QStringList &starting_insps)
 {
     for (QString &name : starting_insps)
         addInspirationByName(data,m_char_data, name);
@@ -173,12 +173,9 @@ void Character::GetCharBuildInfo(BitStream &src, const GameDataStore &data)
         QStringList inherent_and_preorders = config.value("inherent_powers","Brawl").toString().split(',');
         QStringList starting_temps = config.value("starting_temps","EMP_Glove").toString().split(',');
         QStringList starting_insps = config.value("starting_inspirations","Resurgence").toString().split(',');
-        int startlevel = config.value(QStringLiteral("starting_level"), "1").toInt() -1; //combat level is m_level +1, so it gets back to starting_level
-        int startinf = config.value(QStringLiteral("starting_inf"), "0").toInt();
+        uint startlevel = config.value(QStringLiteral("starting_level"), "1").toUInt() -1; //combat level is m_level +1, so it gets back to starting_level
+        uint startinf = config.value(QStringLiteral("starting_inf"), "0").toUInt();
     config.endGroup();
-
-    if (startlevel<0)
-        startlevel = 0;// make sure it isn't negative
 
     m_char_data.m_level = startlevel;
     m_char_data.m_influence = startinf;

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -173,11 +173,14 @@ void Character::GetCharBuildInfo(BitStream &src, const GameDataStore &data)
         QStringList inherent_and_preorders = config.value("inherent_powers","Brawl").toString().split(',');
         QStringList starting_temps = config.value("starting_temps","EMP_Glove").toString().split(',');
         QStringList starting_insps = config.value("starting_inspirations","Resurgence").toString().split(',');
-        int startlevel = config.value(QStringLiteral("level_bonus"), "0").toInt();
+        int startlevel = config.value(QStringLiteral("starting_level"), "1").toInt() -1; //combat level is m_level +1, so it gets back to starting_level
         int startinf = config.value(QStringLiteral("starting_inf"), "0").toInt();
     config.endGroup();
 
-    m_char_data.m_level = startlevel; //combat level is m_level +1
+    if (startlevel<0)
+        startlevel = 0;// make sure it isn't negative
+
+    m_char_data.m_level = startlevel;
     m_char_data.m_influence = startinf;
 
     // Temporary Powers MUST come first (must be idx 0)

--- a/Projects/CoX/Common/NetStructures/Character.h
+++ b/Projects/CoX/Common/NetStructures/Character.h
@@ -78,7 +78,7 @@ const   QString &       getName() const { return m_name; }
         void            serialize_costumes(BitStream &buffer, const ColorAndPartPacker *packer, bool all_costumes=true) const;
         void            serializetoCharsel(BitStream &bs, const QString& entity_map_name);
         void            finalizeLevel(const GameDataStore &data);
-        void            addStartingInspirations(const GameDataStore &data, QStringList starting_insps);
+        void            addStartingInspirations(const GameDataStore &data, QStringList &starting_insps);
         void            getStartingPowers(const GameDataStore &data, const QString &pcat_name, const QString &pset_name, const QStringList &power_names);
         void            getPowerFromBuildInfo(const GameDataStore &data,BitStream &src);
         void            sendEnhancements(BitStream &bs) const;

--- a/Projects/CoX/Common/NetStructures/Character.h
+++ b/Projects/CoX/Common/NetStructures/Character.h
@@ -78,7 +78,7 @@ const   QString &       getName() const { return m_name; }
         void            serialize_costumes(BitStream &buffer, const ColorAndPartPacker *packer, bool all_costumes=true) const;
         void            serializetoCharsel(BitStream &bs, const QString& entity_map_name);
         void            finalizeLevel(const GameDataStore &data);
-        void            addStartingInspirations(const GameDataStore &data);
+        void            addStartingInspirations(const GameDataStore &data, QStringList starting_insps);
         void            getStartingPowers(const GameDataStore &data, const QString &pcat_name, const QString &pset_name, const QStringList &power_names);
         void            getPowerFromBuildInfo(const GameDataStore &data,BitStream &src);
         void            sendEnhancements(BitStream &bs) const;

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -90,5 +90,5 @@ log_powers          = false
 inherent_powers="Brawl,prestige_generic_Sprintp,Sprint,Rest"
 starting_temps="EMP_Glove,Cryoprojection_Bracers"
 starting_inspirations="Resurgence,Phenomenal_Luck"
-starting_levels=1
+starting_level=1
 starting_inf=0

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -90,5 +90,5 @@ log_powers          = false
 inherent_powers="Brawl,prestige_generic_Sprintp,Sprint,Rest"
 starting_temps="EMP_Glove,Cryoprojection_Bracers"
 starting_inspirations="Resurgence,Phenomenal_Luck"
-level_bonus=0
+starting_levels=1
 starting_inf=0

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -85,3 +85,10 @@ log_lfg             = false
 log_npcs            = false
 log_animations      = false
 log_powers          = false
+
+[StartingCharacter]
+inherent_powers="Brawl,prestige_generic_Sprintp,Sprint,Rest"
+starting_temps="EMP_Glove,Cryoprojection_Bracers"
+starting_inspirations="Resurgence,Phenomenal_Luck"
+level_bonus=0
+starting_inf=0


### PR DESCRIPTION
Closes #572.

Additions/modifications proposed in this pull request:
- moved starting powers and inspirations to settings.cfg
- added starting level and inf
