### PR TITLE
NetStructures no longer uses any of the MapServer internals:

### DIFF
--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -491,4 +491,10 @@ int getEntityClassIndex(const GameDataStore &data, bool is_player, const QString
     return 0;
 }
 
+GameDataStore &getGameData() {
+    static GameDataStore instance;
+    return instance;
+}
+
 //! @}
+

--- a/Projects/CoX/Common/GameData/GameDataStore.h
+++ b/Projects/CoX/Common/GameData/GameDataStore.h
@@ -85,3 +85,4 @@ public:
 };
 int getEntityOriginIndex(const GameDataStore &data,bool is_player, const QString &origin_name);
 int getEntityClassIndex(const GameDataStore &data,bool is_player, const QString &class_name);
+extern GameDataStore& getGameData();

--- a/Projects/CoX/Common/GameData/keybind_definitions.cpp
+++ b/Projects/CoX/Common/GameData/keybind_definitions.cpp
@@ -12,6 +12,7 @@
 
 #include "keybind_definitions.h"
 
+#include "GameDataStore.h"
 #include "Logging.h"
 
 QString makeKeyString(const KeyName &key, const ModKeys &mods)
@@ -54,9 +55,6 @@ const CurrentKeybinds &KeybindSettings::getCurrentKeybinds() const
 
 void KeybindSettings::resetKeybinds(const Parse_AllKeyProfiles &default_profiles)
 {
-//    const MapServerData &data(g_GlobalMapServer->runtimeData());
-//    const Parse_AllKeyProfiles &default_profiles(data.m_keybind_profiles);
-
     m_keybind_profiles = default_profiles;
 }
 

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -100,8 +100,8 @@ void Character::sendTray(BitStream &bs) const
 
 void Character::finalizeLevel()
 {
-    GameDataStore *data = getMapServerData();
-    uint32_t max_xp = data->expMaxLevel();
+    GameDataStore &data(getGameData());
+    uint32_t max_xp = data.expMaxLevel();
 
     if (m_char_data.m_level >= 50)
         m_char_data.m_level = 0;// /levelup can set this negative, need to bring it up
@@ -111,12 +111,12 @@ void Character::finalizeLevel()
     if(m_char_data.m_combat_level >= max_xp)
         m_char_data.m_combat_level = max_xp - 1;
 
-    if(m_char_data.m_experience_points < data->expForLevel(m_char_data.m_combat_level))
-        m_char_data.m_experience_points = data->expForLevel(m_char_data.m_combat_level);
+    if(m_char_data.m_experience_points < data.expForLevel(m_char_data.m_combat_level))
+        m_char_data.m_experience_points = data.expForLevel(m_char_data.m_combat_level);
 
-    m_char_data.m_max_insp_rows = data->countForLevel(m_char_data.m_level, data->m_pi_schedule.m_InspirationRow);
-    m_char_data.m_max_insp_cols = data->countForLevel(m_char_data.m_level, data->m_pi_schedule.m_InspirationCol);
-    m_char_data.m_max_enhance_slots = data->countForLevel(m_char_data.m_level, data->m_pi_schedule.m_BoostSlot);
+    m_char_data.m_max_insp_rows = data.countForLevel(m_char_data.m_level, data.m_pi_schedule.m_InspirationRow);
+    m_char_data.m_max_insp_cols = data.countForLevel(m_char_data.m_level, data.m_pi_schedule.m_InspirationCol);
+    m_char_data.m_max_enhance_slots = data.countForLevel(m_char_data.m_level, data.m_pi_schedule.m_BoostSlot);
 
     // TODO: client will only accept 5col x 4row of insps MAX, see Issue #524
     assert(m_char_data.m_max_insp_cols <= 5 || m_char_data.m_max_insp_rows <= 4);

--- a/Projects/CoX/Common/NetStructures/Friend.h
+++ b/Projects/CoX/Common/NetStructures/Friend.h
@@ -32,6 +32,13 @@ static const constexpr  uint32_t    class_version   = 1;
                         std::vector<Friend> m_friends;
 };
 
