### PR TITLE
AddTimeStateLog and TimeUpdate

### DIFF
--- a/Projects/CoX/Common/NetStructures/Entity.h
+++ b/Projects/CoX/Common/NetStructures/Entity.h
@@ -136,15 +136,27 @@ enum class AppearanceType : uint8_t
     SequencerName = 4
 };
 
+enum class StateMode : uint8_t
+{
+    Simple              = 0,
+    Create_Team         = 1,
+    Create_Team_Wait    = 2,
+    Dead                = 3,
+    Ressurect           = 4,
+    NeedsGurney         = 5,
+    Max_State           = 6
+};
+
 struct SuperGroup
 {
-    int             m_SG_id                 = {0};
-    QString         m_SG_name               = "Supergroup"; // 64 chars max
-    //QString         m_SG_motto;
-    //QString         m_SG_costume;                         // 128 chars max -> hash table key from the CostumeString_HTable
-    uint32_t        m_SG_color1             = 0;            // supergroup color 1
-    uint32_t        m_SG_color2             = 0;            // supergroup color 2
-    int             m_SG_rank               = 1;
+    int             m_SG_id         = {0};
+    QString         m_SG_name       = "Supergroup"; // 64 chars max
+    QString         m_SG_motto;
+    QString         m_SG_motd;
+    QString         m_SG_emblem;         // 128 chars max -> hash table key from the CostumeString_HTable
+    uint32_t        m_SG_color1     = 0; // supergroup color 1
+    uint32_t        m_SG_color2     = 0; // supergroup color 2
+    int             m_SG_rank       = 1;
 };
 
 struct NPCData
@@ -155,14 +167,31 @@ struct NPCData
     int costume_variant=0;
 };
 
+struct NetFxTarget
+{
+    bool        type_is_location = false;
+    uint32_t    ent_idx = 0;
+    glm::vec3   pos;
+};
+
 struct NetFx
 {
-    uint8_t command;
-    uint32_t net_id;
-    uint32_t handle;
-    bool pitch_to_target;
-    uint8_t bone_id;
+    uint8_t     command;
+    uint32_t    net_id;
+    uint32_t    handle;
+    bool        pitch_to_target     = false;
+    uint8_t     bone_id;
+    float       client_timer        = 0;
+    int         client_trigger_fx   = 0;
+    float       duration            = 0;
+    float       radius              = 0;
+    QString     power               = 0;
+    int         debris              = 0;
+    NetFxTarget target;
+    NetFxTarget origin;
 };
