### PR TITLE
Attempt to fix map transfers causing session reaping and disconnects

### DIFF
--- a/Projects/CoX/Common/Servers/InternalEvents.h
+++ b/Projects/CoX/Common/Servers/InternalEvents.h
@@ -204,11 +204,11 @@ struct ClientDisconnectedData
 {
     uint64_t m_session;
     uint32_t m_char_db_id;       // id of the character disconnected
-    uint32_t m_map_server_id;
+    uint32_t m_map_instance_id;
     template<class Archive>
     void serialize(Archive &ar)
     {
-        ar(m_session,m_char_db_id, m_map_server_id);
+        ar(m_session,m_char_db_id, m_map_instance_id);
     }
 };
 //[[ev_def:macro]]

--- a/Projects/CoX/Common/Servers/InternalEvents.h
+++ b/Projects/CoX/Common/Servers/InternalEvents.h
@@ -204,10 +204,11 @@ struct ClientDisconnectedData
 {
     uint64_t m_session;
     uint32_t m_char_db_id;       // id of the character disconnected
+    uint32_t m_map_server_id;
     template<class Archive>
     void serialize(Archive &ar)
     {
-        ar(m_session,m_char_db_id);
+        ar(m_session,m_char_db_id, m_map_server_id);
     }
 };
 //[[ev_def:macro]]

--- a/Projects/CoX/Servers/GameServer/GameHandler.cpp
+++ b/Projects/CoX/Servers/GameServer/GameHandler.cpp
@@ -442,6 +442,8 @@ void GameHandler::on_client_connected_to_other_server(ClientConnectedMessage *ev
         // check if this session perhaps is in ready for reaping set
         m_session_store.unmark_session_for_reaping(&session);
     }
+
+    qCDebug(logMapXfers) << QString("client_connected_to_other ev.id: %1 sess.id: %2").arg(ev->m_data.m_sub_server_id).arg(session.is_connected_to_map_instance_id);
     session.is_connected_to_map_server_id = ev->m_data.m_server_id;
     session.is_connected_to_map_instance_id = ev->m_data.m_sub_server_id;
 }