+enum class FriendListChangeStatus
+{
+    FRIEND_ADDED,
+    FRIEND_REMOVED,
+    MAX_FRIENDS_REACHED,
+    FRIEND_NOT_FOUND,
+};
 
 /*
  * Friend Methods
@@ -39,7 +46,8 @@ static const constexpr  uint32_t    class_version   = 1;
 void toggleFriendList(Entity &src);
 void dumpFriends(const Entity &src);
 void dumpFriendsList(const Friend &f);
-void addFriend(Entity &src, const Entity &tgt);
-void removeFriend(Entity &src, QString friendName);
+
+FriendListChangeStatus addFriend(Entity &src, const Entity &tgt);
+FriendListChangeStatus removeFriend(Entity &src, QString friendName);
 
 const QString &getFriendDisplayMapName(const Friend &f);

--- a/Projects/CoX/Common/NetStructures/Powers.cpp
+++ b/Projects/CoX/Common/NetStructures/Powers.cpp
@@ -199,7 +199,7 @@ int getPowerCatByName(const QString &name)
 {
     int idx = 0;
 
-    for(const StoredPowerCategory &pcat : getMapServerData()->m_all_powers.m_categories)
+    for(const StoredPowerCategory &pcat : getGameData().m_all_powers.m_categories)
     {
         if(pcat.name.compare(name, Qt::CaseInsensitive) == 0)
             return idx;
@@ -215,7 +215,7 @@ int getPowerSetByName(const QString &name, uint32_t pcat_idx)
 {
     int idx = 0;
 
-    for(const Parse_PowerSet &pset : getMapServerData()->get_power_category(pcat_idx).m_PowerSets)
+    for(const Parse_PowerSet &pset : getGameData().get_power_category(pcat_idx).m_PowerSets)
     {
         if(pset.m_Name.compare(name, Qt::CaseInsensitive) == 0)
             return idx;
@@ -231,7 +231,7 @@ int getPowerByName(const QString &name, uint32_t pcat_idx, uint32_t pset_idx)
 {
     int idx = 0;
 
-    for(const Power_Data &pow : getMapServerData()->get_powerset(pcat_idx, pset_idx).m_Powers)
+    for(const Power_Data &pow : getGameData().get_powerset(pcat_idx, pset_idx).m_Powers)
     {
         if(pow.m_Name.compare(name, Qt::CaseInsensitive) == 0)
             return idx;
@@ -245,7 +245,7 @@ int getPowerByName(const QString &name, uint32_t pcat_idx, uint32_t pset_idx)
 
 CharacterPower getPowerData(PowerPool_Info &ppool)
 {
-    Power_Data power = getMapServerData()->get_power_template(ppool.m_pcat_idx, ppool.m_pset_idx, ppool.m_pow_idx);
+    Power_Data power = getGameData().get_power_template(ppool.m_pcat_idx, ppool.m_pset_idx, ppool.m_pow_idx);
 
     CharacterPower result;
     result.m_power_info.m_pcat_idx      = ppool.m_pcat_idx;
@@ -266,7 +266,7 @@ CharacterPower getPowerData(PowerPool_Info &ppool)
 CharacterPowerSet getPowerSetData(PowerPool_Info &ppool)
 {
     CharacterPowerSet result;
-    Parse_PowerSet powerset = getMapServerData()->get_powerset(ppool.m_pcat_idx, ppool.m_pset_idx);
+    Parse_PowerSet powerset = getGameData().get_powerset(ppool.m_pcat_idx, ppool.m_pset_idx);
 
     for(uint32_t pow_idx = 0; pow_idx < powerset.m_Powers.size(); ++pow_idx)
     {
@@ -448,7 +448,7 @@ void addInspirationByName(CharacterData &cd, QString &name)
     bool found  = false;
 
     int i = 0;
-    for(const Parse_PowerSet &pset : getMapServerData()->get_power_category(pcat_idx).m_PowerSets)
+    for(const Parse_PowerSet &pset : getGameData().get_power_category(pcat_idx).m_PowerSets)
     {
         int j = 0;
         for(const Power_Data &pow : pset.m_Powers)
@@ -665,7 +665,7 @@ void addEnhancementByName(CharacterData &cd, QString &name, uint32_t &level)
     }
 
     int i = 0;
-    for(const Parse_PowerSet &pset : getMapServerData()->get_power_category(pcat_idx).m_PowerSets)
+    for(const Parse_PowerSet &pset : getGameData().get_power_category(pcat_idx).m_PowerSets)
     {
         if(pset.m_Name.compare(name, Qt::CaseInsensitive) == 0)
         {
@@ -842,8 +842,8 @@ void reserveEnhancementSlot(CharacterData &cd, CharacterPower *pow)
         pow->m_total_eh_slots = 3;
 
     // Modify based upon level
-    pow->m_total_eh_slots = pow->m_total_eh_slots + getMapServerData()->countForLevel(
-                cd.m_combat_level - pow->m_level_bought, getMapServerData()->m_pi_schedule.m_FreeBoostSlotsOnPower);
+    pow->m_total_eh_slots = pow->m_total_eh_slots + getGameData().countForLevel(
+                cd.m_combat_level - pow->m_level_bought, getGameData().m_pi_schedule.m_FreeBoostSlotsOnPower);
 
 //    if(pow->m_enhancements.size() <= pow->m_total_eh_slots)
 //        pow->m_enhancements.resize(pow->m_total_eh_slots);
@@ -865,9 +865,9 @@ float enhancementCombineChances(CharacterEnhancement *eh1, CharacterEnhancement 
     qCDebug(logPowers) << "chance_idx" << chance_idx;
 
     if(eh1->m_enhance_tpl.parent_StoredPowerSet == eh2->m_enhance_tpl.parent_StoredPowerSet)
-        combine_chances = &getMapServerData()->m_combine_same.CombineChances;
+        combine_chances = &getGameData().m_combine_same.CombineChances;
     else
-        combine_chances = &getMapServerData()->m_combine_chances.CombineChances;
+        combine_chances = &getGameData().m_combine_chances.CombineChances;
 
     int chance_count = combine_chances->size();
     qCDebug(logPowers) << "combine_chances size" << chance_count;

--- a/Projects/CoX/Common/NetStructures/Powers.h
+++ b/Projects/CoX/Common/NetStructures/Powers.h
@@ -10,7 +10,6 @@
 #include "BitStream.h"
 #include "GameData/power_definitions.h"
 #include "GameData/GameDataStore.h"
-#include "Servers/MapServer/DataHelpers.h"
 
 #include <cereal/cereal.hpp>
 #include <QtCore/QString>
@@ -182,7 +181,7 @@ static const constexpr  uint32_t    class_version = 1;
 
         Power_Data getPowerTemplate() const
         {
-            return getMapServerData()->get_power_template(m_power_info.m_pcat_idx, m_power_info.m_pset_idx, m_power_info.m_pow_idx);
+            return getGameData().get_power_template(m_power_info.m_pcat_idx, m_power_info.m_pset_idx, m_power_info.m_pow_idx);
         }
 };
 

--- a/Projects/CoX/Common/NetStructures/Team.h
+++ b/Projects/CoX/Common/NetStructures/Team.h
@@ -51,13 +51,25 @@ bool inviteTeam(Entity &src, Entity &tgt);
 bool kickTeam(Entity &tgt);
 void leaveTeam(Entity &e);
 void removeTeamMember(Team &self,Entity *e);
-void findTeamMember(Entity &tgt);
-
+enum class SidekickChangeStatus
+{
+    SUCCESS,
+    GENERIC_FAILURE=1,
+    LEVEL_DIFFERENCE_TOO_HIGH,
+    MENTOR_LEVEL_TOO_LOW, // player level is not high enough
+    CANNOT_MENTOR_YET, // player level must be higher to have a sidekick
+    HAVE_SIDEKICK_ALREADY,
+    TARGET_IS_SIDEKICKING_ALREADY,
+    NO_TEAM_OR_SAME_TEAM_REQUIRED,
+    NOT_SIDEKICKED_CURRENTLY,
+};
 
 /*
  * Sidekick Methods -- Sidekick system requires teaming.
  */
