### PR TITLE
Fix spawning at 0,0,0, height and physique, and no hp or end bugs

### DIFF
--- a/Projects/CoX/Common/NetStructures/Character.cpp
+++ b/Projects/CoX/Common/NetStructures/Character.cpp
@@ -655,6 +655,8 @@ bool toActualCharacter(const GameAccountResponseCharacterData &src,
         toActualCostume(costume, main_costume);
         // appearance related.
         main_costume.m_body_type = src.m_costumes.back().m_body_type;
+        main_costume.m_height = src.m_costumes.back().m_height;
+                main_costume.m_physique = src.m_costumes.back().m_physique;
         main_costume.setSlotIndex(costume.m_slot_index);
         main_costume.setCharacterId(costume.m_character_id);
     }
@@ -692,10 +694,10 @@ bool fromActualCharacter(const Character &src,const PlayerData &player,
         fromActualCostume(costume, main_costume);
         // appearance related.
         main_costume.m_body_type = src.m_costumes.back().m_body_type;
-        main_costume.m_slot_index = costume.getSlotIndex();
-        main_costume.m_character_id= costume.getCharacterId();
         main_costume.m_height = costume.m_height;
         main_costume.m_physique = costume.m_physique;
+        main_costume.m_slot_index = costume.getSlotIndex();
+        main_costume.m_character_id= costume.getCharacterId();
     }
     return true;
 }

--- a/Projects/CoX/Common/NetStructures/Movement.cpp
+++ b/Projects/CoX/Common/NetStructures/Movement.cpp
@@ -62,6 +62,13 @@ void forcePosition(Entity &e, glm::vec3 pos)
     e.m_full_update_count = 10;
 }
 
+void forceOrientation(Entity &e, glm::vec3 pyr)
+{
+    e.m_direction = glm::quat(pyr);
+    e.m_entity_data.m_orientation_pyr = pyr;
+    e.m_force_pos_and_cam = true;
+}
+
 // Move to Sequences or Triggers files later
 void addTriggeredMove(Entity &e, uint32_t move_idx, uint32_t delay, uint32_t fx_idx)
 {

--- a/Projects/CoX/Common/NetStructures/Movement.h
+++ b/Projects/CoX/Common/NetStructures/Movement.h
@@ -88,6 +88,7 @@ enum MoveType
 void addPosUpdate(Entity &e, const PosUpdate &p);
 void addInterp(const PosUpdate & p);
 void forcePosition(Entity &e, glm::vec3 pos);
+void forceOrientation(Entity &e, glm::vec3 pyr);
 
 // Move to Sequences or Triggers files later
 void addTriggeredMove(Entity &e, uint32_t move_idx, uint32_t delay, uint32_t fx_idx);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -721,7 +721,8 @@ void MapInstance::on_expect_client( ExpectMapClientRequest *ev )
     serializeFromQString(char_data,request_data.char_from_db_data);
     // existing character
     Entity *ent = m_entities.CreatePlayer();
-    toActualCharacter(char_data, *ent->m_char,*ent->m_player, *ent->m_entity);
+    toActualCharacter(char_data, *ent->m_char, *ent->m_player, *ent->m_entity);
+    ent->m_char->finalizeLevel(); // done here to fix spawn with 0 hp/end bug
     ent->fillFromCharacter(getGameData());
     ent->m_client = &map_session;
     map_session.m_ent = ent;
@@ -1962,6 +1963,10 @@ void MapInstance::on_client_resumed(ClientResumedRendering *ev)
         session.m_in_map = true;
     if (!map_server->session_has_xfer_in_progress(session.link()->session_token()))
     {
+        // Force position and orientation to fix #617 spawn at 0,0,0 bug
+        forcePosition(*session.m_ent, session.m_ent->m_entity_data.m_pos);
+        forceOrientation(*session.m_ent, session.m_ent->m_entity_data.m_orientation_pyr);
+
         char buf[256];
         std::string welcome_msg = std::string("Welcome to SEGS ") + VersionInfo::getAuthVersion()+"\n";
         std::snprintf(buf, 256, "There are %zu active entities and %zu clients", m_entities.active_entities(),


### PR DESCRIPTION
Closes #616
Closes #617
Closes #585

Additions/modifications proposed in this pull request:
- Fixes spawning at 0,0,0 by forcing position later in the spawning process. There is still a flash at 0,0,0 but it's brief.
- Fixes Height and Physique not being saved to the database properly.
- Resolves spawning or zoning without HP or End
