### PR TITLE
Temporary workaround for #555 team-removal and side-kick removal

### DIFF
--- a/Projects/CoX/Common/GameData/Team.h
+++ b/Projects/CoX/Common/GameData/Team.h
@@ -36,7 +36,7 @@ const   uint32_t    m_team_idx          = 0;
 
         // Methods
         void        dump();
-        void        listTeamMembers();
+        void        dumpAllTeamMembers();
         void        addTeamMember(Entity *e, uint32_t teammate_map_idx);
         bool        isTeamLeader(Entity *e);
 
@@ -75,4 +75,4 @@ uint32_t getSidekickId(const class Character &src);
 bool isSidekickMentor(const Entity &e);
 SidekickChangeStatus inviteSidekick(Entity &src, Entity &tgt);
 void addSidekick(Entity &tgt, Entity &src);
-SidekickChangeStatus removeSidekick(Entity &src, Entity *tgt);
+SidekickChangeStatus removeSidekick(Entity &src, uint32_t sidekick_id);

--- a/Projects/CoX/Servers/AuthDatabase/AuthDBSyncHandler.cpp
+++ b/Projects/CoX/Servers/AuthDatabase/AuthDBSyncHandler.cpp
@@ -40,17 +40,17 @@ void AuthDBSyncHandler::dispatch(Event *ev)
     {
 
         case AuthDBEventTypes::evCreateAccountMessage:
-        on_create_account(static_cast<CreateAccountMessage *>(ev));
-        break;
+            on_create_account(static_cast<CreateAccountMessage *>(ev));
+            break;
         case AuthDBEventTypes::evRetrieveAccountRequest:
-        on_retrieve_account(static_cast<RetrieveAccountRequest *>(ev));
-        break;
+            on_retrieve_account(static_cast<RetrieveAccountRequest *>(ev));
+            break;
         case AuthDBEventTypes::evValidatePasswordRequest:
-        on_validate_password(static_cast<ValidatePasswordRequest *>(ev));
-        break;
+            on_validate_password(static_cast<ValidatePasswordRequest *>(ev));
+            break;
         default:
-        assert(false);
-        break;
+            assert(false);
+            break;
     }
 }
 

--- a/Projects/CoX/Servers/GameServer/EmailService/EmailHandler.cpp
+++ b/Projects/CoX/Servers/GameServer/EmailService/EmailHandler.cpp
@@ -21,39 +21,37 @@ void EmailHandler::dispatch(Event *ev)
     {
         // EmailEvents
         case EmailEventTypes::evEmailHeaderRequest:
-        on_email_header(static_cast<EmailHeaderRequest *>(ev));
-        break;
+            on_email_header(static_cast<EmailHeaderRequest *>(ev));
+            break;
         case EmailEventTypes::evEmailReadRequest:
-        on_email_read(static_cast<EmailReadRequest *>(ev));
-        break;
+            on_email_read(static_cast<EmailReadRequest *>(ev));
+            break;
         case EmailEventTypes::evEmailSendMessage:
-        on_email_send(static_cast<EmailSendMessage *>(ev));
-        break;
+            on_email_send(static_cast<EmailSendMessage *>(ev));
+            break;
         case EmailEventTypes::evEmailDeleteMessage:
-        on_email_delete(static_cast<EmailDeleteMessage *>(ev));
-        break;
-
+            on_email_delete(static_cast<EmailDeleteMessage *>(ev));
+            break;
         // GameDbEvents
         case GameDBEventTypes::evEmailCreateResponse:
-        on_email_create_response(static_cast<EmailCreateResponse *>(ev));
-        break;
+            on_email_create_response(static_cast<EmailCreateResponse *>(ev));
+            break;
         case GameDBEventTypes::evGetEmailsResponse:
-        on_get_emails_response(static_cast<GetEmailsResponse *>(ev));
-        break;
+            on_get_emails_response(static_cast<GetEmailsResponse *>(ev));
+            break;
         case GameDBEventTypes::evFillEmailRecipientIdResponse:
-        on_fill_email_recipient_id_response(static_cast<FillEmailRecipientIdResponse *>(ev));
-        break;
+            on_fill_email_recipient_id_response(static_cast<FillEmailRecipientIdResponse *>(ev));
+            break;
         case GameDBEventTypes::evFillEmailRecipientIdErrorMessage:
-        on_fill_email_recipient_id_error(static_cast<FillEmailRecipientIdErrorMessage *>(ev));
-        break;
-
+            on_fill_email_recipient_id_error(static_cast<FillEmailRecipientIdErrorMessage *>(ev));
+            break;
         // will be obtained from MessageBusEndpoint
         case Internal_EventTypes::evClientConnectedMessage:
-        on_client_connected(static_cast<ClientConnectedMessage *>(ev));
-        break;
+            on_client_connected(static_cast<ClientConnectedMessage *>(ev));
+            break;
         case Internal_EventTypes::evClientDisconnectedMessage:
-        on_client_disconnected(static_cast<ClientDisconnectedMessage *>(ev));
-        break;
+            on_client_disconnected(static_cast<ClientDisconnectedMessage *>(ev));
+            break;
         default: assert(false); break;
     }
 }

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -1269,6 +1269,8 @@ void MapInstance::process_chat(MapClientSession *sender,QString &msg_text)
 
             Entity *tgt = getEntity(sender,target_name);
 
