### PR TITLE
Ubuntu build fixes and ignore Travis macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,11 @@ matrix:
       compiler: "gcc-7"
       env: BUILD='Debug' CC=gcc-7 CXX=g++-7
       addons: *gcc7
-    - os: osx
-      osx_image: xcode9.2
-      compiler: clang
-      env: BUILD='Debug'
+# Disabling macOS builds temporarily until the app bundle issue can be resolved
+#   - os: osx
+#     osx_image: xcode9.2
+#     compiler: clang
+#     env: BUILD='Debug'
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo add-apt-repository ppa:beineri/opt-qt593-trusty -y; fi

--- a/Projects/CoX/Common/GameData/power_definitions.h
+++ b/Projects/CoX/Common/GameData/power_definitions.h
@@ -149,6 +149,10 @@ using namespace SEGS_Enums_Power;
 
 struct StoredAttribMod
 {
+    // Older combinations of Qt/moc/CMake require Q_GADGET macro and granting public access
+    // to members. Otherwise, moc files are not generated properly under certain conditions.
+    Q_GADGET
+public:
     QByteArray         name;
     int                index_in_power;
     QByteArray         DisplayAttackerHit;

--- a/Projects/CoX/Common/GameData/seq_definitions.h
+++ b/Projects/CoX/Common/GameData/seq_definitions.h
@@ -389,6 +389,10 @@ using namespace SEGS_Enums;
 
 struct SeqBitSet
 {
+    // Older combinations of Qt/moc/CMake require Q_GADGET macro and granting public access
+    // to members. Otherwise, moc files are not generated properly under certain conditions.
+    Q_GADGET
+public:
     std::bitset<416> bits;
     bool isSet(SeqBitNames v) const { return bits[uint32_t(v)]; }
     void set(SeqBitNames bit) { bits[uint32_t(bit)] = true;}

--- a/Projects/CoX/Utilities/SEGSAdmin/NetworkManager.h
+++ b/Projects/CoX/Utilities/SEGSAdmin/NetworkManager.h
@@ -10,6 +10,7 @@
 #define NETWORKMANAGER_H
 
 #include <QObject>
+#include <QNetworkRequest>
 #include <QNetworkAccessManager>
 
 class NetworkManager : public QObject


### PR DESCRIPTION
Closes #662.

Additions/modifications proposed in this pull request:
- Added missing header to SEGSAdmin/NetworkManager.h to correct GCC 6.3.1 build error.
- Corrected moc file generation issue which appears under certain conditions and causes builds to fail.
- Temporarily disabling Travis CI macOS builds until the app bundle issue can be resolved.
