### PR TITLE
Use float duration for reporting keypress times + a few small fixes.

### DIFF
--- a/Projects/CoX/Common/GameData/Movement.cpp
+++ b/Projects/CoX/Common/GameData/Movement.cpp
@@ -25,10 +25,10 @@
 #include <glm/ext.hpp>
 #include <chrono>
 
-static glm::mat3    s_identity_matrix = glm::mat3(1.0f);
+static const glm::mat3  s_identity_matrix = glm::mat3(1.0f);
 static int          s_landed_on_ground = 0;
 //static CollInfo     s_last_surf;
-static int          s_reverse_control_dir[6] = {
+static const int s_reverse_control_dir[6] = {
     BinaryControl::BACKWARD,
     BinaryControl::FORWARD,
     BinaryControl::RIGHT,
@@ -132,9 +132,9 @@ void setVelocity(Entity &e) // pmotionSetVel
             else if (press_time >= 75)
             {
                 if (press_time < 75 || press_time >= 100)
-                    control_amounts[i] = (float)(press_time - 100) * 0.004f / 9.0f + 0.6f;
+                    control_amounts[i] = (press_time - 100) * 0.004f / 9.0f + 0.6f;
                 else
-                    control_amounts[i] = std::pow(float(press_time - 75) * 0.04f, 2.0f) * 0.4f + 0.2f;
+                    control_amounts[i] = std::pow((press_time - 75) * 0.04f, 2.0f) * 0.4f + 0.2f;
             }
             else
                 control_amounts[i] = 0.2f;

--- a/Projects/CoX/Common/GameData/NpcStore.cpp
+++ b/Projects/CoX/Common/GameData/NpcStore.cpp
@@ -47,7 +47,7 @@ const Parse_NPC *NPCStorage::npc_by_name(const QStringRef &name) const
 {
     auto iter = m_name_to_npc_def.find(name.toString().toLower());
     if(iter!=m_name_to_npc_def.end())
-        return iter.value();
+        return *iter;
     return nullptr;
 }
 

--- a/Projects/CoX/Common/GameData/StateInterpolator.cpp
+++ b/Projects/CoX/Common/GameData/StateInterpolator.cpp
@@ -85,7 +85,7 @@ float get_interpolator_perturbation(int16_t a1,int level)
 {
     buildErrorTable();
     if ( a1 )
-        return (2 * (a1 >= 0) - 1) * s_coding_sequence[int(std::abs(a1))]*(1<<level);
+        return (2 * (a1 >= 0) - 1) * s_coding_sequence[std::abs(a1)]*(1<<level);
 
     return 0.0f;
 }

--- a/Projects/CoX/Common/GameData/StateStorage.h
+++ b/Projects/CoX/Common/GameData/StateStorage.h
@@ -44,6 +44,7 @@ public:
 
 class InputState
 {
+    using FloatDuration = std::chrono::duration<float>;
 public:
     InputState()
     {
@@ -77,7 +78,7 @@ public:
     bool        m_pyr_valid[3]          = {false};
     glm::vec3   m_pos_delta             = {0.0f, 0.0f, 0.0f};
     std::chrono::steady_clock::time_point m_keypress_start[6];
-    std::chrono::steady_clock::duration m_svr_keypress_time[6]; // for debugging
+    FloatDuration m_svr_keypress_time[6]; // for debugging
     float       m_keypress_time[6]      = {0};  // total_move
     float       m_move_time             = 0.0f;
     float       m_ms_since_prev;

--- a/Projects/CoX/Common/Messages/Map/ContactList.h
+++ b/Projects/CoX/Common/Messages/Map/ContactList.h
@@ -97,7 +97,7 @@ namespace SEGSEvents
         int32_t m_srv_idx = 0;
         explicit ReceiveContactStatus() : MapLinkEvent(MapEventTypes::evReceiveContactStatus){}
 
-        void serializeto(BitStream &bs) const override
+        void serializeto(BitStream &/*bs*/) const override
         {
             assert(!"ReceiveContactStatus serializeto");
         }

--- a/Projects/CoX/Common/Messages/Map/DoorAnims.h
+++ b/Projects/CoX/Common/Messages/Map/DoorAnims.h
@@ -115,7 +115,7 @@ namespace SEGSEvents
         {
             bs.StorePackedBits(1,13);
         }
-        void serializefrom(BitStream &bs) override
+        void serializefrom(BitStream &/*bs*/) override
         {
             // nothing received from client
         }

--- a/Projects/CoX/Common/Messages/Map/InputState.cpp
+++ b/Projects/CoX/Common/Messages/Map/InputState.cpp
@@ -61,7 +61,7 @@ void RecvInputState::receiveControlState(BitStream &bs) // formerly partial_2
                 processDirectionControl(&m_next_state, control_id, ms_since_prev, keypress_state);
 
                 qCDebug(logInput, "key released %d", control_id);
-                qCDebug(logLFG, "svr vs client keypress time: %f %f : %f", 
+                qCDebug(logInput, "svr vs client keypress time: %f %f : %f", 
                         m_next_state.m_svr_keypress_time[control_id].count(),
                         m_next_state.m_keypress_time[control_id], m_next_state.m_ms_since_prev);
                 break;

--- a/Projects/CoX/Common/Messages/Map/InputState.cpp
+++ b/Projects/CoX/Common/Messages/Map/InputState.cpp
@@ -20,6 +20,7 @@
 
 #include <glm/gtc/constants.hpp>
 #include <cmath>
+#include <chrono>
 
 using namespace SEGSEvents;
 
@@ -60,7 +61,9 @@ void RecvInputState::receiveControlState(BitStream &bs) // formerly partial_2
                 processDirectionControl(&m_next_state, control_id, ms_since_prev, keypress_state);
 
                 qCDebug(logInput, "key released %d", control_id);
-                qCDebug(logLFG, "svr vs client keypress time: %f %f : %f", m_next_state.m_svr_keypress_time[control_id].count(), m_next_state.m_keypress_time[control_id], m_next_state.m_ms_since_prev);
+                qCDebug(logLFG, "svr vs client keypress time: %f %f : %f", 
+                        m_next_state.m_svr_keypress_time[control_id].count(),
+                        m_next_state.m_keypress_time[control_id], m_next_state.m_ms_since_prev);
                 break;
             }
             case PITCH: // camera pitch (Insert/Delete keybinds)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -706,25 +706,25 @@ void sendContactDialogClose(MapClientSession &src)
     src.addCommand<ContactDialogClose>();
 }
 
-void updateContactStatusList(MapClientSession &src, Contact contact)
+void updateContactStatusList(MapClientSession &src, const Contact &updated_contact_data)
 {
     vContactList contacts = src.m_ent->m_char->m_char_data.m_contacts;
     //find contact
     bool found = false;
 
-    for (int i = 0; i < contacts.size(); ++i)
+    for (Contact & contact : contacts)
     {
-        if(contacts[i].m_npc_id == contact.m_npc_id)
+        if(contact.m_npc_id == updated_contact_data.m_npc_id)
         {
             found = true;
             //contact already in list, update contact;
-            contacts.at(i) = contact;
+            contact = updated_contact_data;
             break;
         }
     }
 
     if(!found)
-        contacts.push_back(contact);
+        contacts.push_back(updated_contact_data);
 
     //update database contactList
     src.m_ent->m_char->m_char_data.m_contacts = contacts;
@@ -768,15 +768,16 @@ void sendDeadNoGurney(MapClientSession &sess)
 
 void sendDoorAnimStart(MapClientSession &sess, glm::vec3 &entry_pos, glm::vec3 &target_pos, bool has_anims, QString &seq_state)
 {
-    qCDebug(logSlashCommand).noquote() << QString("Sending DoorAnimStart: entry<%1, %2, %3>  target<%4, %5, %6>  has_anims: %7  seq_state: %8")
-                                .arg(entry_pos.x, 0, 'f', 1)
-                                .arg(entry_pos.y, 0, 'f', 1)
-                                .arg(entry_pos.z, 0, 'f', 1)
-                                .arg(target_pos.x, 0, 'f', 1)
-                                .arg(target_pos.y, 0, 'f', 1)
-                                .arg(target_pos.z, 0, 'f', 1)
-                                .arg(has_anims)
-                                .arg(seq_state);
+    qCDebug(logSlashCommand).noquote()
+        << QString("Sending DoorAnimStart: entry<%1, %2, %3>  target<%4, %5, %6>  has_anims: %7  seq_state: %8")
+               .arg(entry_pos.x, 0, 'f', 1)
+               .arg(entry_pos.y, 0, 'f', 1)
+               .arg(entry_pos.z, 0, 'f', 1)
+               .arg(target_pos.x, 0, 'f', 1)
+               .arg(target_pos.y, 0, 'f', 1)
+               .arg(target_pos.z, 0, 'f', 1)
+               .arg(has_anims)
+               .arg(seq_state);
 
     sess.addCommand<DoorAnimStart>(entry_pos, target_pos, has_anims, seq_state);
 }
@@ -1029,7 +1030,7 @@ void usePower(Entity &ent, uint32_t pset_idx, uint32_t pow_idx, int32_t tgt_idx,
                         .arg(QString(powtpl.m_Name));
 
                 if (powtpl.pAttribMod[i].Duration > 0)
-                    to_msg.append(" for a duration of %1").arg(powtpl.pAttribMod[i].Duration);
+                    to_msg.append(QString(" for a duration of %1").arg(powtpl.pAttribMod[i].Duration));
 
                 // Build target specific messages
                 from_msg = QString("You cause ").append(to_msg);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -136,7 +136,7 @@ void sendContactDialog(MapClientSession &src, QString msg_body, std::vector<Cont
 void sendContactDialogYesNoOk(MapClientSession &src, QString msg_body, bool has_yesno);
 void sendContactDialogClose(MapClientSession &src);
 void sendContactStatusList(MapClientSession &src);
-void updateContactStatusList(MapClientSession &src, Contact contact);
+void updateContactStatusList(MapClientSession &src, const Contact &contact_to_update);
 void sendWaypoint(MapClientSession &src, int point_idx, glm::vec3 &location);
 void sendStance(MapClientSession &src, PowerStance stance);
 void sendDeadNoGurney(MapClientSession &sess);

--- a/Projects/CoX/Servers/MapServer/MessageHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/MessageHelpers.cpp
@@ -54,7 +54,7 @@ void storeEntityResponseCommands(BitStream &bs,float time_of_day)
 {
     PUTDEBUG("before commands");
     bs.StorePackedBits(1,1); // use 'time' shortcut
-    bs.StoreFloat(float(time_of_day)*10.0f);
+    bs.StoreFloat(time_of_day*10.0f);
     bs.StorePackedBits(1,2); // use 'time scale' shortcut
     bs.StoreFloat(4.0f);
     bs.StorePackedBits(1,3); // use 'time step scale' shortcut


### PR DESCRIPTION
* m_svr_keypress_time uses a type alias FloatDuration now.
* removed a few useless casts.
* updateContactStatusList takes the parameter by `const &` now.
* fix debug message in `usePower` for `powtpl.pAttribMod[i].Duration >
0` case
* removed/fxied a few 'unused argument' warnings.