+            qWarning() << "Private chat: this only work for players on local server. We should introduce a message router, and send messages to EntityIDs instead of directly using sessions.";
+
             if(tgt == nullptr)
             {
                 prepared_chat_message = QString("No player named \"%1\" currently online.").arg(target_name);
@@ -1277,11 +1279,11 @@ void MapInstance::process_chat(MapClientSession *sender,QString &msg_text)
             }
             else
             {
-                prepared_chat_message = QString(" -->%1: %2").arg(target_name,msg_content.toString());
-                sendChatMessage(MessageChannel::PRIVATE,prepared_chat_message,sender,*sender); // in this case, sender is target
+                prepared_chat_message = QString(" --> %1: %2").arg(target_name,msg_content.toString());
+                sendInfoMessage(MessageChannel::PRIVATE, prepared_chat_message, *sender); // in this case, sender is target
 
                 prepared_chat_message = QString(" %1: %2").arg(sender_char_name,msg_content.toString());
-                sendChatMessage(MessageChannel::PRIVATE,prepared_chat_message,sender,*tgt->m_client);
+                sendChatMessage(MessageChannel::PRIVATE, prepared_chat_message, sender, *tgt->m_client);
             }
 
             break;
@@ -1291,9 +1293,11 @@ void MapInstance::process_chat(MapClientSession *sender,QString &msg_text)
             if(!sender->m_ent->m_has_team)
             {
                 prepared_chat_message = "You are not a member of a Team.";
-                sendInfoMessage(MessageChannel::USER_ERROR,prepared_chat_message,*sender);
+                sendInfoMessage(MessageChannel::USER_ERROR, prepared_chat_message, *sender);
                 break;
             }
+
+            qWarning() << "Team chat: this only work for members on local server. We should introduce a message router, and send messages to EntityIDs instead of directly using sessions.";
 
             // Only send the message to characters on sender's team
             for(MapClientSession *cl : m_session_store)
@@ -1304,7 +1308,7 @@ void MapInstance::process_chat(MapClientSession *sender,QString &msg_text)
             prepared_chat_message = QString(" %1: %2").arg(sender_char_name,msg_content.toString());
             for(MapClientSession * cl : recipients)
             {
-                sendChatMessage(MessageChannel::TEAM,prepared_chat_message,sender,*cl);
+                sendChatMessage(MessageChannel::TEAM, prepared_chat_message, sender, *cl);
             }
             break;
         }
@@ -1313,9 +1317,11 @@ void MapInstance::process_chat(MapClientSession *sender,QString &msg_text)
             if(!sender->m_ent->m_has_supergroup)
             {
                 prepared_chat_message = "You are not a member of a SuperGroup.";
-                sendInfoMessage(MessageChannel::USER_ERROR,prepared_chat_message,*sender);
+                sendInfoMessage(MessageChannel::USER_ERROR, prepared_chat_message, *sender);
                 break;
             }
