### PR TITLE
Use a game data singleton in MapServer instead of it's own instance.

### DIFF
--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -205,6 +205,13 @@ bool read_data_to(const QString &directory_path,const QString &storage,TARGET &t
 
 GameDataStore::GameDataStore()
 {
+    static bool was_created = false;
+    if(!was_created)
+        was_created = true;
+    else
+    {
+        qCritical() << "Multiple instances of GameDataStore created in a single process, expect trouble";
+    }
     packer_instance = new HashBasedPacker;
 }
 

--- a/Projects/CoX/Servers/MapServer/MapServer.cpp
+++ b/Projects/CoX/Servers/MapServer/MapServer.cpp
@@ -49,7 +49,6 @@ namespace
 class MapServer::PrivateData
 {
 public:
-        GameDataStore   m_runtime_data;
         MapManager      m_manager;
 };
 
@@ -70,7 +69,7 @@ bool MapServer::Run()
 {
     assert(m_owner_game_server_id != INVALID_GAME_SERVER_ID);
 
-    if (!d->m_runtime_data.read_runtime_data(RUNTIME_DATA_PATH))
+    if (!getGameData().read_runtime_data(RUNTIME_DATA_PATH))
         return false;
 
     assert(d->m_manager.num_templates() > 0);
@@ -118,7 +117,7 @@ bool MapServer::ReadConfigAndRestart()
 
     bool ok = true;
     QVariant fade_in_variant = config.value("player_fade_in","380.0");
-    d->m_runtime_data.m_player_fade_in = fade_in_variant.toFloat(&ok);
+    getGameData().m_player_fade_in = fade_in_variant.toFloat(&ok);
     if(!ok)
     {
         qCritical() << "Badly formed float for 'player_fade_in': " << fade_in_variant.toString();


### PR DESCRIPTION
Report multiple instantiations of GameDataStore.
