### PR TITLE
Testing cache theory on appveyor. Iterated version number

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.4.{build}
+version: 0.5.{build}
 image: Visual Studio 2017
 
 platform: x64
@@ -18,6 +18,10 @@ branches:
   only:
   - master
   - develop
+
+# preserve "3rd_party" directory in the root of build folder but will reset it if 3rd_party CMakeLists.txt is modified
+cache:
+  - 3rd_party -> **3rd_party\CMakeLists.txt
 
 configuration: Release
 shallow_clone: true


### PR DESCRIPTION
Appveyor fails due to timeout. See if caching will fix that.

Also, iterate version number to v5, as we're cool like that
