### PR TITLE
mysql: Unremove `costume` table removal

### DIFF
--- a/Projects/CoX/Data/mysql/segs_game_mysql_create.sql
+++ b/Projects/CoX/Data/mysql/segs_game_mysql_create.sql
@@ -9,6 +9,9 @@ SET time_zone = "+00:00";
 DROP TABLE IF EXISTS `table_versions`;
 DROP TABLE IF EXISTS `supergroups`;
 DROP TABLE IF EXISTS `progress`;
+-- The costume table is no more but for compatibility with older releases
+-- we want to make sure to still remove it.
+DROP TABLE IF EXISTS `costume`;
 DROP TABLE IF EXISTS `emails`;
 DROP TABLE IF EXISTS `characters`;
 DROP TABLE IF EXISTS `accounts`;


### PR DESCRIPTION
Updating a MySQL-server from pre-tailor PR to current develop HEAD crashes because of foreign key constraints no longer being taken care of in the correct order.

Having references to old tables which shouldn't exist anymore might feel silly, but it makes the admin life easier.