### PR TITLE
fix SEGSAdmin failing to start "authserver", which was renamed to "segs_server"

### DIFF
--- a/Projects/CoX/Utilities/SEGSAdmin/SEGSAdminTool.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/SEGSAdminTool.cpp
@@ -303,39 +303,39 @@ void SEGSAdminTool::is_server_running()
 {
     if (m_server_running == true)
     {
-        SEGSAdminTool::stop_auth_server();
+        SEGSAdminTool::stop_segs_server();
     }
     else
     {
-        SEGSAdminTool::start_auth_server();
+        SEGSAdminTool::start_segs_server();
     }
 }
-void SEGSAdminTool::start_auth_server()
+void SEGSAdminTool::start_segs_server()
 {
     ui->output->appendPlainText("Setting arguments...");
     qApp->processEvents();
-    QString program = "authserver";
+    QString program = "segs_server";
     #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     program.prepend("./");
     #endif
-    m_start_auth_server = new QProcess(this);
-    m_start_auth_server->start(program);
+    m_start_segs_server = new QProcess(this);
+    m_start_segs_server->start(program);
 
-    if (m_start_auth_server->waitForStarted())
+    if (m_start_segs_server->waitForStarted())
     {
 
         ui->authserver_start->setText("Please Wait...");
-        ui->output->appendPlainText("Starting AuthServer...");
+        ui->output->appendPlainText("Starting SEGS Server...");
         ui->authserver_status->setText("STARTING");
         ui->authserver_status->setStyleSheet("QLabel {color: rgb(255, 153, 51)}");
         qApp->processEvents();
-        qDebug() << "Starting AuthServer...";
-        connect(m_start_auth_server,&QProcess::readyReadStandardError,this,&SEGSAdminTool::read_authserver);
-        connect(m_start_auth_server,&QProcess::readyReadStandardOutput,this,&SEGSAdminTool::read_authserver);
-        m_start_auth_server->waitForFinished(2000);
-        if(m_start_auth_server->state()==QProcess::Running)
+        qDebug() << "Starting SEGS Server...";
+        connect(m_start_segs_server,&QProcess::readyReadStandardError,this,&SEGSAdminTool::read_segsserver);
+        connect(m_start_segs_server,&QProcess::readyReadStandardOutput,this,&SEGSAdminTool::read_segsserver);
+        m_start_segs_server->waitForFinished(2000);
+        if(m_start_segs_server->state()==QProcess::Running)
         {
-            ui->output->appendPlainText("*** AuthServer Running ***");
+            ui->output->appendPlainText("*** SEGS Server Running ***");
             ui->authserver_status->setText("RUNNING");
             ui->authserver_status->setStyleSheet("QLabel {color: rgb(0, 200, 0)}");
             ui->authserver_start->setStyleSheet("color: rgb(255, 0, 0);");
@@ -344,11 +344,11 @@ void SEGSAdminTool::start_auth_server()
             ui->user_box->setEnabled(false);
             ui->server_setup_box->setEnabled(false);
             ui->server_config->setEnabled(false);
-            //qint64 pid = m_start_auth_server->processId();
+            //qint64 pid = m_start_segs_server->processId();
             //qDebug()<<pid;
             m_server_running = true;
         }
-        if(m_start_auth_server->state()==QProcess::NotRunning)
+        if(m_start_segs_server->state()==QProcess::NotRunning)
         {
             ui->output->appendPlainText("*** AUTHSERVER NOT RUNNING... Have you setup your piggs and settings files? ***");
             ui->authserver_start->setText("Start Server");
@@ -360,8 +360,8 @@ void SEGSAdminTool::start_auth_server()
     }
     else
     {
-        ui->output->appendPlainText("Failed to start AuthServer...");
-        qDebug() <<"Failed to start AuthServer...";
+        ui->output->appendPlainText("Failed to start SEGS Server...");
+        qDebug() <<"Failed to start SEGS Server...";
         ui->authserver_start->setText("Start Server");
         ui->authserver_start->setEnabled(true);
         qApp->processEvents();
@@ -369,10 +369,10 @@ void SEGSAdminTool::start_auth_server()
 
 }
 
-void SEGSAdminTool::read_authserver()
+void SEGSAdminTool::read_segsserver()
 {
-    QByteArray out_err = m_start_auth_server->readAllStandardError();
-    QByteArray out_std = m_start_auth_server->readAllStandardOutput();
+    QByteArray out_err = m_start_segs_server->readAllStandardError();
+    QByteArray out_std = m_start_segs_server->readAllStandardOutput();
     qDebug().noquote()<<QString(out_err);
     qDebug().noquote()<<QString(out_std);
     QString output_err = out_err;
@@ -384,14 +384,14 @@ void SEGSAdminTool::read_authserver()
     qApp->processEvents();
 }
 
-void SEGSAdminTool::stop_auth_server()
+void SEGSAdminTool::stop_segs_server()
 {
-    m_start_auth_server->close();
-    if(m_start_auth_server->state()==QProcess::Running)
+    m_start_segs_server->close();
+    if(m_start_segs_server->state()==QProcess::Running)
     {
-        ui->output->appendPlainText("*** AuthServer Failed to Stop ***");
+        ui->output->appendPlainText("*** SEGS Server Failed to Stop ***");
     }
-    if(m_start_auth_server->state()==QProcess::NotRunning)
+    if(m_start_segs_server->state()==QProcess::NotRunning)
     {
         ui->authserver_start->setEnabled(true);
         ui->authserver_status->setText("STOPPED");
@@ -403,7 +403,7 @@ void SEGSAdminTool::stop_auth_server()
         ui->server_setup_box->setEnabled(true);
         ui->server_config->setEnabled(true);
         m_server_running = false;
-        ui->output->appendPlainText("*** AuthServer Stopped ***");
+        ui->output->appendPlainText("*** SEGS Server Stopped ***");
     }
 }
 

--- a/Projects/CoX/Utilities/SEGSAdmin/SEGSAdminTool.h
+++ b/Projects/CoX/Utilities/SEGSAdmin/SEGSAdminTool.h
@@ -40,11 +40,11 @@ public slots:
     void commit_user(QString username, QString password, QString acclevel);
     void create_databases(bool overwrite);
     void check_db_exist(bool on_startup);
-    void start_auth_server();
-    void stop_auth_server();
+    void start_segs_server();
+    void stop_segs_server();
     void read_createuser();
     void read_createDB();
-    void read_authserver();
+    void read_segsserver();
     void check_for_config_file();
     void check_data_and_dir(QString maps_dir);
     void read_release_info(const QString &error);
@@ -65,7 +65,7 @@ private:
     void is_server_running();
     QProcess *m_createUser;
     QProcess *m_createDB;
-    QProcess *m_start_auth_server;
+    QProcess *m_start_segs_server;
     QStringList m_segs_releases;
 };
 


### PR DESCRIPTION
Closes # none.

Additions/modifications proposed in this pull request:
- fix SEGSAdmin failing to start "authserver", which was renamed to "segs_server"
- update UI, replacing "Auth Server" with "SEGS Server"
