### PR TITLE
A bunch of scary bugs came trick-or-treating, sweets were applied.

### DIFF
--- a/Components/serialization_types.h
+++ b/Components/serialization_types.h
@@ -41,6 +41,16 @@ inline void prologue(JSONInputArchive &, QString const &) { }
 inline void prologue(BinaryOutputArchive &, QString const &) { }
 inline void prologue(BinaryInputArchive &, QString const &) { }
 
+inline void epilogue(BinaryOutputArchive &, QByteArray const &) { }
+inline void epilogue(BinaryInputArchive &, QByteArray const &) { }
+inline void epilogue(JSONOutputArchive &, QByteArray const &) { }
+inline void epilogue(JSONInputArchive &, QByteArray const &) { }
+
+inline void prologue(JSONOutputArchive &, QByteArray const &) { }
+inline void prologue(JSONInputArchive &, QByteArray const &) { }
+inline void prologue(BinaryOutputArchive &, QByteArray const &) { }
+inline void prologue(BinaryInputArchive &, QByteArray const &) { }
+
 template<class Archive>
 inline void CEREAL_SAVE_FUNCTION_NAME(Archive & ar, ::QString const & str)
 {
@@ -50,7 +60,7 @@ inline void CEREAL_SAVE_FUNCTION_NAME(Archive & ar, ::QString const & str)
 template<class Archive>
 inline void CEREAL_SAVE_FUNCTION_NAME(Archive & ar, ::QByteArray const & str)
 {
-    // make sure we actually have a latin1 string in str
+    // make sure we actually have a latin1 string in str, and not something that has strange ascii chars
     assert(QString(str).toLatin1()==str);
     ar( str.toStdString() );
 }

--- a/Projects/CoX/Common/GameData/CommonNetStructures.h
+++ b/Projects/CoX/Common/GameData/CommonNetStructures.h
@@ -45,6 +45,17 @@ public:
     virtual void packPartname(const QString &c,BitStream &into) const =0;
     virtual void unpackPartname(BitStream &from,QString &tgt) const =0;
 };
+///
+/// \brief The IndexedStringPacker class is responsible for storing a mapping from string to index
+/// So when sending a new string to the client, the contents can be sent only once, and afterwards the index is used instead.
+///
+class IndexedStringPacker
+{
+public:
+    virtual void addString(const QString &) = 0;
+    /// return index of a string, or 0 if the string has not been added yet.
+    virtual int getIndex(const QString &) const =0;
+};
 extern  void        storeBitsConditional(BitStream &bs, uint8_t numbits, int bits);
 extern  int         getBitsConditional(BitStream &bs, uint32_t numbits);
 extern  void        storePackedBitsConditional(BitStream &bs, uint8_t numbits, int bits);

--- a/Projects/CoX/Common/GameData/GameDataStore.h
+++ b/Projects/CoX/Common/GameData/GameDataStore.h
@@ -19,11 +19,13 @@
 #include "NpcStore.h"
 
 class ColorAndPartPacker;
+class IndexedStringPacker;
 class QString;
 class GameDataStore
 {
-        ColorAndPartPacker *packer_instance = nullptr;
-        LevelExpAndDebt     m_experience_and_debt_per_level;
+        ColorAndPartPacker * packer_instance      = nullptr;
+        IndexedStringPacker *m_index_based_packer = nullptr;
+        LevelExpAndDebt      m_experience_and_debt_per_level;
 
         bool            read_costumes(const QString &directory_path);
         bool            read_colors(const QString &src_filename);
@@ -38,6 +40,7 @@ class GameDataStore
         bool            read_combine_chances(const QString &directory_path);
         bool            read_effectiveness(const QString &directory_path);
         bool            read_pi_schedule(const QString &directory_path);
+        bool            read_fx(const QString &directory_path);
 public:
                         GameDataStore();
                         ~GameDataStore();
@@ -66,6 +69,7 @@ public:
         Parse_Effectiveness         m_effectiveness_above;
         Parse_Effectiveness         m_effectiveness_below;
         Parse_PI_Schedule           m_pi_schedule;
+        std::vector<struct FxInfo>  m_fx_infos;
         float                       m_player_fade_in;
 
         // keep in mind the hierarchy is all_powers -> powercat -> powerset -> powerdata (template)

--- a/Projects/CoX/Common/Runtime/Prefab.cpp
+++ b/Projects/CoX/Common/Runtime/Prefab.cpp
@@ -150,3 +150,10 @@ GeoStoreDef * PrefabStore::groupGetFileEntryPtr(const QString &full_name)
     key = key.mid(0, key.indexOf("__"));
     return m_modelname_to_geostore.value(key, nullptr);
 }
+void PrefabStore::sceneGraphWasReset()
+{
+    for(auto & v : m_dir_to_geoset)
+    {
+        v.loaded = false;
+    }
+}

--- a/Projects/CoX/Common/Runtime/Prefab.h
+++ b/Projects/CoX/Common/Runtime/Prefab.h
@@ -58,6 +58,7 @@ struct PrefabStore
     bool loadNamedPrefab(const QString &name, LoadingContext &conv);
     Model *groupModelFind(const QString &path, LoadingContext &ctx);
     GeoStoreDef * groupGetFileEntryPtr(const QString &full_name);
+    void sceneGraphWasReset(); // reset 'loaded' flag on all geostores
 };
 
 } // namespace SEGS

--- a/include/version.h
+++ b/include/version.h
@@ -8,7 +8,7 @@
 
 #pragma once
 #define ProjectName "SEGS"
-#define VersionNumber "0.6.0"
+#define VersionNumber "0.6.1"
 #define VersionName "Outbreak"
 #define VersionString ProjectName " v" VersionNumber " (" VersionName ")"
 #define CopyrightString "Super Entity Game Server\nhttp://github.com/Segs/\nCopyright (c) 2006-2018 Super Entity Game Server Team (see AUTHORS.md)\nThis software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.\n";


### PR DESCRIPTION
Added: GameData now loads up fx infos
Added:  FxInfos are properly recorded in indexed string table ( client
requires the string index to produce power effects )
Fixed: binConverter output is less verbose for  serialized QByteArray
strings
Fixed: When a new SceneGraph is loaded, PrefabStore entries are properly
mareked as not loaded.
Fixed: SceneNode::name should have had it's name set from non-lowercased
value
