### PR TITLE
Hash all spawners and use them to spawn and mapxfer

### DIFF
--- a/Components/serialization_common.h
+++ b/Components/serialization_common.h
@@ -15,6 +15,7 @@
 #include <cereal/cereal.hpp>
 
 #include <QtCore/QString>
+#include <QtCore/QDir>
 #include <QtCore/QFile>
 #include <QtCore/QDebug>
 
@@ -59,9 +60,11 @@ void commonSaveTo(const T & target, const char *classname, const QString & baseN
 }
 
 template<class T>
-bool commonReadFrom(const QString &crl_path,const char *classname, T &target) {
+bool commonReadFrom(const QString &crl_path,const char *classname, T &target)
+{
     QFile ifl(crl_path);
-    if(crl_path.endsWith("json") || crl_path.endsWith("crl_json")) {
+    if(crl_path.endsWith("json") || crl_path.endsWith("crl_json"))
+    {
         if(!ifl.open(QFile::ReadOnly|QFile::Text))
         {
             qWarning() << "Failed to open" << crl_path;

--- a/Projects/CoX/Common/GameData/Clue.cpp
+++ b/Projects/CoX/Common/GameData/Clue.cpp
@@ -5,8 +5,6 @@
  * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
  */
 
-#pragma once
-
 #include "Clue.h"
 #include "Logging.h"
 #include "serialization_common.h"

--- a/Projects/CoX/Common/GameData/scenegraph_serializers.cpp
+++ b/Projects/CoX/Common/GameData/scenegraph_serializers.cpp
@@ -395,7 +395,7 @@ QString getFilepathCaseInsensitive(QString fpath)
     QStringList files = dir.entryList(QDir::Files | QDir::NoSymLinks);
     for(QString &f : files)
     {
-        qCDebug(logScenegraph) << "Comparing" << f << fpath;
+        qCDebug(logSceneGraph) << "Comparing" << f << fpath;
         if(fpath.endsWith(f, Qt::CaseInsensitive))
             fpath = base_path + "/" + f;
     }

--- a/Projects/CoX/Common/GameData/scenegraph_serializers.h
+++ b/Projects/CoX/Common/GameData/scenegraph_serializers.h
@@ -17,5 +17,6 @@ static constexpr uint32_t scenegraph_i0_2_requiredCrc=0xD3432007;
 bool loadFrom(BinStore *s,SceneGraph_Data &target);
 bool loadFrom(const QString &filepath,SceneGraph_Data &target);
 void saveTo(const SceneGraph_Data &target,const QString &baseName,bool text_format=false);
+QString getFilepathCaseInsensitive(QString fpath);
 //! Generic loader function will load cereal version, or if that does not exists a bin version
 bool LoadSceneData(const QString &fname, SceneGraph_Data &scenegraph);

--- a/Projects/CoX/Common/Runtime/SceneGraph.cpp
+++ b/Projects/CoX/Common/Runtime/SceneGraph.cpp
@@ -230,7 +230,7 @@ void addRoot(const SceneRootNode_Data &refload, LoadingContext &ctx, PrefabStore
     }
     if(!def)
     {
-        qCritical() << "Missing reference:"<<newname;
+        qCritical() << "Missing reference:" << newname;
         return;
     }
     auto ref = newRef(*ctx.m_target);
@@ -639,8 +639,10 @@ SceneGraph *loadWholeMap(const QString &filename)
     ctx.m_base_path = filename.mid(0, geobin_idx);
     assert(rd.m_prefab_mapping);
     QString upcase_city = filename;
-    upcase_city.replace("city","City");
-    upcase_city.replace("zones","Zones");
+    upcase_city.replace("city", "City");
+    upcase_city.replace("hazard", "Hazard");
+    upcase_city.replace("trial", "Trial");
+    upcase_city.replace("zones", "Zones");
     rd.m_prefab_mapping->sceneGraphWasReset();
     bool res = loadSceneGraph(upcase_city.mid(maps_idx), ctx, *rd.m_prefab_mapping);
     if(!res)

--- a/Projects/CoX/Common/Runtime/SceneGraph.h
+++ b/Projects/CoX/Common/Runtime/SceneGraph.h
@@ -103,7 +103,7 @@ struct PrefabStore;
 struct LoadingContext;
 
 bool loadSceneGraph(const QString &path, LoadingContext &ctx, PrefabStore &prefabs);
-SceneGraph *loadWholeMap(const QString &path);
+SceneGraph *loadWholeMap(const QString &filename);
 void loadSubgraph(const QString &filename, LoadingContext &ctx,PrefabStore &prefabs);
 SceneNode * getNodeByName(const SceneGraph &graph,const QString &name);
 } // and of SEGS namespace

--- a/Projects/CoX/Servers/MapServer/MapInstance.h
+++ b/Projects/CoX/Servers/MapServer/MapInstance.h
@@ -115,8 +115,7 @@ class MapInstance final : public EventProcessor
         using SessionStore = ClientSessionStore<MapClientSession>;
         using ScriptEnginePtr = std::unique_ptr<ScriptingEngine>;
         QString                m_data_path;
-        std::vector<glm::mat4>  m_new_player_spawns;
-        std::vector<glm::mat4>  m_all_zone_spawns;
+        QMultiHash<QString, glm::mat4>  m_all_spawners;
         std::unique_ptr<SEGSTimer> m_world_update_timer;
         std::unique_ptr<SEGSTimer> m_resend_timer;
         std::unique_ptr<SEGSTimer> m_link_timer;
@@ -148,6 +147,7 @@ public:
         void                    load_map_lua();
         bool                    spin_up_for(uint8_t game_server_id, uint32_t owner_id, uint32_t instance_id);
         void                    start(const QString &scenegraph_path);
+        void                    setPlayerSpawn(Entity &e);
         glm::vec3               closest_safe_location(glm::vec3 v) const;
 
 protected:

--- a/Projects/CoX/Servers/MapServer/MapSceneGraph.h
+++ b/Projects/CoX/Servers/MapServer/MapSceneGraph.h
@@ -20,23 +20,6 @@ struct SceneGraph;
 struct SceneNode;
 } // namespace SEGS
 
-static const QStringList s_starting_spawn_nodes = {
-    "PlayerSpawn",
-    "_PlayerSpawn",
-    "NewPlayer",
-};
-
-static const QStringList s_spawn_nodes = {
-    "ExitPoint",
-    "LinkFrom_Monorail_Red",
-    "LinkFrom_Monorail_Blue",
-    "LinkFrom_City_01_01",
-    "LinkFrom_City_02_01",
-    "LinkFrom_City_02_02",
-    "LinkFrom_Hazard_01_01",
-    "LinkFrom_Trial_01_01",
-};
-
 ///
 /// \brief The MapSceneGraph class and functions operating on it are central point of access to the world's geometry
 ///
@@ -46,14 +29,11 @@ class MapSceneGraph
     //! Contains all nodes from the scene graph that have any properties set, for faster lookups.
     //! @todo consider creating a property-name => [SceneNode,SceneNode] mapping instead ?
     std::vector<SEGS::SceneNode *> m_nodes_with_properties;
-    glm::vec3 m_spawn_point;
 public:
     MapSceneGraph();
     ~MapSceneGraph();
     bool loadFromFile(const QString &mapname);
-    void set_default_spawn_point(glm::vec3 loc) { m_spawn_point = loc; }
-    glm::vec3 spawn_location() const { return m_spawn_point; }
-    std::vector<glm::mat4> spawn_points(const QStringList &kinds) const;
+    QMultiHash<QString, glm::mat4> getSpawnPoints() const;
     void spawn_npcs(class MapInstance *instance);
     void build_combat_navigation_graph();
     void build_pedestrian_navigation_graph();

--- a/Projects/CoX/Servers/MapServer/NpcGenerator.cpp
+++ b/Projects/CoX/Servers/MapServer/NpcGenerator.cpp
@@ -37,8 +37,8 @@ void NpcGenerator::generate(MapInstance *map_instance)
         Entity *e = map_instance->m_entities.CreateGeneric(getGameData(), *npc_def, idx, 0, m_type);
         e->m_char->setName(makeReadableName(npc_costume_name));
         forcePosition(*e, glm::vec3(v[3]));
-        auto valquat = glm::quat_cast(v);
 
+        auto valquat = glm::quat_cast(v);
         glm::vec3 angles = glm::eulerAngles(valquat);
         angles.y += glm::pi<float>();
         forceOrientation(*e, angles);

--- a/Projects/CoX/Servers/MapServer/ScriptingEngine.cpp
+++ b/Projects/CoX/Servers/MapServer/ScriptingEngine.cpp
@@ -384,8 +384,7 @@ void ScriptingEngine::registerTypes()
         "begin_logout",  &Entity::beginLogout
     );
     m_private->m_lua.new_usertype<MapSceneGraph>( "MapSceneGraph",
-        "new", sol::no_constructor, // The client links are not constructible from the script side.
-        "set_default_spawn_point", &MapSceneGraph::set_default_spawn_point
+        "new", sol::no_constructor // The client links are not constructible from the script side.
     );
     m_private->m_lua.script("function ErrorHandler(msg) return \"Lua call error:\"..msg end");
     m_private->m_lua["printDebug"] = [](const char* msg)

--- a/Projects/CoX/Servers/MapServer/SlashCommand.cpp
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.cpp
@@ -1480,7 +1480,8 @@ void cmdHandler_SetSpecialTitle(const QString &cmd, MapClientSession &sess)
 void cmdHandler_Stuck(const QString &cmd, MapClientSession &sess)
 {
     // TODO: Implement true move-to-safe-location-nearby logic
-    forcePosition(*sess.m_ent, sess.m_current_map->closest_safe_location(sess.m_ent->m_entity_data.m_pos));
+    //forcePosition(*sess.m_ent, sess.m_current_map->closest_safe_location(sess.m_ent->m_entity_data.m_pos));
+    sess.m_current_map->setPlayerSpawn(*sess.m_ent);
 
     QString msg = QString("Resetting location to default spawn <%1, %2, %3>")
             .arg(sess.m_ent->m_entity_data.m_pos.x, 0, 'f', 1)


### PR DESCRIPTION
## Summary
Correct an issue with typecase when loading bin files, and load all spawners into a MultiHash that we can reference for spawning.

### Issues closed
Closes #469 
Resolves falling under the map

### Additions/modifications proposed in this pull request:
- Ignore typecase when loading bin files
- Load all spawners on a map into a MultiHash
- Use MultiHash to spawn new characters and properly zone transfer
- Couple minor code cleanups