+
+            qWarning() << "SuperGroup chat: this only work for members on local server. We should introduce a message router, and send messages to EntityIDs instead of directly using sessions.";
 
             // Only send the message to characters in sender's supergroup
             for(MapClientSession *cl : m_session_store)
@@ -1339,22 +1345,25 @@ void MapInstance::process_chat(MapClientSession *sender,QString &msg_text)
                 sendInfoMessage(MessageChannel::USER_ERROR,prepared_chat_message,*sender);
                 break;
             }
+
+            qWarning() << "Friend chat: this only work for friends on local server. We should introduce a message router, and send messages to EntityIDs instead of directly using sessions.";
+
             // Only send the message to characters in sender's friendslist
             prepared_chat_message = QString(" %1: %2").arg(sender_char_name,msg_content.toString());
             for(Friend &f : fl->m_friends)
             {
                 if(f.m_online_status != true)
                     continue;
-                assert(false);
+
                 //TODO: this only work for friends on local server
                 // introduce a message router, and send messages to EntityIDs instead of directly using sessions.
-                Entity *tgt = nullptr; //getEntityByDBID(*sender,f.m_db_id);
+                Entity *tgt = getEntityByDBID(sender->m_current_map, f.m_db_id);
                 if(tgt == nullptr) // In case we didn't toggle online_status.
                     continue;
 
-                sendChatMessage(MessageChannel::FRIENDS,prepared_chat_message,sender,*tgt->m_client);
+                sendChatMessage(MessageChannel::FRIENDS, prepared_chat_message, sender, *tgt->m_client);
             }
-            sendChatMessage(MessageChannel::FRIENDS,prepared_chat_message,sender,*sender);
+            sendChatMessage(MessageChannel::FRIENDS, prepared_chat_message, sender, *sender);
             break;
         }
         default:

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -1630,8 +1630,7 @@ void cmdHandler_UnSidekick(const QString &/*cmd*/, MapClientSession &sess)
     QString msg;
 
     uint32_t sidekick_id = getSidekickId(*sess.m_ent->m_char);
-    Entity *tgt = getEntityByDBID(sess.m_current_map,sidekick_id);
-    auto res = removeSidekick(*sess.m_ent,tgt);
+    auto res = removeSidekick(*sess.m_ent, sidekick_id);
     if(res==SidekickChangeStatus::GENERIC_FAILURE)
     {
         msg = "You are not sidekicked with anyone.";
@@ -1640,6 +1639,7 @@ void cmdHandler_UnSidekick(const QString &/*cmd*/, MapClientSession &sess)
     }
     else if(res==SidekickChangeStatus::SUCCESS)
     {
+        Entity *tgt = getEntityByDBID(sess.m_current_map, sidekick_id);
         QString tgt_name = tgt ? tgt->name() : "Unknown Player";
         if(isSidekickMentor(*sess.m_ent))
         {

--- a/Projects/CoX/Servers/MapServer/WorldSimulation.cpp
+++ b/Projects/CoX/Servers/MapServer/WorldSimulation.cpp
@@ -176,6 +176,18 @@ void World::updateEntity(Entity *e, const ACE_Time_Value &dT)
     effectsStep(e, dT.msec());
     checkPowerTimers(e, dT.msec());
 
+    // TODO: Issue #555 needs to handle team cleanup properly
+    // and we need to remove the following
+    if(e->m_team != nullptr)
+    {
+        if(e->m_team->m_team_members.size() <= 1)
+        {
+            qWarning() << "Team cleanup being handled in updateEntity, but we need to move this to TeamHandler";
+            e->m_has_team = false;
+            e->m_team = nullptr;
+        }
+    }
+
     // check death, set clienstate if dead, and
     // if alive, recover endurance and health
     if(!isPlayerDead(e))


### PR DESCRIPTION
## Summary
This still has issues, to avoid using MapInstance in Team.cpp there is a condition where removing a sidekick can result in one member of the sidekick duo having a "sidekick" state still. This really wont be resolved until #642 is complete.

- The goal of this PR is to prevent the hard crashes when someone removes a team member, or zones while on a team.
- This isn't pretty, but it's supposed to be temporary.
