### PR TITLE
hotfix: Close emailhandler on shutdown

### DIFF
--- a/Projects/CoX/Servers/GameServer/GameServer.cpp
+++ b/Projects/CoX/Servers/GameServer/GameServer.cpp
@@ -72,6 +72,8 @@ public:
         shutdown_event_processor_and_wait(m_handler);
         // tell our friendship service to close too
         shutdown_event_processor_and_wait(m_friendship_service.get());
+	// tell our email service to close too
+	shutdown_event_processor_and_wait(m_email_service.get());
     }
 };
 


### PR DESCRIPTION
Closes #622.

Additions/modifications proposed in this pull request:
- Close emailhandler on shutdown as it prevents the server from exiting otherwise