+
+uint32_t getSidekickId(const class Character &src);
 bool isSidekickMentor(const Entity &e);
-void inviteSidekick(Entity &src, Entity &tgt);
+SidekickChangeStatus inviteSidekick(Entity &src, Entity &tgt);
 void addSidekick(Entity &tgt, Entity &src);
-void removeSidekick(Entity &src);
+SidekickChangeStatus removeSidekick(Entity &src, Entity *tgt);

--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -179,7 +179,7 @@ bool CreateServers()
               },"Starting game(1) server");
     TIMED_LOG({
                   g_map_server.reset(new MapServer(1));
-                  g_map_server->sett_game_server_owner(1);
+                  g_map_server->set_game_server_owner(1);
                   g_map_server->activate();
               },"Starting map server");
 

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -343,15 +343,6 @@ const QString &getOriginTitle(uint32_t val)
     return g_origin_titles.at(val);
 }
 
-
-/*
- * getMapServerData Wrapper to provide access to NetStructures
- */
-GameDataStore *getMapServerData()
-{
-    return &g_GlobalMapServer->runtimeData();
-}
-
 /*
  * sendInfoMessage wrapper to provide access to NetStructures
  */
@@ -630,5 +621,9 @@ void usePower(Entity &ent, uint32_t pset_idx, uint32_t pow_idx, uint32_t tgt_idx
     setHP(*target_ent->m_char, getHP(*target_ent->m_char)-damage);
 }
 
