### PR TITLE
get maxHP from classes.bin and cleaned up combat level

### DIFF
--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -257,14 +257,14 @@ bool GameDataStore::read_runtime_data(const QString &directory_path)
 
 uint32_t GameDataStore::expForLevel(uint32_t lev) const
 {
-    assert(lev>0 && lev<m_experience_and_debt_per_level.m_ExperienceRequired.size());
-    return m_experience_and_debt_per_level.m_ExperienceRequired.at(lev - 1);
+    assert(lev>=0 && lev<m_experience_and_debt_per_level.m_ExperienceRequired.size());
+    return m_experience_and_debt_per_level.m_ExperienceRequired.at(lev);
 }
 
 uint32_t GameDataStore::expDebtForLevel(uint32_t lev) const
 {
-    assert(lev>0 && lev<m_experience_and_debt_per_level.m_DefeatPenalty.size());
-    return m_experience_and_debt_per_level.m_DefeatPenalty.at(lev - 1);
+    assert(lev>=0 && lev<m_experience_and_debt_per_level.m_DefeatPenalty.size());
+    return m_experience_and_debt_per_level.m_DefeatPenalty.at(lev);
 }
 
 uint32_t GameDataStore::expMaxLevel() const

--- a/Projects/CoX/Common/GameData/chardata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/chardata_serializers.cpp
@@ -191,7 +191,7 @@ void serialize(Archive &archive, CharacterData &cd, uint32_t const version)
     }
 
     archive(cereal::make_nvp("Level",cd.m_level));
-    archive(cereal::make_nvp("CombatLevel",cd.m_combat_level+1));
+    archive(cereal::make_nvp("CombatLevel",cd.m_combat_level));
     archive(cereal::make_nvp("XP",cd.m_experience_points));
     archive(cereal::make_nvp("Debt",cd.m_experience_debt));
     archive(cereal::make_nvp("PatrolXP",cd.m_experience_patrol));

--- a/Projects/CoX/Common/GameData/chardata_serializers.cpp
+++ b/Projects/CoX/Common/GameData/chardata_serializers.cpp
@@ -191,7 +191,7 @@ void serialize(Archive &archive, CharacterData &cd, uint32_t const version)
     }
 
     archive(cereal::make_nvp("Level",cd.m_level));
-    archive(cereal::make_nvp("CombatLevel",cd.m_combat_level));
+    archive(cereal::make_nvp("CombatLevel",cd.m_combat_level+1));
     archive(cereal::make_nvp("XP",cd.m_experience_points));
     archive(cereal::make_nvp("Debt",cd.m_experience_debt));
     archive(cereal::make_nvp("PatrolXP",cd.m_experience_patrol));

--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -106,8 +106,8 @@ void Character::finalizeLevel()
     if(m_char_data.m_level > max_level)
         m_char_data.m_level = max_level - 1;
 
-    if(m_char_data.m_experience_points < data.expForLevel(m_char_data.m_combat_level))
-        m_char_data.m_experience_points = data.expForLevel(m_char_data.m_combat_level);
+    if(m_char_data.m_experience_points < data.expForLevel(m_char_data.m_level))
+        m_char_data.m_experience_points = data.expForLevel(m_char_data.m_level);
 
     m_char_data.m_max_insp_rows = data.countForLevel(m_char_data.m_level, data.m_pi_schedule.m_InspirationRow);
     m_char_data.m_max_insp_cols = data.countForLevel(m_char_data.m_level, data.m_pi_schedule.m_InspirationCol);

--- a/Projects/CoX/Common/NetStructures/Character.h
+++ b/Projects/CoX/Common/NetStructures/Character.h
@@ -81,6 +81,7 @@ const   QString &       getName() const { return m_name; }
         void            addStartingInspirations(QStringList &starting_insps);
         void            getStartingPowers(const QString &pcat_name, const QString &pset_name, const QStringList &power_names);
         void            getPowerFromBuildInfo(BitStream &src);
+        void            getMaxAttribs(const GameDataStore &data);
         void            sendEnhancements(BitStream &bs) const;
         void            sendInspirations(BitStream &bs) const;
         void            GetCharBuildInfo(BitStream &src); // serialize from char creation