--- a/Projects/CoX/Servers/GameServer/GameHandler.cpp
+++ b/Projects/CoX/Servers/GameServer/GameHandler.cpp
@@ -451,7 +451,8 @@ void GameHandler::on_client_disconnected_from_other_server(ClientDisconnectedMes
     GameSession &session(m_session_store.session_from_token(ev->m_data.m_session));
     // Prevent altering the session when disconnecting from a map server after a map transfer in cases
     // where the disconnect is handled after the reconnection.
-    if (ev->m_data.m_map_server_id == session.is_connected_to_map_server_id)
+    qCDebug(logMapXfers) << QString("client_disconnected_from ev.id: %1 sess.id: %2").arg(ev->m_data.m_map_instance_id).arg(session.is_connected_to_map_instance_id);
+    if (ev->m_data.m_map_instance_id == session.is_connected_to_map_instance_id)
     {
         session.is_connected_to_map_server_id = 0;
         session.is_connected_to_map_instance_id = 0;

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -259,11 +259,15 @@ void MapInstance::on_client_connected_to_other_server(ClientConnectedMessage */*
 void MapInstance::on_client_disconnected_from_other_server(ClientDisconnectedMessage *ev)
 {
     MapClientSession &session(m_session_store.session_from_event(ev));
-    session.is_connected_to_map_server_id = 0;
-    session.is_connected_to_map_instance_id = 0;
+    qCDebug(logMapXfers) << QString("disconnect_from_instance ev.instance: %1 sess.instance: %2").arg(ev->m_data.m_map_instance_id).arg(m_instance_id);
+    if (ev->m_data.m_map_instance_id == m_instance_id)
     {
-        SessionStore::MTGuard guard(m_session_store.reap_lock());
-        m_session_store.mark_session_for_reaping(&session,ev->session_token());
+        session.is_connected_to_map_server_id = 0;
+        session.is_connected_to_map_instance_id = 0;
+        {
+            SessionStore::MTGuard guard(m_session_store.reap_lock());
+            m_session_store.mark_session_for_reaping(&session,ev->session_token());
+        }
     }
 }
 

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -525,6 +525,8 @@ void MapInstance::on_map_xfer_complete(MapXferComplete *ev)
 {
     MapClientSession &session(m_session_store.session_from_event(ev));
     qCDebug(logMapXfers) << QString("Map xfer complete for session: %1").arg(session.link()->session_token());
+    qCDebug(logMapXfers) << QString("Previous Map Instance ID: %1 Current Map Instance ID: %2").arg(session.is_connected_to_map_instance_id).arg(m_index);
+    session.is_connected_to_map_instance_id = m_index;  // change map instance to new instance.
     // TODO: Do anything necessary after connecting to new map instance here.
 }
 

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -593,7 +593,7 @@ void MapInstance::on_link_lost(Event *ev)
     //todo: notify all clients about entity removal
 
     HandlerLocator::getGame_Handler(m_game_server_id)
-            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), ent->m_char->m_db_id, m_owner_id},0));
+            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), m_owner_id},0));
 
     // one last character update for the disconnecting entity
     send_character_update(ent);
@@ -615,7 +615,7 @@ void MapInstance::on_disconnect(DisconnectRequest *ev)
     assert(ent);
         //todo: notify all clients about entity removal
     HandlerLocator::getGame_Handler(m_game_server_id)
-            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), ent->m_char->m_db_id, m_owner_id},0));
+            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), m_owner_id},0));
 
     removeLFG(*ent);
     leaveTeam(*ent);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -593,7 +593,7 @@ void MapInstance::on_link_lost(Event *ev)
     //todo: notify all clients about entity removal
 
     HandlerLocator::getGame_Handler(m_game_server_id)
-            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id()},0));
+            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), ent->m_char->m_db_id, m_owner_id},0));
 
     // one last character update for the disconnecting entity
     send_character_update(ent);
@@ -615,7 +615,7 @@ void MapInstance::on_disconnect(DisconnectRequest *ev)
     assert(ent);
         //todo: notify all clients about entity removal
     HandlerLocator::getGame_Handler(m_game_server_id)
-            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id()},0));
+            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), ent->m_char->m_db_id, m_owner_id},0));
 
     removeLFG(*ent);
     leaveTeam(*ent);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -596,7 +596,7 @@ void MapInstance::on_link_lost(Event *ev)
     //todo: notify all clients about entity removal
 
     HandlerLocator::getGame_Handler(m_game_server_id)
-            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), m_owner_id},0));
+            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), m_instance_id},0));
 
     // one last character update for the disconnecting entity
     send_character_update(ent);
@@ -618,7 +618,7 @@ void MapInstance::on_disconnect(DisconnectRequest *ev)
     assert(ent);
         //todo: notify all clients about entity removal
     HandlerLocator::getGame_Handler(m_game_server_id)
-            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), m_owner_id},0));
+            ->putq(new ClientDisconnectedMessage({session_token,session.auth_id(), m_instance_id},0));
 
     removeLFG(*ent);
     leaveTeam(*ent);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -497,7 +497,7 @@ void MapInstance::on_initiate_map_transfer(InitiateMapXfer *ev)
     MapClientSession &session(m_session_store.session_from_event(ev));
     MapLink *lnk = session.link();
     MapServer *map_server = (MapServer *)HandlerLocator::getMap_Handler(m_game_server_id);
-    qCDebug(logMapXfers) << QString("Initiating map transfer for session: %1").arg(lnk->session_token());
+    qCDebug(logMapXfers) << QString("Initiating map transfer for session: %1 on map instance %2").arg(lnk->session_token()).arg(m_instance_id);
     if (!map_server->session_has_xfer_in_progress(lnk->session_token()))
     {
          qCDebug(logMapXfers) << QString("Client Session %1 attempting to initiate transfer with no map data message received").arg(session.link()->session_token());
@@ -525,8 +525,8 @@ void MapInstance::on_map_xfer_complete(MapXferComplete *ev)
 {
     MapClientSession &session(m_session_store.session_from_event(ev));
     qCDebug(logMapXfers) << QString("Map xfer complete for session: %1").arg(session.link()->session_token());
-    qCDebug(logMapXfers) << QString("Previous Map Instance ID: %1 Current Map Instance ID: %2").arg(session.is_connected_to_map_instance_id).arg(m_index);
-    session.is_connected_to_map_instance_id = m_index;  // change map instance to new instance.
+    qCDebug(logMapXfers) << QString("Previous Map Instance ID: %1 Current Map Instance ID: %2").arg(session.is_connected_to_map_instance_id).arg(m_instance_id);
+    session.is_connected_to_map_instance_id = m_instance_id;  // change map instance to new instance.
     // TODO: Do anything necessary after connecting to new map instance here.
 }
 


### PR DESCRIPTION
Attempts to close #565 .

Attempt to fix the issue that sessions were being reaped sometimes after transferring between maps. This adds a check to the GameHandler disconnect handler to only reap the session if the map server the disconnect is from and the map server the session is connected to are the same.