### PR TITLE
Spawn correctly on zone change and stop asserts on Pelegrine Island

### DIFF
--- a/Projects/CoX/Common/Runtime/SceneGraph.cpp
+++ b/Projects/CoX/Common/Runtime/SceneGraph.cpp
@@ -282,12 +282,13 @@ void addChildNodes(const SceneGraphNode_Data &inp_data, SceneNode *node, Loading
     {
         const QString new_name = groupRename(ctx, dat.name, false);
         SceneNodeChildTransform child;
-        child.node = getNodeByName(*ctx.m_target,new_name);
+        child.node = getNodeByName(*ctx.m_target, new_name);
         if( !child.node )
         {
-            bool loaded=store.loadNamedPrefab(new_name,ctx);
-            assert(loaded);
-            child.node = getNodeByName(*ctx.m_target,new_name);
+            bool loaded = store.loadNamedPrefab(new_name, ctx);
+            if(!loaded)
+                qCritical() << "Cannot load named prefab" << new_name << "result is" << loaded;
+            child.node = getNodeByName(*ctx.m_target, new_name);
         }
         // construct from euler angles
         glm::quat qPitch = glm::angleAxis(dat.rot.x, glm::vec3(-1, 0, 0));

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -2032,6 +2032,9 @@ void MapInstance::on_client_resumed(ClientResumedRendering *ev)
     }
     else
     {
+        glm::vec3 spawn_loc = session.m_current_map->closest_safe_location(session.m_ent->m_entity_data.m_pos);
+        // force position into safe spawner. Works for most zones.
+        forcePosition(*session.m_ent, spawn_loc);
         // else don't send motd, as this is from a map transfer
         // TODO: check if there's a better place to complete the map transfer..
         map_server->session_xfer_complete(session.link()->session_token());


### PR DESCRIPTION
## Summary
Spawn correctly on zone change and stop asserts on Pelegrine Island

### Issues closed
Closes #695 
Fixes spawning under map (on some zones)

### Additions/modifications proposed in this pull request:
- Replaces the assert in addChildNode() with a qCritical()
- Fixes spawning under the map on some zones by finding the Spawners and using those. Doesn't seem to work everywhere because :man_shrugging: 
