### PR TITLE
log: Put 'duplicate mod trick' in 'SceneGraph' category

### DIFF
--- a/Components/Logging.cpp
+++ b/Components/Logging.cpp
@@ -47,6 +47,7 @@ SEGS_LOGGING_CATEGORY(logNPCs,         "log.npcs")
 SEGS_LOGGING_CATEGORY(logAnimations,   "log.animations")
 SEGS_LOGGING_CATEGORY(logPowers,       "log.powers")
 SEGS_LOGGING_CATEGORY(logTrades,       "log.trades")
+SEGS_LOGGING_CATEGORY(logSceneGraph,   "log.scenegraph")
 
 void setLoggingFilter()
 {
@@ -78,9 +79,10 @@ void setLoggingFilter()
     filter_rules += "\nlog.lfg="            + config.value("log_lfg","false").toString();
     filter_rules += "\nlog.npcs="           + config.value("log_npcs","false").toString();
     filter_rules += "\nlog.animations="     + config.value("log_animations","false").toString();
-    filter_rules += "\nlog.powers="         + config.value("log_powers","false").toString();
+    filter_rules += "\nlog.powers="         + config.value("log_powers","false").toString(); 
     filter_rules += "\nlog.trades="         + config.value("log_trades","false").toString();
     filter_rules += "\nlog.scripts="        + config.value("log_scripts","false").toString();
+    filter_rules += "\nlog.scenegraph="     + config.value("log_scenegraph","false").toString();
     config.endGroup(); // Logging
 
     QLoggingCategory::setFilterRules(filter_rules);
@@ -149,6 +151,8 @@ void toggleLogging(QString &category)
         cat = &logTrades();
     else if(category.contains("scripts", Qt::CaseInsensitive))
         cat = &logScripts();
+    else if(category.contains("scenegraph",Qt::CaseInsensitive))
+        cat = &logSceneGraph();
     else
         return;
 
@@ -188,6 +192,7 @@ void dumpLogging()
     output += "\n\t animations: "   + QString::number(logAnimations().isDebugEnabled());
     output += "\n\t powers: "       + QString::number(logPowers().isDebugEnabled());
     output += "\n\t trades: "       + QString::number(logTrades().isDebugEnabled());
+    output += "\n\t scenegraph: "   + QString::number(logSceneGraph().isDebugEnabled());
 
     qDebug().noquote() << output;
 }

--- a/Components/Logging.h
+++ b/Components/Logging.h
@@ -40,6 +40,7 @@ SEGS_DECLARE_LOGGING_CATEGORY(logNPCs)
 SEGS_DECLARE_LOGGING_CATEGORY(logAnimations)
 SEGS_DECLARE_LOGGING_CATEGORY(logPowers)
 SEGS_DECLARE_LOGGING_CATEGORY(logTrades)
+SEGS_DECLARE_LOGGING_CATEGORY(logSceneGraph)
 
 void    setLoggingFilter();
 void    toggleLogging(QString &category);

--- a/Components/Settings.cpp
+++ b/Components/Settings.cpp
@@ -175,6 +175,7 @@ void Settings::setDefaultSettings()
         config.setValue("log_powers","false");
         config.setValue("log_trades","false");
         config.setValue("log_scripts","false");
+        config.setValue("log_scenegraph","false");
     config.endGroup();
 
     config.sync(); // sync changes or they wont be saved to file.

--- a/Projects/CoX/Common/Runtime/SceneGraph.cpp
+++ b/Projects/CoX/Common/Runtime/SceneGraph.cpp
@@ -568,7 +568,7 @@ static void registerGeometryModifier(GeometryModifiers *mod)
     auto iter = g_tricks_string_hash_tab.find(mod->name.toLower());
     if (iter!=g_tricks_string_hash_tab.end())
     {
-        qDebug() << "duplicate model trick!";
+        qCDebug(logSceneGraph) << "duplicate model trick!";
         return;
     }
     g_tricks_string_hash_tab[mod->name.toLower()]=mod;

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -94,3 +94,4 @@ log_animations      = false
 log_powers          = false
 log_trades          = false
 log_scripts         = false
+log_scenegraph      = false


### PR DESCRIPTION
As title says, move the message ` debug: duplicate model trick!` into a log category.
Said logging category is a new one.