--- a/Projects/CoX/Common/NetStructures/CharacterHelpers.cpp
+++ b/Projects/CoX/Common/NetStructures/CharacterHelpers.cpp
@@ -27,16 +27,16 @@ const QString &     getAlignment(const Character &c) { return c.m_char_data.m_al
 // Setters
 void setLevel(Character &c, uint32_t val)
 {
-    if(val>50)
-        val = 50;
-    c.m_char_data.m_level = val - 1; // client stores lvl arrays starting at 0
+    if(val>49)
+        val = 49;
+    c.m_char_data.m_level = val; // client stores lvl arrays starting at 0
     // TODO: run finalizelevel here, but requires MapClientSession
 }
 
 void setCombatLevel(Character &c, uint32_t val)
 {
-    if(val>50)
-        val = 50;
+    if(val>49)
+        val = 49;
     c.m_char_data.m_combat_level = val;
 }
 

--- a/Projects/CoX/Common/NetStructures/Powers.cpp
+++ b/Projects/CoX/Common/NetStructures/Powers.cpp
@@ -843,7 +843,7 @@ void reserveEnhancementSlot(CharacterData &cd, CharacterPower *pow)
 
     // Modify based upon level
     pow->m_total_eh_slots = pow->m_total_eh_slots + getMapServerData()->countForLevel(
-                cd.m_combat_level - pow->m_level_bought, getMapServerData()->m_pi_schedule.m_FreeBoostSlotsOnPower);
+                cd.m_level - pow->m_level_bought, getMapServerData()->m_pi_schedule.m_FreeBoostSlotsOnPower);
 
 //    if(pow->m_enhancements.size() <= pow->m_total_eh_slots)
 //        pow->m_enhancements.resize(pow->m_total_eh_slots);

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -519,26 +519,26 @@ void cmdHandler_SetInf(const QString &cmd, MapClientSession &sess)
 
 void cmdHandler_SetLevel(const QString &cmd, MapClientSession &sess)
 {
-    uint32_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
+    uint32_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt()-1; // convert from 1-50 to 0-49
 
-    setLevel(*sess.m_ent->m_char, attrib); // TODO: Why does this result in -1?
+    setLevel(*sess.m_ent->m_char, attrib);
     sess.m_ent->m_char->finalizeLevel();
 
     QString contents = FloatingInfoMsg.find(FloatingMsg_Leveled).value();
     sendFloatingInfo(sess, contents, FloatingInfoStyle::FloatingInfo_Attention, 4.0);
 
-    QString msg = "Setting Level to: " + QString::number(attrib);
+    QString msg = "Setting Level to: " + QString::number(attrib + 1);
     qCDebug(logSlashCommand) << msg;
     sendInfoMessage(MessageChannel::DEBUG_INFO, msg, sess);
 }
 
 void cmdHandler_SetCombatLevel(const QString &cmd, MapClientSession &sess)
 {
-    uint32_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
+    uint32_t attrib = cmd.midRef(cmd.indexOf(' ')+1).toUInt()-1; // convert from 1-50 to 0-49
 
-    setCombatLevel(*sess.m_ent->m_char, attrib); // TODO: Why does this result in -1?
+    setCombatLevel(*sess.m_ent->m_char, attrib);
 
-    QString msg = "Setting Combat Level to: " + QString::number(attrib);
+    QString msg = "Setting Combat Level to: " + QString::number(attrib+1);
     qCDebug(logSlashCommand) << msg;
     sendInfoMessage(MessageChannel::DEBUG_INFO, msg, sess);
 }
@@ -563,7 +563,7 @@ void cmdHandler_DebugChar(const QString &/*cmd*/, MapClientSession &sess)
             + "\n  idx: " + QString::number(sess.m_ent->m_idx)
             + "\n  access: " + QString::number(sess.m_ent->m_entity_data.m_access_level)
             + "\n  acct: " + QString::number(chardata.m_account_id)
-            + "\n  lvl/clvl: " + QString::number(chardata.m_char_data.m_level) + "/" + QString::number(chardata.m_char_data.m_combat_level)
+            + "\n  lvl/clvl: " + QString::number(chardata.m_char_data.m_level+1) + "/" + QString::number(chardata.m_char_data.m_combat_level+1)
             + "\n  inf: " + QString::number(chardata.m_char_data.m_influence)
             + "\n  xp/debt: " + QString::number(chardata.m_char_data.m_experience_points) + "/" + QString::number(chardata.m_char_data.m_experience_debt)
             + "\n  lfg: " + QString::number(chardata.m_char_data.m_lfg)
@@ -913,7 +913,7 @@ void cmdHandler_AddEnhancement(const QString &cmd, MapClientSession &sess)
     CharacterData &cd = sess.m_ent->m_char->m_char_data;
     QVector<QStringRef> args(cmd.splitRef(' '));
     QString name = args.value(1).toString();
-    uint32_t level = args.value(2).toInt();
+    uint32_t level = args.value(2).toUInt() -1;
     QString msg = "You do not have room for any more enhancements!";
 
     if(args.size() < 3)
@@ -938,11 +938,11 @@ void cmdHandler_AddEnhancement(const QString &cmd, MapClientSession &sess)
 
 void cmdHandler_LevelUpXp(const QString &cmd, MapClientSession &sess)
 {
-    uint32_t level = cmd.midRef(cmd.indexOf(' ')+1).toUInt();
+    uint32_t level = cmd.midRef(cmd.indexOf(' ')+1).toUInt() -1; // convert from 1-50 to 0-49
 
     // levelup command appears to only work 1 level at a time.
-    if(level > sess.m_ent->m_char->m_char_data.m_level+1)
-        level = sess.m_ent->m_char->m_char_data.m_level + 1;
+    if(level > sess.m_ent->m_char->m_char_data.m_level)
+        level = sess.m_ent->m_char->m_char_data.m_level;
 
     setLevel(*sess.m_ent->m_char, level);
     sess.m_ent->m_char->finalizeLevel();


### PR DESCRIPTION
Closes #502.

Gets maxHP and maxEnd from AttribMaxTable, and sets based on class/archetype and level.
Also cleared up some more uses of combat_level, and changed it to be 0-49 for consistency with level.

The hp values are a little off from what the wiki lists, but these are the values in classes.bin.

At a latter date, AttribMaxTable could be overwritten from a cfg/lua file to customize the values.