### PR TITLE
Correlate Map Indexes with Original Servers  

### DIFF
--- a/Projects/CoX/Common/GameData/map_definitions.cpp
+++ b/Projects/CoX/Common/GameData/map_definitions.cpp
@@ -6,34 +6,34 @@
 static const std::vector<MapData> g_defined_map_datas =
 {
     // City_Zones
-    {0, "City_00_01", "maps/City_Zones/City_00_01/City_00_01.txt", "Outbreak"},
+    {24, "City_00_01", "maps/City_Zones/City_00_01/City_00_01.txt", "Outbreak"},
     {1, "City_01_01", "maps/City_Zones/City_01_01/City_01_01.txt", "Atlas Park"},
-    {2, "City_01_02", "maps/City_Zones/City_01_02/City_01_02.txt", "King's Row"},
-    {3, "City_01_03", "maps/City_Zones/City_01_03/City_01_03.txt", "Galaxy City"},
-    {4, "City_02_01", "maps/City_Zones/City_02_01/City_02_01.txt", "Steel Canyon"},
-    {5, "City_02_02", "maps/City_Zones/City_02_02/City_02_02.txt", "Skyway City"},
-    {6, "City_03_01", "maps/City_Zones/City_03_01/City_03_01.txt", "Talos Island"},
-    {7, "City_03_02", "maps/City_Zones/City_03_02/City_03_02.txt", "Independence Port"},
-    {8, "City_04_01", "maps/City_Zones/City_04_01/City_04_01.txt", "Founders' Falls"},
-    {9, "City_04_02", "maps/City_Zones/City_04_02/City_04_02.txt", "Brickstown"},
-    {10, "City_05_01", "maps/City_Zones/City_05_01/City_05_01.txt", "Peregrine Island"},
+    {5, "City_01_02", "maps/City_Zones/City_01_02/City_01_02.txt", "King's Row"},
+    {29, "City_01_03", "maps/City_Zones/City_01_03/City_01_03.txt", "Galaxy City"},
+    {6, "City_02_01", "maps/City_Zones/City_02_01/City_02_01.txt", "Steel Canyon"},
+    {7, "City_02_02", "maps/City_Zones/City_02_02/City_02_02.txt", "Skyway City"},
+    {8, "City_03_01", "maps/City_Zones/City_03_01/City_03_01.txt", "Talos Island"},
+    {9, "City_03_02", "maps/City_Zones/City_03_02/City_03_02.txt", "Independence Port"},
+    {10, "City_04_01", "maps/City_Zones/City_04_01/City_04_01.txt", "Founders' Falls"},
+    {11, "City_04_02", "maps/City_Zones/City_04_02/City_04_02.txt", "Brickstown"},
+    {61, "City_05_01", "maps/City_Zones/City_05_01/City_05_01.txt", "Peregrine Island"},
 
     // Hazards
-    {11, "Hazard_01_01", "maps/City_Zones/Hazard_01_01/Hazard_01_01.txt", "Perez Park"},
-    {12, "Hazard_02_01", "maps/City_Zones/Hazard_02_01/Hazard_02_01.txt", "Boomtown"},
-    {13, "Hazard_03_01", "maps/City_Zones/Hazard_03_01/Hazard_03_01.txt", "Dark Astoria"},
-    {14, "Hazard_04_01", "maps/City_Zones/Hazard_04_01/Hazard_04_01.txt", "Crey's Folly"},
-    {15, "Hazard_04_02", "maps/City_Zones/Hazard_04_02/Hazard_04_02.txt", "Enviro Nightmare"},
-    {16, "Hazard_05_01", "maps/City_Zones/Hazard_05_01/Hazard_05_01.txt", "Elysium"},
+    {12, "Hazard_01_01", "maps/City_Zones/Hazard_01_01/Hazard_01_01.txt", "Perez Park"},
+    {13, "Hazard_02_01", "maps/City_Zones/Hazard_02_01/Hazard_02_01.txt", "Boomtown"},
+    {14, "Hazard_03_01", "maps/City_Zones/Hazard_03_01/Hazard_03_01.txt", "Dark Astoria"},
+    {15, "Hazard_04_01", "maps/City_Zones/Hazard_04_01/Hazard_04_01.txt", "Crey's Folly"},
+    //???{15, "Hazard_04_02", "maps/City_Zones/Hazard_04_02/Hazard_04_02.txt", "Enviro Nightmare"},
+    {9928, "Hazard_05_01", "maps/City_Zones/Hazard_05_01/Hazard_05_01.txt", "Elysium"},
 
     // Trials
-    {17, "Trial_01_01", "maps/City_Zones/Trial_01_01/Trial_01_01.txt", "Abandoned Sewer Network"},
-    {18, "Trial_01_02", "maps/City_Zones/Trial_01_02/Trial_01_02.txt", "Sewer Network"},
-    {19, "Trial_02_01", "maps/City_Zones/Trial_02_01/Trial_02_01.txt", "Faultline"},
+    {18, "Trial_01_01", "maps/City_Zones/Trial_01_01/Trial_01_01.txt", "Abandoned Sewer Network"},
+    {23, "Trial_01_02", "maps/City_Zones/Trial_01_02/Trial_01_02.txt", "Sewer Network"},
+    {84, "Trial_02_01", "maps/City_Zones/Trial_02_01/Trial_02_01.txt", "Faultline"},
     {20, "Trial_03_01", "maps/City_Zones/Trial_03_01/Trial_03_01.txt", "Terra Volta"},
     {21, "Trial_04_01", "maps/City_Zones/Trial_04_01/Trial_04_01.txt", "Eden"},
     {22, "Trial_04_02", "maps/City_Zones/Trial_04_02/Trial_04_02.txt", "The Hive"},
-    {23, "Trial_05_01", "maps/City_Zones/Trial_05_01/Trial_05_01.txt", "Rikti Crash Site"}
+    {60, "Trial_05_01", "maps/City_Zones/Trial_05_01/Trial_05_01.txt", "Rikti Crash Site"}
 };
 
 const std::vector<MapData> &getAllMapData()


### PR DESCRIPTION
Closes #584.

Additions/modifications proposed in this pull request:
- Changed map indexes to match Original Servers. 
- Excluded "{15, "Hazard_04_02", "maps/City_Zones/Hazard_04_02/Hazard_04_02.txt", "Enviro Nightmare"},"
- **_Was unable to test_**
- Also included is travel.cfg to fulfill bonus 3: "Utilize the attached travel.cfg to generate a list of zones for /mapmenu"
[travel.cfg.txt](https://github.com/Segs/Segs/files/2504584/travel.cfg.txt)

