### PR TITLE
Waypoints implementation with slash command to test `/setwaypoint`

### DIFF
--- a/Projects/CoX/Common/NetStructures/Entity.h
+++ b/Projects/CoX/Common/NetStructures/Entity.h
@@ -99,6 +99,12 @@ enum class FadeDirection
     Out
 };
 
+struct Destination // aka waypoint
+{
+    int point_idx = 0;
+    glm::vec3 location;
+};
+
 // returned by getEntityFromDB()
 struct CharacterFromDB
 {
@@ -305,6 +311,7 @@ public:
         MapClientSession *  m_client                    = nullptr;
         FadeDirection       m_fading_direction          = FadeDirection::In;
         uint32_t            m_db_store_flags            = 0;
+        Destination         m_cur_destination;
 
         void                dump();
         void                addPosUpdate(const PosUpdate &p);

--- a/Projects/CoX/Servers/MapServer/CMakeLists.txt
+++ b/Projects/CoX/Servers/MapServer/CMakeLists.txt
@@ -93,6 +93,7 @@ SET(target_INCLUDE
     Events/TrayAdd.h
     Events/InfoMessageCmd.h
     Events/InteractWithEntity.h
+    Events/Waypoints.h
     Events/WindowState.h
     NpcGenerator.h
     MapEventFactory.h

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -43,6 +43,7 @@ glm::vec3   getSpeed(const Entity &e) { return e.m_spd; }
 float       getBackupSpd(const Entity &e) { return e.m_backup_spd; }
 float       getJumpHeight(const Entity &e) { return e.m_jump_height; }
 uint8_t     getUpdateId(const Entity &e) { return e.m_update_id; }
+Destination getCurrentDestination(const Entity &e) { return e.m_cur_destination; }
 
 // Setters
 void    setDbId(Entity &e, uint8_t val) { e.m_char->m_db_id = val; e.m_db_id = val; }
@@ -128,6 +129,12 @@ void setAssistTarget(Entity &e)
     e.m_assist_target_idx = getTargetIdx(*target_ent);
 
     qCDebug(logTarget) << "Assist Target is:" << getAssistTargetIdx(e);
+}
+
+void setCurrentDestination(Entity &e, int point_idx, glm::vec3 location)
+{
+    e.m_cur_destination.point_idx = point_idx;
+    e.m_cur_destination.location = location;
 }
 
 // For live debugging
@@ -536,6 +543,17 @@ void sendContactDialogClose(MapClientSession &src)
 {
     qCDebug(logSlashCommand) << "Sending ContactDialogClose";
     src.addCommand<ContactDialogClose>();
+}
+
+void sendWaypoint(MapClientSession &src, int point_idx, glm::vec3 location)
+{
+    qCDebug(logSlashCommand) << QString("Sending SendWaypoint: %1 <%2, %3, %4>")
+                                .arg(point_idx)
+                                .arg(location.x, 0, 'f', 1)
+                                .arg(location.y, 0, 'f', 1)
+                                .arg(location.z, 0, 'f', 1);
+
+    src.addCommand<SendWaypoint>(point_idx, location);
 }
 
 

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -27,6 +27,7 @@ struct CharacterPower;
 class GameDataStore;
 class TradeMember;
 struct ContactEntry;
+struct Destination;
 
 
 /*
@@ -42,6 +43,7 @@ glm::vec3   getSpeed(const Entity &e);
 float       getBackupSpd(const Entity &e);
 float       getJumpHeight(const Entity &e);
 uint8_t     getUpdateId(const Entity &e);
+Destination getCurrentDestination(const Entity &e);
 
 // Setters
 void    setDbId(Entity &e, uint8_t val);
@@ -54,6 +56,7 @@ void    setTeamID(Entity &e, uint8_t team_id);
 void    setSuperGroup(Entity &e, int sg_id = 0, QString sg_name = "", uint32_t sg_rank = 3);
 void    setTarget(Entity &e, uint32_t target_idx);
 void    setAssistTarget(Entity &e);
+void    setCurrentDestination(Entity &e, int point_idx, glm::vec3 location);
 
 // For live debugging
 void    setu1(Entity &e, int val);
@@ -126,6 +129,7 @@ void sendTradeSuccess(Entity& src, Entity& tgt);
 void sendContactDialog(MapClientSession &src, QString msg_body, std::vector<ContactEntry> active_contacts);
 void sendContactDialogYesNoOk(MapClientSession &src, QString msg_body, bool has_yesno);
 void sendContactDialogClose(MapClientSession &src);
+void sendWaypoint(MapClientSession &src, int point_idx, glm::vec3 location);
 
 
 /*

--- a/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
+++ b/Projects/CoX/Servers/MapServer/Events/GameCommandList.h
@@ -33,4 +33,5 @@
 #include "Events/TeamOffer.h"
 #include "Events/TimeUpdate.h"
 #include "Events/TrayAdd.h"
+#include "Waypoints.h"
 

--- a/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
+++ b/Projects/CoX/Servers/MapServer/Events/MapEventTypes.h
@@ -42,7 +42,7 @@ enum MapEventTypes
     EVENT_DECL(MapEventTypes, evChatMessage                ,120)
     EVENT_DECL(MapEventTypes, evFloatingDamage             ,121)
 //    EVENT_DECL(MapEventTypes, evVisitMapCells            ,122)
-//    EVENT_DECL(MapEventTypes, evSendWaypoint             ,123)
+    EVENT_DECL(MapEventTypes, evSendWaypoint               ,123)
     EVENT_DECL(MapEventTypes, evTeamOffer                  ,124)
     EVENT_DECL(MapEventTypes, evTeamLooking                ,125)
 //    EVENT_DECL(MapEventTypes, evTaskForceKick            ,126)

--- a/Projects/CoX/Servers/MapServer/Events/Waypoints.h
+++ b/Projects/CoX/Servers/MapServer/Events/Waypoints.h
@@ -1,0 +1,69 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.io/
+ * Copyright (c) 2006 - 2018 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+
+#pragma once
+#include "GameCommand.h"
+#include "MapEventTypes.h"
+#include <glm/vec3.hpp>
+
+namespace SEGSEvents
+{
+
+// [[ev_def:type]]
+class SendWaypoint final : public GameCommandEvent
+{
+public:
+    // [[ev_def:field]]
+    int m_point_idx; // maybe?
+    // [[ev_def:field]]
+    glm::vec3 m_location;
+
+    explicit SendWaypoint() : GameCommandEvent(evSendWaypoint) {}
+    SendWaypoint(int point_idx, glm::vec3 location) : GameCommandEvent(evSendWaypoint),
+        m_point_idx(point_idx),
+        m_location(location)
+    {
+    }
+    void    serializeto(BitStream &bs) const override
+    {
+        bs.StorePackedBits(1,type()-evFirstServerToClient); // pkt 23
+        bs.StorePackedBits(1, m_point_idx);
+        bs.StoreFloat(m_location.x);
+        bs.StoreFloat(m_location.y);
+        bs.StoreFloat(m_location.z);
+    }
+
+    EVENT_IMPL(SendWaypoint)
+};
+
+// [[ev_def:type]]
+class SetDestination final : public MapLinkEvent
+{
+public:
+    // [[ev_def:field]]
+    glm::vec3 destination;
+    // [[ev_def:field]]
+    int point_index;
+
+    SetDestination():MapLinkEvent(MapEventTypes::evSetDestination)
+    {}
+    void serializeto(BitStream &bs) const override
+    {
+        bs.StorePackedBits(1,11);
+        qWarning() << "SetDestination serializeto unimplemented.";
+    }
+    void serializefrom(BitStream &bs) override
+    {
+        destination.x = bs.GetFloat();
+        destination.y = bs.GetFloat();
+        destination.z = bs.GetFloat();
+        point_index   = bs.GetPackedBits(1);
+    }
+    EVENT_IMPL(SetDestination)
+};
+
+} // end of SEGSEvents namespace

--- a/Projects/CoX/Servers/MapServer/MapEvents.h
+++ b/Projects/CoX/Servers/MapServer/MapEvents.h
@@ -389,34 +389,6 @@ public:
 };
 
 // [[ev_def:type]]
-class SetDestination final : public MapLinkEvent
-{
-public:
-    // [[ev_def:field]]
-    glm::vec3 destination;
-    // [[ev_def:field]]
-    int point_index;
-    SetDestination():MapLinkEvent(MapEventTypes::evSetDestination)
-    {}
-    void serializeto(BitStream &bs) const override
-    {
-        bs.StorePackedBits(1,11);
-        bs.StoreFloat(destination.x);
-        bs.StoreFloat(destination.y);
-        bs.StoreFloat(destination.z);
-        bs.StorePackedBits(1,point_index);
-    }
-    void serializefrom(BitStream &bs) override
-    {
-        destination.x = bs.GetFloat();
-        destination.y = bs.GetFloat();
-        destination.z = bs.GetFloat();
-        point_index   = bs.GetPackedBits(1);
-    }
-    EVENT_IMPL(SetDestination)
-};
-
-// [[ev_def:type]]
 class DialogButton final : public MapLinkEvent
 {
 public:
@@ -917,3 +889,4 @@ public:
 #include "Events/TradeUpdate.h"
 #include "Events/TradeWasCancelledMessage.h"
 #include "Events/TradeWasUpdatedMessage.h"
+#include "Events/Waypoints.h"

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -1113,7 +1113,7 @@ void cmdHandler_SendWaypoint(const QString &cmd, MapClientSession &sess)
     }
 
     Destination cur_dest = getCurrentDestination(*sess.m_ent);
-    int idx = cur_dest.point_idx + 1;
+    int idx = cur_dest.point_idx; // client will only change waypoint if idx == client_side_idx
 
     glm::vec3 loc {
       parts[1].toFloat(),


### PR DESCRIPTION
Relates to #519 

Additions/modifications proposed in this pull request:
- SendWaypoints event
- `/setwaypoint` to test. NOTE: client will only set waypoint if the idx is equal to the client-side idx. This creates a small issue where you cannot simply set a waypoint without one having been set already. In the future, we'll be able to do with with Tasks or Contacts. Right now, the only mechanism for doing so with in the UI (clicking on the map)
- Cleaned up a couple of small bugs in slashcommands
- Moved SetDestination to Waypoints.h for organization 
