### PR TITLE
Less asserts where error messages will work

### DIFF
--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -315,13 +315,13 @@ bool GameDataStore::read_game_data(const QString &directory_path)
 
 uint32_t GameDataStore::expForLevel(uint32_t lev) const
 {
-    assert(lev>=0 && lev<m_experience_and_debt_per_level.m_ExperienceRequired.size());
+    lev = std::max<uint32_t>(0,std::min<uint32_t>(49, lev));
     return m_experience_and_debt_per_level.m_ExperienceRequired.at(lev);
 }
 
 uint32_t GameDataStore::expDebtForLevel(uint32_t lev) const
 {
-    assert(lev>=0 && lev<m_experience_and_debt_per_level.m_DefeatPenalty.size());
+    lev = std::max<uint32_t>(0,std::min<uint32_t>(49, lev));
     return m_experience_and_debt_per_level.m_DefeatPenalty.at(lev);
 }
 

--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -315,13 +315,13 @@ bool GameDataStore::read_game_data(const QString &directory_path)
 
 uint32_t GameDataStore::expForLevel(uint32_t lev) const
 {
-    lev = std::max<uint32_t>(0,std::min<uint32_t>(49, lev));
+    lev = std::max<uint32_t>(0,std::min<uint32_t>(expMaxLevel(), lev));
     return m_experience_and_debt_per_level.m_ExperienceRequired.at(lev);
 }
 
 uint32_t GameDataStore::expDebtForLevel(uint32_t lev) const
 {
-    lev = std::max<uint32_t>(0,std::min<uint32_t>(49, lev));
+    lev = std::max<uint32_t>(0,std::min<uint32_t>(expMaxLevel(), lev));
     return m_experience_and_debt_per_level.m_DefeatPenalty.at(lev);
 }
 

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -1176,7 +1176,14 @@ void removeTask(MapClientSession &src, Task task)
 
 void train (MapClientSession &sess)
 {
-    int level = getLevel(*sess.m_ent->m_char)+1;
+    uint level = getLevel(*sess.m_ent->m_char)+1;
+    if (level > 49)
+    {
+        QString msg = "You are already at the max level!";
+        qCDebug(logSlashCommand) << msg;
+        sendInfoMessage(MessageChannel::USER_ERROR, msg, sess);
+        return;
+    }
 
     // XP must be high enough for the level you're advancing to
     GameDataStore &data(getGameData());

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -1177,7 +1177,8 @@ void removeTask(MapClientSession &src, Task task)
 void train (MapClientSession &sess)
 {
     uint level = getLevel(*sess.m_ent->m_char)+1;
-    if (level > 49)
+    GameDataStore &data(getGameData());
+    if (level > data.expMaxLevel())
     {
         QString msg = "You are already at the max level!";
         qCDebug(logSlashCommand) << msg;
@@ -1186,7 +1187,6 @@ void train (MapClientSession &sess)
     }
 
     // XP must be high enough for the level you're advancing to
-    GameDataStore &data(getGameData());
     if(getXP(*sess.m_ent->m_char) < data.expForLevel(level))
     {
         QString msg = "You do not have enough Experience Points to train to the next level!";

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -919,6 +919,7 @@ void cmdHandler_AddEntirePowerSet(const QString &cmd, MapClientSession &sess)
     {
         qCDebug(logSlashCommand) << "Bad invocation:" << cmd;
         sendInfoMessage(MessageChannel::USER_ERROR, "Bad invocation: " + cmd, sess);
+        return;
     }
 
     QString msg = QString("Granting Entire PowerSet <%1, %2> to %3").arg(v1).arg(v2).arg(sess.m_ent->name());
@@ -1319,6 +1320,7 @@ void cmdHandler_MoveTo(const QString &cmd, MapClientSession &sess)
     {
         qCDebug(logSlashCommand) << "Bad invocation:"<<cmd;
         sendInfoMessage(MessageChannel::USER_ERROR, "Bad invocation:"+cmd, sess);
+        return;
     }
 
     glm::vec3 new_pos {
@@ -1929,7 +1931,11 @@ void cmdHandler_EmailSend(const QString &cmd, MapClientSession &sess)
             result.push_back(parts[i]);
     }
 
-    assert(result.size() >= 5);
+    if (result.size() >= 5)
+    {
+        sendInfoMessage(MessageChannel::SERVER, "Too many arguements!", sess);
+        return;
+    }
     result[1].replace("\\q ", "");
     result[1].replace("\\q", "");
 


### PR DESCRIPTION
## Summary
From a discussion in discord, train is causing asserts due to checking the level higher than you current, which causes expForLevel to assert. I added an error message to train(), and changed the assert in expforlevel into a min0 max49 so we won't have this problem again.

Also, an assert in emails that shouldn't be needed, and 2 returns that are needed to prevent asserting. 