### PR TITLE
auth: Don't assert on bad reconnection attempts

### DIFF
--- a/Projects/CoX/Common/Messages/Auth/AuthEvents.h
+++ b/Projects/CoX/Common/Messages/Auth/AuthEvents.h
@@ -8,6 +8,7 @@
 #pragma once
 #include "LinkLevelEvent.h"
 #include "Buffer.h"
+#include "Logging.h"
 class AuthLink;
 
 namespace SEGSEvents
@@ -66,7 +67,11 @@ public:
     {
         uint8_t op;
         buf.uGet(op);
-        assert(op==3);
+	if (op != 3){
+	    qWarning() << op << "in ReconnectAttempt serializefrom";
+	    for (auto i : m_arr)
+	        qWarning() << i;
+	}
         buf.uGetBytes(m_arr,8);
     }
     EVENT_IMPL(ReconnectAttempt)


### PR DESCRIPTION
Closes #619 .

Additions/modifications proposed in this pull request:
- Replace `assert(op==3)` with a conditional warning message.