+void findTeamMember(Entity &tgt)
+{
+    sendTeamLooking(&tgt);
+}
 //! @}
 

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -90,12 +90,6 @@ const QString &getOriginTitle(uint32_t val);
 
 
 /*
- * getMapServerData Wrapper to provide access to NetStructures
- */
-GameDataStore *getMapServerData();
-
-
-/*
  * sendInfoMessage wrapper to provide access to NetStructures
  */
 void messageOutput(MessageChannel ch, const QString &msg, Entity &tgt);
@@ -140,3 +134,8 @@ void readEmailMessage(Entity *e, const int id);
  * usePower exposed for future Lua support
  */
 void usePower(Entity &ent, uint32_t pset_idx, uint32_t pow_idx, uint32_t tgt_idx, uint32_t tgt_id);
+
+/*
+ * Team related helpers
+ */
+void findTeamMember(Entity &tgt);

--- a/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
+++ b/Projects/CoX/Servers/MapServer/EntityUpdateCodec.cpp
@@ -256,7 +256,7 @@ void sendNetFx(const Entity &src,BitStream &bs)
 void sendCostumes(const Entity &src,BitStream &bs)
 {
     //NOTE: this will only be initialized once, and no changes later on will influence this
-    static const ColorAndPartPacker *packer = g_GlobalMapServer->runtimeData().getPacker();
+    static const ColorAndPartPacker *packer = getGameData().getPacker();
     PUTDEBUG("before sendCostumes");
     storePackedBitsConditional(bs,2,uint8_t(src.m_costume_type));
     switch(src.m_costume_type)

--- a/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
+++ b/Projects/CoX/Servers/MapServer/Events/EntitiesResponse.cpp
@@ -718,7 +718,7 @@ void EntitiesResponse::serializeto( BitStream &tgt ) const
     sendControlState(*this,tgt);// These are not client specific ?
     ent_manager.sendDeletes(tgt,*m_client);
     // Client specific part
-    sendClientData(mi->serverData(),*this,tgt);
+    sendClientData(getGameData(),*this,tgt);
     // Server messages follow the entity update.
     auto v= std::move(m_client->m_contents);
     for(const auto &command : v)

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -114,7 +114,7 @@ MapInstance::MapInstance(const QString &mapdir_path, const ListenAndLocationAddr
   : m_data_path(mapdir_path), m_index(getMapIndex(mapdir_path.mid(mapdir_path.indexOf('/')))),
     m_addresses(listen_addr)
 {
-    m_world = new World(m_entities, serverData().m_player_fade_in);
+    m_world = new World(m_entities, getGameData().m_player_fade_in);
     m_scripting_interface.reset(new ScriptingEngine);
     m_endpoint = new MapLinkEndpoint(m_addresses.m_listen_addr); //,this
     m_endpoint->set_downstream(this);
@@ -698,7 +698,7 @@ void MapInstance::on_expect_client( ExpectMapClientRequest *ev )
     // existing character
     Entity *ent = m_entities.CreatePlayer();
     toActualCharacter(char_data, *ent->m_char,*ent->m_player, *ent->m_entity);
-    ent->fillFromCharacter(serverData());
+    ent->fillFromCharacter(getGameData());
     ent->m_client = &map_session;
     map_session.m_ent = ent;
     // Now we inform our game server that this Map server instance is ready for the client
@@ -807,7 +807,7 @@ void MapInstance::on_create_map_entity(NewEntity *ev)
         QString ent_data;
         Entity *e = m_entities.CreatePlayer();
 
-        const GameDataStore &data(g_GlobalMapServer->runtimeData());
+        const GameDataStore &data(getGameData());
 
         fillEntityFromNewCharData(*e, ev->m_character_data, data);
         e->m_char->m_account_id = map_session.auth_id();
@@ -2237,11 +2237,6 @@ void MapInstance::on_remove_keybind(RemoveKeybind *ev)
     //qCDebug(logMapEvents) << "Clearing Keybind: " << ev->profile << QString::number(ev->key) << QString::number(ev->mods);
 }
 
-const GameDataStore &MapInstance::serverData() const
-{
-    return g_GlobalMapServer->runtimeData();
-}
-
 glm::vec3 MapInstance::closest_safe_location(glm::vec3 v) const
 {
     Q_UNUSED(v);
@@ -2263,7 +2258,7 @@ void MapInstance::serialize_to(ostream &/*is*/)
 }
 void MapInstance::on_reset_keybinds(ResetKeybinds *ev)
 {
-    const GameDataStore &data(g_GlobalMapServer->runtimeData());
+    const GameDataStore &data(getGameData());
     const Parse_AllKeyProfiles &default_profiles(data.m_keybind_profiles);
     MapClientSession &session(m_session_store.session_from_event(ev));
     Entity *ent = session.m_ent;
@@ -2375,7 +2370,7 @@ void MapInstance::on_browser_close(BrowserClose *ev)
 void MapInstance::on_afk_update()
 {
     const std::vector<MapClientSession *> &active_sessions (m_session_store.get_active_sessions());
-    const GameDataStore &data(g_GlobalMapServer->runtimeData());
+    const GameDataStore &data(getGameData());
     QString msg;
 
     for (const auto &sess : active_sessions)

--- a/Projects/CoX/Servers/MapServer/MapInstance.h
+++ b/Projects/CoX/Servers/MapServer/MapInstance.h
@@ -133,7 +133,6 @@ public:
         void                    dispatch(SEGSEvents::Event *ev) override;
 
         const QString &         name() const { return m_data_path; }
-        const GameDataStore &   serverData() const;
         bool                    spin_up_for(uint8_t game_server_id, uint32_t owner_id, uint32_t instance_id);
         void                    start(const QString &scenegraph_path);
         glm::vec3               closest_safe_location(glm::vec3 v) const;

--- a/Projects/CoX/Servers/MapServer/MapSceneGraph.cpp
+++ b/Projects/CoX/Servers/MapServer/MapSceneGraph.cpp
@@ -141,13 +141,13 @@ struct NpcCreator
         if(has_npc && map_instance)
         {
             qCDebug(logNPCs) << "Attempting to spawn npc" << persistent_name << "at" << v[3][0] << v[3][1] << v[3][2];
-            const NPCStorage & npc_store(map_instance->serverData().getNPCDefinitions());
+            const NPCStorage & npc_store(getGameData().getNPCDefinitions());
             QString npc_costume_name = convertNpcName(persistent_name);
             const Parse_NPC * npc_def = npc_store.npc_by_name(&npc_costume_name);
             if (npc_def)
             {
                 int idx = npc_store.npc_idx(npc_def);
-                Entity *e = map_instance->m_entities.CreateNpc(map_instance->serverData(),*npc_def, idx, 0);
+                Entity *e = map_instance->m_entities.CreateNpc(getGameData(),*npc_def, idx, 0);
                 forcePosition(*e,glm::vec3(v[3]));
                 auto valquat = glm::quat_cast(v);
 

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -147,12 +147,7 @@ MapManager &MapServer::map_manager()
     return d->m_manager;
 }
 
-GameDataStore &MapServer::runtimeData()
-{
-    return d->m_runtime_data;
-}
-
-void MapServer::sett_game_server_owner(uint8_t owner_id)
+void MapServer::set_game_server_owner(uint8_t owner_id)
 {
     m_owner_game_server_id = owner_id;
 }

--- a/Projects/CoX/Servers/MapServer/MapServer.h
+++ b/Projects/CoX/Servers/MapServer/MapServer.h
@@ -41,8 +41,7 @@ public:
 
         void                    per_thread_shutdown() override;
         MapManager &            map_manager();
-        GameDataStore &         runtimeData();
-        void                    sett_game_server_owner(uint8_t owner_id);
+        void                    set_game_server_owner(uint8_t owner_id);
         bool                    session_has_xfer_in_progress(uint64_t session_token);
         uint8_t                 session_map_xfer_idx(uint64_t session_token);
         void                    session_xfer_complete(uint64_t session_token);

--- a/Projects/CoX/Servers/MapServer/NpcGenerator.cpp
+++ b/Projects/CoX/Servers/MapServer/NpcGenerator.cpp
@@ -15,14 +15,14 @@ QString makeReadableName(QString &name)
 
 void NpcGenerator::generate(MapInstance *map_instance)
 {
-    const NPCStorage & npc_store(map_instance->serverData().getNPCDefinitions());
+    const NPCStorage & npc_store(getGameData().getNPCDefinitions());
     const Parse_NPC * npc_def = npc_store.npc_by_name(&costume_name);
     if (!npc_def)
         return;
     for(const glm::mat4 &v : initial_positions)
     {
         int idx = npc_store.npc_idx(npc_def);
-        Entity *e = map_instance->m_entities.CreateGeneric(map_instance->serverData(),*npc_def, idx, 0,type);
+        Entity *e = map_instance->m_entities.CreateGeneric(getGameData(),*npc_def, idx, 0,type);
         forcePosition(*e,glm::vec3(v[3]));
         auto valquat = glm::quat_cast(v);
 

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -1086,7 +1086,7 @@ void cmdHandler_AddNPC(const QString &cmd, MapClientSession &sess)
         return;
     }
     glm::vec3 gm_loc = sess.m_ent->m_entity_data.m_pos;
-    const NPCStorage & npc_store(sess.m_current_map->serverData().getNPCDefinitions());
+    const NPCStorage & npc_store(getGameData().getNPCDefinitions());
     const Parse_NPC * npc_def = npc_store.npc_by_name(parts[1]);
     if(!npc_def)
     {
@@ -1096,7 +1096,7 @@ void cmdHandler_AddNPC(const QString &cmd, MapClientSession &sess)
     glm::vec3 offset = glm::vec3 {2,0,1};
     int idx = npc_store.npc_idx(npc_def);
 
-    Entity *e = sess.m_current_map->m_entities.CreateNpc(*getMapServerData(),*npc_def,idx,variation);
+    Entity *e = sess.m_current_map->m_entities.CreateNpc(getGameData(),*npc_def,idx,variation);
     forcePosition(*e,gm_loc + offset);
     e->m_velocity = {0,0,0};
     sendInfoMessage(MessageChannel::DEBUG_INFO, QString("Created npc with ent idx:%1").arg(e->m_idx), sess);
@@ -1397,15 +1397,73 @@ void cmdHandler_Sidekick(const QString &cmd, MapClientSession &sess)
         return;
     }
 
-    inviteSidekick(*sess.m_ent, *tgt);
+    auto res=inviteSidekick(*sess.m_ent, *tgt);
+    static const QLatin1Literal possible_messages[] = {
+        QLatin1String("Unable to add sidekick."),
+        QLatin1String("To Mentor another player, you must be at least 3 levels higher than them."),
+        QLatin1String("To Mentor another player, you must be at least level 10."),
+        QLatin1String("You are already Mentoring someone."),
+        QLatin1String("Target is already a sidekick."),
+        QLatin1String("To Mentor another player, you must be on the same team."),
+    };
+    if(res==SidekickChangeStatus::SUCCESS)
+    {
+        // sendSidekickOffer
+        sendSidekickOffer(tgt, sess.m_ent->m_db_id); // tgt gets dialog, src.db_id is named.
+    }
+    else
+    {
+        qCDebug(logTeams).noquote() << possible_messages[int(res)-1];
+        messageOutput(MessageChannel::USER_ERROR, possible_messages[int(res)-1], *sess.m_ent);
+    }
 }
 
 void cmdHandler_UnSidekick(const QString &/*cmd*/, MapClientSession &sess)
 {
     if(sess.m_ent->m_char->isEmpty())
         return;
+    QString msg;
 
-    removeSidekick(*sess.m_ent);
+    uint32_t sidekick_id = getSidekickId(*sess.m_ent->m_char);
+    Entity *tgt = getEntityByDBID(sess.m_current_map,sidekick_id);
+    auto res = removeSidekick(*sess.m_ent,tgt);
+    if(res==SidekickChangeStatus::GENERIC_FAILURE)
+    {
+        msg = "You are not sidekicked with anyone.";
+        qCDebug(logTeams).noquote() << msg;
+        messageOutput(MessageChannel::USER_ERROR, msg, *sess.m_ent);
+    }
+    else if(res==SidekickChangeStatus::SUCCESS)
+    {
+        QString tgt_name = tgt ? tgt->name() : "Unknown Player";
+        if(isSidekickMentor(*sess.m_ent))
+        {
+            // src is mentor, tgt is sidekick
+            msg = QString("You are no longer mentoring %1.").arg(tgt_name);
+            messageOutput(MessageChannel::TEAM, msg, *sess.m_ent);
+            if(tgt)
+            {
+                msg = QString("%1 is no longer mentoring you.").arg(sess.m_ent->name());
+                messageOutput(MessageChannel::TEAM, msg, *tgt);
+            }
+        }
+        else
+        {
+            // src is sidekick, tgt is mentor
+            if(tgt)
+            {
+                msg = QString("You are no longer mentoring %1.").arg(sess.m_ent->name());
+                messageOutput(MessageChannel::TEAM, msg, *tgt);
+            }
+            msg = QString("%1 is no longer mentoring you.").arg(tgt_name);
+            messageOutput(MessageChannel::TEAM, msg, *sess.m_ent);
+        }
+    }
+    else if(res==SidekickChangeStatus::NOT_SIDEKICKED_CURRENTLY)
+    {
+        msg = QString("You are no longer sidekicked with anyone.");
+        messageOutput(MessageChannel::USER_ERROR, msg, *sess.m_ent);
+    }
 }
 
 void cmdHandler_TeamBuffs(const QString & /*cmd*/, MapClientSession &sess)
@@ -1424,7 +1482,21 @@ void cmdHandler_Friend(const QString &cmd, MapClientSession &sess)
         return;
     }
 
-    addFriend(*sess.m_ent, *tgt);
+    FriendListChangeStatus status = addFriend(*sess.m_ent, *tgt);
+    if(status==FriendListChangeStatus::MAX_FRIENDS_REACHED)
+    {
+        QString msg = "You cannot have more than " + QString::number(g_max_friends) + " friends.";
+        qCDebug(logFriends).noquote() << msg;
+        messageOutput(MessageChannel::USER_ERROR, msg, *sess.m_ent);
+    }
+    else
+    {
+        QString msg = "Adding " + tgt->name() + " to your friendlist.";
+        qCDebug(logFriends).noquote() << msg;
+        messageOutput(MessageChannel::FRIENDS, msg, *sess.m_ent);
+        // Send FriendsListUpdate
+        sendFriendsListUpdate(sess.m_ent, sess.m_ent->m_char->m_char_data.m_friendlist);
+    }
 }
 
 void cmdHandler_Unfriend(const QString &cmd, MapClientSession &sess)
@@ -1441,7 +1513,20 @@ void cmdHandler_Unfriend(const QString &cmd, MapClientSession &sess)
         name = tgt->name();
     }
 
-    removeFriend(*sess.m_ent, name);
+    FriendListChangeStatus status =  removeFriend(*sess.m_ent, name);
+    if(status==FriendListChangeStatus::FRIEND_REMOVED)
+    {
+        QString msg = "Removing " + name + " from your friends list.";
+        messageOutput(MessageChannel::FRIENDS, msg, *sess.m_ent);
+
+        // Send FriendsListUpdate
+        sendFriendsListUpdate(sess.m_ent, sess.m_ent->m_char->m_char_data.m_friendlist);
+    }
+    else
+    {
+        QString msg = name + " is not on your friends list.";
+        messageOutput(MessageChannel::USER_ERROR, msg, *sess.m_ent);
+    }
 }
 
 void cmdHandler_FriendList(const QString &/*cmd*/, MapClientSession &sess)
@@ -1569,6 +1654,11 @@ void cmdHandler_SidekickAccept(const QString &/*cmd*/, MapClientSession &sess)
         return;
 
     addSidekick(*sess.m_ent,*tgt);
+    // Send message to each player
+    QString msg = QString("You are now Mentoring %1.").arg(tgt->name()); // Customize for src.
+    messageOutput(MessageChannel::TEAM, msg, *sess.m_ent);
+    msg = QString("%1 is now Mentoring you.").arg(sess.m_ent->name()); // Customize for src.
+    messageOutput(MessageChannel::TEAM, msg, *tgt);
 }
 
 void cmdHandler_SidekickDecline(const QString &/*cmd*/, MapClientSession &sess)

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -34,6 +34,7 @@
 #include <QtCore/QFileInfo>
 #include <QRegularExpression>
 #include <QtCore/QDebug>
+#include <ctime>
 
 using namespace SEGSEvents;
 


### PR DESCRIPTION
* GameData became a singleton
* Team and Friend support functions return their status as enums and the
caller is responsible for proper reporting.

This should fix some of the 'random' linking problems we sometimes encounter.