+
+
 class Entity
 {
     // only EntityStore can create instances of this class

--- a/Projects/CoX/Servers/MapServer/CMakeLists.txt
+++ b/Projects/CoX/Servers/MapServer/CMakeLists.txt
@@ -44,6 +44,7 @@ SET(target_INCLUDE
     EntityStorage.h
     EntityUpdateCodec.h
     Events/GameCommandList.h
+    Events/AddTimeStateLog.h
     Events/Browser.h
     Events/ChangeTitle.h
     Events/ChatDividerMoved.h

--- a/Projects/CoX/Servers/MapServer/CMakeLists.txt
+++ b/Projects/CoX/Servers/MapServer/CMakeLists.txt
@@ -81,6 +81,7 @@ SET(target_INCLUDE
     Events/StandardDialogCmd.h
     Events/TeamLooking.h
     Events/TeamOffer.h
+    Events/TimeUpdate.h
     Events/TradeCancel.h
     Events/TradeInit.h
     Events/TradeOffer.h

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -403,8 +403,14 @@ void messageOutput(MessageChannel ch, const QString &msg, Entity &tgt)
  */
 void sendTimeStateLog(MapClientSession &src, uint32_t control_log)
 {
-    qCDebug(logSlashCommand, "Sending ControlLog %d", control_log);
+    qCDebug(logSlashCommand, "Sending TimeStateLog %d", control_log);
     src.addCommand<AddTimeStateLog>(control_log);
+}
+
+void sendTimeUpdate(MapClientSession &src, int32_t sec_since_jan_1_2000)
+{
+    qCDebug(logSlashCommand, "Sending TimeUpdate %d", sec_since_jan_1_2000);
+    src.addCommand<TimeUpdate>(sec_since_jan_1_2000);
 }
 
 void sendClientState(MapClientSession &ent, ClientStates client_state)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -401,6 +401,12 @@ void messageOutput(MessageChannel ch, const QString &msg, Entity &tgt)
 /*
  * SendUpdate Wrappers to provide access to NetStructures
  */
+void sendTimeStateLog(MapClientSession &src, uint32_t control_log)
+{
+    qCDebug(logSlashCommand, "Sending ControlLog %d", control_log);
+    src.addCommand<AddTimeStateLog>(control_log);
+}
+
 void sendClientState(MapClientSession &ent, ClientStates client_state)
 {
     qCDebug(logSlashCommand) << "Sending ClientState:" << QString::number(client_state);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -110,7 +110,7 @@ void messageOutput(MessageChannel ch, const QString &msg, Entity &tgt);
  * SendUpdate Wrappers to provide access to NetStructures
  */
 void sendTimeStateLog(MapClientSession &src, uint32_t control_log);
-void sendTimeUpdate(MapClientSession &src, int32_t ms_since_jan_1_2000);
+void sendTimeUpdate(MapClientSession &src, int32_t sec_since_jan_1_2000);
 void sendClientState(MapClientSession &ent, ClientStates client_state);
 void showMapXferList(MapClientSession &ent, bool has_location, glm::vec3 &location, QString &name);
 void sendFloatingInfo(MapClientSession &tgt, QString &msg, FloatingInfoStyle style, float delay);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -109,6 +109,7 @@ void messageOutput(MessageChannel ch, const QString &msg, Entity &tgt);
 /*
  * SendUpdate Wrappers to provide access to NetStructures
  */
+void sendTimeStateLog(MapClientSession &src, uint32_t control_log);
 void sendClientState(MapClientSession &ent, ClientStates client_state);
 void showMapXferList(MapClientSession &ent, bool has_location, glm::vec3 &location, QString &name);
 void sendFloatingInfo(MapClientSession &tgt, QString &msg, FloatingInfoStyle style, float delay);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -110,6 +110,7 @@ void messageOutput(MessageChannel ch, const QString &msg, Entity &tgt);
  * SendUpdate Wrappers to provide access to NetStructures
  */
 void sendTimeStateLog(MapClientSession &src, uint32_t control_log);
+void sendTimeUpdate(MapClientSession &src, int32_t ms_since_jan_1_2000);
 void sendClientState(MapClientSession &ent, ClientStates client_state);
 void showMapXferList(MapClientSession &ent, bool has_location, glm::vec3 &location, QString &name);
 void sendFloatingInfo(MapClientSession &tgt, QString &msg, FloatingInfoStyle style, float delay);

--- a/Projects/CoX/Servers/MapServer/Events/AddTimeStateLog.h
+++ b/Projects/CoX/Servers/MapServer/Events/AddTimeStateLog.h
@@ -1,0 +1,36 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.io/
+ * Copyright (c) 2006 - 2018 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+
+#pragma once
+#include "GameCommand.h"
+#include "MapEventTypes.h"
+
+namespace SEGSEvents
+{
+
+// [[ev_def:type]]
+class AddTimeStateLog final : public GameCommandEvent
+{
+public:
+    // [[ev_def:field]]
+    int m_time_log = 0;
+
+    explicit AddTimeStateLog() : GameCommandEvent(evAddTimeStateLog) {}
+    AddTimeStateLog(int time_log) : GameCommandEvent(evAddTimeStateLog),
+        m_time_log(time_log)
+    {
+    }
+    void    serializeto(BitStream &bs) const override
+    {
+        bs.StorePackedBits(1,type()-evFirstServerToClient); // pkt 60
+        bs.StorePackedBits(1, m_time_log);
+    }
+
+    EVENT_IMPL(AddTimeStateLog)
+};
+
+} // end of SEGSEvents namespace

--- a/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
+++ b/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "Events/AddTimeStateLog.h"
 #include "Events/Browser.h"
 #include "Events/StandardDialogCmd.h"
 #include "Events/ChangeTitle.h"
@@ -26,6 +27,7 @@
 #include "Events/PowerSystemEvents.h"
 #include "Events/SetClientState.h"
 #include "Events/SidekickOffer.h"
+#include "Events/StandardDialogCmd.h"
 #include "Events/TeamLooking.h"
 #include "Events/TeamOffer.h"
 #include "Events/TrayAdd.h"

--- a/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
+++ b/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
@@ -30,5 +30,6 @@
 #include "Events/StandardDialogCmd.h"
 #include "Events/TeamLooking.h"
 #include "Events/TeamOffer.h"
+#include "Events/TimeUpdate.h"
 #include "Events/TrayAdd.h"
 

--- a/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
+++ b/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
@@ -67,7 +67,7 @@ enum MapEventTypes
 //    EVENT_DECL(MapEventTypes, evTaskStatusList           ,145)
 //    EVENT_DECL(MapEventTypes, evTaskSelect               ,146)
 //    EVENT_DECL(MapEventTypes, evTaskRemoveTeammates      ,147)
-//    EVENT_DECL(MapEventTypes, evTimeUpdate               ,148)
+    EVENT_DECL(MapEventTypes, evTimeUpdate                 ,148)
 //    EVENT_DECL(MapEventTypes, evMissionEntryText         ,149)
 //    EVENT_DECL(MapEventTypes, evMissionKick              ,150)
     EVENT_DECL(MapEventTypes, evDeadNoGurney               ,151)

--- a/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
+++ b/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
@@ -79,7 +79,7 @@ enum MapEventTypes
     EVENT_DECL(MapEventTypes, evSendStance                 ,157) // I think?
     EVENT_DECL(MapEventTypes, evMapXferList                ,158)
     EVENT_DECL(MapEventTypes, evMapXferListClose           ,159)
-//    EVENT_DECL(MapEventTypes, evEnableControlLog         ,160)
+    EVENT_DECL(MapEventTypes, evAddTimeStateLog            ,160)
     EVENT_DECL(MapEventTypes, evLevelUp                    ,161)
     EVENT_DECL(MapEventTypes, evChangeTitle                ,162)
 //    EVENT_DECL(MapEventTypes, evCSRBugReport             ,164)

--- a/Projects/CoX/Servers/MapServer/Events/TimeUpdate.h
+++ b/Projects/CoX/Servers/MapServer/Events/TimeUpdate.h
@@ -1,0 +1,36 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.io/
+ * Copyright (c) 2006 - 2018 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+
+#pragma once
+#include "GameCommand.h"
+#include "MapEventTypes.h"
+
+namespace SEGSEvents
+{
+
+// [[ev_def:type]]
+class TimeUpdate final : public GameCommandEvent
+{
+public:
+    // [[ev_def:field]]
+    int m_time_since_jan_1_2000 = 0;
+
+    explicit TimeUpdate() : GameCommandEvent(evTimeUpdate) {}
+    TimeUpdate(int time) : GameCommandEvent(evTimeUpdate),
+        m_time_since_jan_1_2000(time)
+    {
+    }
+    void    serializeto(BitStream &bs) const override
+    {
+        bs.StorePackedBits(1,type()-evFirstServerToClient); // pkt 48
+        bs.StorePackedBits(1, m_time_since_jan_1_2000);
+    }
+
+    EVENT_IMPL(TimeUpdate)
+};
+
+} // end of SEGSEvents namespace

--- a/Projects/CoX/Servers/MapServer/Events/TimeUpdate.h
+++ b/Projects/CoX/Servers/MapServer/Events/TimeUpdate.h
@@ -17,17 +17,17 @@ class TimeUpdate final : public GameCommandEvent
 {
 public:
     // [[ev_def:field]]
-    int m_time_since_jan_1_2000 = 0;
+    int32_t m_time_since_jan_1_2000 = 0;
 
     explicit TimeUpdate() : GameCommandEvent(evTimeUpdate) {}
-    TimeUpdate(int time) : GameCommandEvent(evTimeUpdate),
+    TimeUpdate(int32_t time) : GameCommandEvent(evTimeUpdate),
         m_time_since_jan_1_2000(time)
     {
     }
     void    serializeto(BitStream &bs) const override
     {
         bs.StorePackedBits(1,type()-evFirstServerToClient); // pkt 48
-        bs.StorePackedBits(1, m_time_since_jan_1_2000);
+        bs.StorePackedBits(32, m_time_since_jan_1_2000);
     }
 
     EVENT_IMPL(TimeUpdate)

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -104,6 +104,7 @@ void cmdHandler_MoveZone(const QString &cmd, MapClientSession &sess);
 void cmdHandler_TestDeadNoGurney(const QString &cmd, MapClientSession &sess);
 void cmdHandler_DoorMessage(const QString &cmd, MapClientSession &sess);
 void cmdHandler_Browser(const QString &cmd, MapClientSession &sess);
+void cmdHandler_SendTimeUpdate(const QString &cmd, MapClientSession &sess);
 
 void cmdHandler_SetU1(const QString &cmd, MapClientSession &sess);
 
@@ -202,6 +203,7 @@ static const SlashCommand g_defined_slash_commands[] = {
     {{"deadnogurney"}, "Test Dead No Gurney. Fakes sending the client packet.", cmdHandler_TestDeadNoGurney, 9},
     {{"doormsg"}, "Test Door Message. Fakes sending the client packet.", cmdHandler_DoorMessage, 9},
     {{"browser"}, "Test Browser. Sends content to a browser window", cmdHandler_Browser, 9},
+    {{"timeupdate"}, "Test TimeUpdate. Sends time update to server", cmdHandler_SendTimeUpdate, 9},
 
     {{"setu1"},"Set bitvalue u1. Used for live-debugging.", cmdHandler_SetU1, 9},
 
@@ -1032,6 +1034,20 @@ void cmdHandler_Browser(const QString &cmd, MapClientSession &sess)
     int space = cmd.indexOf(' ');
     QString content = cmd.mid(space+1);
     sendBrowser(sess, content);
+}
+
+void cmdHandler_SendTimeUpdate(const QString &/*cmd*/, MapClientSession &sess)
+{
+    // I thought this would require time since postgres epoch, like other timers
+    // but sending this crashes the client. Leaving this here during the
+    // review process as perhaps I'm overlooking something.
+    //QDateTime base_date(QDate(2000,1,1));
+    //int32_t time_in_sec = static_cast<int32_t>(base_date.secsTo(QDateTime::currentDateTime()));
+
+    // Sec since epoch works without crashing the client
+    int32_t time_in_sec = static_cast<int32_t>(QDateTime::currentSecsSinceEpoch());
+
+    sendTimeUpdate(sess, time_in_sec);
 }
 
 // Slash commands for setting bit values

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -1038,14 +1038,9 @@ void cmdHandler_Browser(const QString &cmd, MapClientSession &sess)
 
 void cmdHandler_SendTimeUpdate(const QString &/*cmd*/, MapClientSession &sess)
 {
-    // I thought this would require time since postgres epoch, like other timers
-    // but sending this crashes the client. Leaving this here during the
-    // review process as perhaps I'm overlooking something.
-    //QDateTime base_date(QDate(2000,1,1));
-    //int32_t time_in_sec = static_cast<int32_t>(base_date.secsTo(QDateTime::currentDateTime()));
-
-    // Sec since epoch works without crashing the client
-    int32_t time_in_sec = static_cast<int32_t>(QDateTime::currentSecsSinceEpoch());
+    // client expects PostgresEpoch of Jan 1 2000
+    QDateTime base_date(QDate(2000,1,1));
+    int32_t time_in_sec = static_cast<int32_t>(base_date.secsTo(QDateTime::currentDateTime()));
 
     sendTimeUpdate(sess, time_in_sec);
 }

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -91,13 +91,13 @@ void cmdHandler_FriendsListDebug(const QString &cmd, MapClientSession &sess);
 void cmdHandler_SendFloatingNumbers(const QString &cmd, MapClientSession &sess);
 void cmdHandler_ToggleExtraInfo(const QString &cmd, MapClientSession &sess);
 void cmdHandler_ToggleMoveInstantly(const QString &cmd, MapClientSession &sess);
+void cmdHandler_AddTimeStateLog(const QString &cmd, MapClientSession &sess);
 void cmdHandler_SetClientState(const QString &cmd, MapClientSession &sess);
 void cmdHandler_AddEntirePowerSet(const QString &cmd, MapClientSession &sess);
 void cmdHandler_AddPower(const QString &cmd, MapClientSession &sess);
 void cmdHandler_AddInspiration(const QString &cmd, MapClientSession &sess);
 void cmdHandler_AddEnhancement(const QString &cmd, MapClientSession &sess);
 void cmdHandler_LevelUpXp(const QString &cmd, MapClientSession &sess);
-void cmdHandler_SetU1(const QString &cmd, MapClientSession &sess);
 void cmdHandler_FaceEntity(const QString &cmd, MapClientSession &sess);
 void cmdHandler_FaceLocation(const QString &cmd, MapClientSession &sess);
 void cmdHandler_MoveZone(const QString &cmd, MapClientSession &sess);
@@ -105,9 +105,12 @@ void cmdHandler_TestDeadNoGurney(const QString &cmd, MapClientSession &sess);
 void cmdHandler_DoorMessage(const QString &cmd, MapClientSession &sess);
 void cmdHandler_Browser(const QString &cmd, MapClientSession &sess);
 
+void cmdHandler_SetU1(const QString &cmd, MapClientSession &sess);
+
 // Access Level 2[GM] Commands
-void addNpc(const QString &cmd, MapClientSession &sess);
-void moveTo(const QString &cmd, MapClientSession &sess);
+void cmdHandler_AddNPC(const QString &cmd, MapClientSession &sess);
+void cmdHandler_MoveTo(const QString &cmd, MapClientSession &sess);
+
 // Access Level 1 Commands
 void cmdHandler_CmdList(const QString &cmd, MapClientSession &sess);
 void cmdHandler_AFK(const QString &cmd, MapClientSession &sess);
@@ -132,6 +135,8 @@ void cmdHandler_Unfriend(const QString &cmd, MapClientSession &sess);
 void cmdHandler_FriendList(const QString &cmd, MapClientSession &sess);
 void cmdHandler_MapXferList(const QString &cmd, MapClientSession &sess);
 void cmdHandler_ReSpec(const QString &cmd, MapClientSession &sess);
+void cmdHandler_Trade(const QString &cmd, MapClientSession &sess);
+
 // Access Level 0 Commands
 void cmdHandler_TeamAccept(const QString &cmd, MapClientSession &sess);
 void cmdHandler_TeamDecline(const QString &cmd, MapClientSession &sess);
@@ -141,7 +146,6 @@ void cmdHandler_EmailHeaders(const QString &cmd, MapClientSession &sess);
 void cmdHandler_EmailRead(const QString &cmd, MapClientSession &sess);
 void cmdHandler_EmailSend(const QString &cmd, MapClientSession &sess);
 void cmdHandler_EmailDelete(const QString &cmd, MapClientSession &sess);
-void cmdHandler_Trade(const QString &cmd, MapClientSession &sess);
 void cmdHandler_TradeAccept(const QString &cmd, MapClientSession &sess);
 void cmdHandler_TradeDecline(const QString &cmd, MapClientSession &sess);
 
@@ -185,13 +189,13 @@ static const SlashCommand g_defined_slash_commands[] = {
     {{"damage", "heal"}, "Make current target (or self) take damage/health", cmdHandler_SendFloatingNumbers, 9},
     {{"extrainfo"},"Toggle extra_info", &cmdHandler_ToggleExtraInfo, 9},
     {{"moveinstantly"},"Toggle move_instantly", &cmdHandler_ToggleMoveInstantly, 9},
+    {{"timestate", "setTimeStateLog"},"Set TimeStateLog value.", cmdHandler_AddTimeStateLog, 9},
     {{"clientstate"},"Set ClientState mode", &cmdHandler_SetClientState, 9},
     {{"addpowerset"},"Adds entire PowerSet (by 'pcat pset' idxs) to Entity", &cmdHandler_AddEntirePowerSet, 9},
     {{"addpower"},"Adds Power (by 'pcat pset pow' idxs) to Entity", &cmdHandler_AddPower, 9},
     {{"addinsp"},"Adds Inspiration (by name) to Entity", &cmdHandler_AddInspiration, 9},
     {{"addboost", "addEnhancement"},"Adds Enhancement (by name) to Entity", &cmdHandler_AddEnhancement, 9},
     {{"levelupxp"},"Level Up Character to Level Provided", &cmdHandler_LevelUpXp, 9},
-    {{"setu1"},"Set bitvalue u1. Used for live-debugging.", cmdHandler_SetU1, 9},
     {{"face"}, "Face a target", cmdHandler_FaceEntity, 9},
     {{"faceLocation"}, "Face a location", cmdHandler_FaceLocation, 9},
     {{"movezone", "mz"}, "Move to a map id", cmdHandler_MoveZone, 9},
@@ -199,9 +203,11 @@ static const SlashCommand g_defined_slash_commands[] = {
     {{"doormsg"}, "Test Door Message. Fakes sending the client packet.", cmdHandler_DoorMessage, 9},
     {{"browser"}, "Test Browser. Sends content to a browser window", cmdHandler_Browser, 9},
 
+    {{"setu1"},"Set bitvalue u1. Used for live-debugging.", cmdHandler_SetU1, 9},
+
     /* Access Level 2 Commands */
-    {{"addNpc"},"add <npc_name> with costume [variation] in front of gm", addNpc, 2},
-    {{"moveTo"},"set the gm's position to <x> <y> <z>", moveTo, 2},
+    {{"addNpc"},"add <npc_name> with costume [variation] in front of gm", cmdHandler_AddNPC, 2},
+    {{"moveTo", "setpospyr"},"set the gm's position to <x> <y> <z>", cmdHandler_MoveTo, 2},
 
     /* Access Level 1 Commands */
     {{"cmdlist","commandlist"},"List all accessible commands", cmdHandler_CmdList, 1},
@@ -293,7 +299,7 @@ void cmdHandler_MoveZone(const QString &cmd, MapClientSession &sess)
     if (map_idx == getMapIndex(sess.m_current_map->name()))
         map_idx = (map_idx + 1) % 23;   // To prevent crashing if trying to access the map you're on.
     QString map_path = getMapPath(map_idx);
-    sess.link()->putq(new MapXferWait(map_path));  
+    sess.link()->putq(new MapXferWait(map_path));
 
     HandlerLocator::getMap_Handler(sess.is_connected_to_game_server_id)
         ->putq(new ClientMapXferMessage({sess.link()->session_token(), map_idx}, 0));
@@ -792,6 +798,20 @@ void cmdHandler_ToggleMoveInstantly(const QString &cmd, MapClientSession &sess)
     sendInfoMessage(MessageChannel::DEBUG_INFO, msg, sess);
 }
 
+void cmdHandler_AddTimeStateLog(const QString &cmd, MapClientSession &sess)
+{
+    int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
+
+    if(val == 0)
+        val = std::time(nullptr);
+
+    sendTimeStateLog(sess, val);
+
+    QString msg = "Set TimeStateLog to: " + QString::number(val);
+    qCDebug(logSlashCommand) << msg;
+    sendInfoMessage(MessageChannel::DEBUG_INFO, msg, sess);
+}
+
 void cmdHandler_SetClientState(const QString &cmd, MapClientSession &sess)
 {
     int val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
@@ -880,7 +900,7 @@ void cmdHandler_AddInspiration(const QString &cmd, MapClientSession &sess)
         // NOTE: floating message shows no message here, but plays the awarding insp sound!
         QString floating_msg = FloatingInfoMsg.find(FloatingMsg_FoundInspiration).value();
         sendFloatingInfo(sess, floating_msg, FloatingInfoStyle::FloatingInfo_Attention, 4.0);
-    } 
+    }
 
     qCDebug(logSlashCommand).noquote() << msg;
     sendInfoMessage(MessageChannel::DEBUG_INFO, msg, sess);
@@ -932,18 +952,6 @@ void cmdHandler_LevelUpXp(const QString &cmd, MapClientSession &sess)
     sendLevelUp(sess.m_ent);
 }
 
-// Slash commands for setting bit values
-void cmdHandler_SetU1(const QString &cmd, MapClientSession &sess)
-{
-    uint32_t val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
-
-    setu1(*sess.m_ent, val);
-
-    QString msg = "Set u1 to: " + QString::number(val);
-    qCDebug(logSlashCommand) << msg;
-    sendInfoMessage(MessageChannel::DEBUG_INFO, msg, sess);
-}
-
 void cmdHandler_FaceEntity(const QString &cmd, MapClientSession &sess)
 {
     Entity *tgt = nullptr;
@@ -965,6 +973,7 @@ void cmdHandler_FaceEntity(const QString &cmd, MapClientSession &sess)
     }
     sendFaceEntity(sess.m_ent, tgt->m_idx);
 }
+
 void cmdHandler_FaceLocation(const QString &cmd, MapClientSession &sess)
 {
     QVector<QStringRef> parts;
@@ -1025,10 +1034,22 @@ void cmdHandler_Browser(const QString &cmd, MapClientSession &sess)
     sendBrowser(sess, content);
 }
 
+// Slash commands for setting bit values
+void cmdHandler_SetU1(const QString &cmd, MapClientSession &sess)
+{
+    uint32_t val = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
+
+    setu1(*sess.m_ent, val);
+
+    QString msg = "Set u1 to: " + QString::number(val);
+    qCDebug(logSlashCommand) << msg;
+    sendInfoMessage(MessageChannel::DEBUG_INFO, msg, sess);
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Access Level 2 Commands
-void addNpc(const QString &cmd, MapClientSession &sess)
+void cmdHandler_AddNPC(const QString &cmd, MapClientSession &sess)
 {
     QVector<QStringRef> parts;
     int variation = 0;
@@ -1062,13 +1083,14 @@ void addNpc(const QString &cmd, MapClientSession &sess)
     }
     glm::vec3 offset = glm::vec3 {2,0,1};
     int idx = npc_store.npc_idx(npc_def);
+
     Entity *e = sess.m_current_map->m_entities.CreateNpc(*getMapServerData(),*npc_def,idx,variation);
     forcePosition(*e,gm_loc + offset);
     e->m_velocity = {0,0,0};
     sendInfoMessage(MessageChannel::DEBUG_INFO, QString("Created npc with ent idx:%1").arg(e->m_idx), sess);
 }
 
-void moveTo(const QString &cmd, MapClientSession &sess)
+void cmdHandler_MoveTo(const QString &cmd, MapClientSession &sess)
 {
     QVector<QStringRef> parts;
     parts = cmd.splitRef(' ');
@@ -1077,14 +1099,15 @@ void moveTo(const QString &cmd, MapClientSession &sess)
         qCDebug(logSlashCommand) << "Bad invocation:"<<cmd;
         sendInfoMessage(MessageChannel::USER_ERROR, "Bad invocation:"+cmd, sess);
     }
+
     glm::vec3 new_pos {
       parts[1].toFloat(),
       parts[2].toFloat(),
       parts[3].toFloat()
     };
+
     forcePosition(*sess.m_ent,new_pos);
     sendInfoMessage(MessageChannel::DEBUG_INFO, QString("New position set"), sess);
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1217,12 +1240,13 @@ void cmdHandler_SetSpecialTitle(const QString &cmd, MapClientSession &sess)
 void cmdHandler_Stuck(const QString &cmd, MapClientSession &sess)
 {
     // TODO: Implement true move-to-safe-location-nearby logic
-    forcePosition(*sess.m_ent,sess.m_current_map->closest_safe_location(sess.m_ent->m_entity_data.m_pos));
+    forcePosition(*sess.m_ent, sess.m_current_map->closest_safe_location(sess.m_ent->m_entity_data.m_pos));
 
-    QString msg = QString("Resetting location to default spawn <%L1, %L2, %L3>")
-                      .arg(sess.m_ent->m_entity_data.m_pos.x)
-                      .arg(sess.m_ent->m_entity_data.m_pos.y)
-                      .arg(sess.m_ent->m_entity_data.m_pos.z);
+    QString msg = QString("Resetting location to default spawn <%1, %2, %3>")
+            .arg(sess.m_ent->m_entity_data.m_pos.x, 0, 'f', 1)
+            .arg(sess.m_ent->m_entity_data.m_pos.y, 0, 'f', 1)
+            .arg(sess.m_ent->m_entity_data.m_pos.z, 0, 'f', 1);
+
     qCDebug(logSlashCommand) << cmd << ":" << msg;
     sendInfoMessage(MessageChannel::SERVER, msg, sess);
 }

--- a/Projects/CoX/Servers/MapServer/UnitTests/MapEventRegistry.cpp
+++ b/Projects/CoX/Servers/MapServer/UnitTests/MapEventRegistry.cpp
@@ -12,6 +12,7 @@ namespace
         "ActivateInspiration",
         "ActivatePower",
         "ActivatePowerAtLocation",
+        "AddTimeStateLog",
         "Browser",
         "BrowserClose",
         "BuyEnhancementSlot",

--- a/Projects/CoX/Servers/MapServer/UnitTests/MapEventRegistry.cpp
+++ b/Projects/CoX/Servers/MapServer/UnitTests/MapEventRegistry.cpp
@@ -81,6 +81,7 @@ namespace
         "TargetChatChannelSelected",
         "TeamLooking",
         "TeamOffer",
+        "TimeUpdate",
         "TradeCancel",
         "TradeInit",
         "TradeOffer",


### PR DESCRIPTION
## Summary
This PR pulls some of the features out of my Movement PR to simplify review and narrow the focus of #580 to movement related issues. I went ahead and added TimeUpdate as it may relate to syncing client with server when factoring latency

### Additions/modifications proposed in this pull request:
- Add AddTimeStateLog packet 60
- Add `/timestate` that takes an integer for control_log id
- Add TimeUpdate packet 48
- Add `/timeupdate` to test (no arguments)

### Related Issues
Relates to two tasks in #519 