### PR TITLE
Fix a map entering process to solve link/server blocking.

### DIFF
--- a/Projects/CoX/Common/CRUDP_Protocol/CRUDP_Protocol.cpp
+++ b/Projects/CoX/Common/CRUDP_Protocol/CRUDP_Protocol.cpp
@@ -500,7 +500,7 @@ bool CrudP_Protocol::batchSend(lCrudP_Packet &tgt)
         qDebug() << "Unresponsive link";
         return false;
     }
-    // move some packaets from reliable_packets to retransmit_queue
+    // move some packets from reliable_packets to retransmit_queue
     processRetransmits();
     // first handle retransmit queue
     CrudP_Packet *pak;

--- a/Projects/CoX/Common/CRUDP_Protocol/CRUD_Link.cpp
+++ b/Projects/CoX/Common/CRUDP_Protocol/CRUD_Link.cpp
@@ -140,7 +140,6 @@ int CRUDLink::handle_output( ACE_HANDLE )
                 break;
             case evPacket: // CRUDP_Protocol has posted a pre-parsed packet to us
                 event_for_packet(static_cast<Packet *>(ev));
-                connection_update(); // we've received some bytes -> connection update
                 break;
             default:
                 packets_for_event(static_cast<CRUDLink_Event *>(ev));

--- a/Projects/CoX/Common/GameData/Entity.cpp
+++ b/Projects/CoX/Common/GameData/Entity.cpp
@@ -213,20 +213,20 @@ void revivePlayer(Entity &e, ReviveLevel lvl)
     switch(lvl)
     {
     case ReviveLevel::AWAKEN:
-        setHP(*e.m_char, getMaxHP(*e.m_char)*0.25);
+        setHP(*e.m_char, getMaxHP(*e.m_char)*0.25f);
         break;
     case ReviveLevel::BOUNCE_BACK:
-        setHP(*e.m_char, getMaxHP(*e.m_char)*0.5);
+        setHP(*e.m_char, getMaxHP(*e.m_char)*0.5f);
         break;
     case ReviveLevel::RESTORATION:
-        setHP(*e.m_char, getMaxHP(*e.m_char)*0.75);
+        setHP(*e.m_char, getMaxHP(*e.m_char)*0.75f);
         break;
     case ReviveLevel::IMMORTAL_RECOVERY:
         setMaxHP(*e.m_char);
         break;
     case ReviveLevel::REGEN_REVIVE:
-        setHP(*e.m_char, getMaxHP(*e.m_char)*0.75);
-        setEnd(*e.m_char, getMaxEnd(*e.m_char)*0.5);
+        setHP(*e.m_char, getMaxHP(*e.m_char)*0.75f);
+        setEnd(*e.m_char, getMaxEnd(*e.m_char)*0.5f);
         break;
     case ReviveLevel::FULL:
     default:


### PR DESCRIPTION
The client entering a new map does not want/need constant full world
state updates. So now we only send 2 full world updates before client
'resumes' and starts receiving incremental ones.
