### PR TITLE
Add RPC endpoints and reading from settings file.

### DIFF
--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -1,16 +1,55 @@
 #include "AdminRPC.h"
+#include "AuthHandler.h"
+#include "version.h"
+#include "ConfigExtension.h"
+#include "Settings.h"
+
 #include "jcon/json_rpc_server.h"
 #include "jcon/json_rpc_websocket_server.h"
 
-#include "AuthHandler.h"
-#include "version.h"
-
 #include <QVariant>
 #include <QJsonDocument>
+#include <QtCore/QSettings>
+#include <QtCore/QString>
 
 using namespace jcon;
 AdminRPC::AdminRPC()
 {
+    SetStartTime();
+    ReadConfig();
+}
+
+void AdminRPC::SetStartTime()
+{
+    m_start_time = QString::number(QDateTime::currentSecsSinceEpoch());
+}
+
+/*!
+ * @brief Read server configuration
+ * @note m_mutex is held locked during this function
+ * @return bool, if it's false, this function failed somehow.
+ */
+bool AdminRPC::ReadConfig()
+{
+    ACE_Guard<ACE_Thread_Mutex> guard(m_mutex);
+
+    qInfo() << "Loading AdminRPC settings...";
+    QSettings config(Settings::getSettingsPath(),QSettings::IniFormat,nullptr);
+
+    config.beginGroup(QStringLiteral("AdminRPC"));
+    if(!config.contains(QStringLiteral("location_addr")))
+        qDebug() << "Config file is missing 'location_addr' entry in AdminRPC group, will try to use default";
+
+    QString location_addr = config.value(QStringLiteral("location_addr"),"127.0.0.1:6001").toString();
+    config.endGroup(); // AdminRPC
+
+    if(!parseAddress(location_addr,m_location))
+    {
+        qCritical() << "Badly formed IP address: " << location_addr;
+        return false;
+    }
+
+    return true;
 }
 
 bool AdminRPC::heyServer()
@@ -31,13 +70,25 @@ QString AdminRPC::getVersion()
     return version;
 }
 
-void startWebSocketServer(const char *addr, int port)
+QString AdminRPC::ping()
+{
+    QString response = "pong";
+    return response;
+}
+
+QString AdminRPC::getStartTime()
+{
+    return m_start_time;
+}
+
+void startWebSocketServer()
 {
     static jcon::JsonRpcWebSocketServer *m_server;
     if(!m_server)
     {
         m_server = new JsonRpcWebSocketServer();
     }
-    m_server->registerServices({ new AdminRPC() });
-    m_server->listen(QHostAddress(addr),port);
+    AdminRPC* m_adminrpc = new AdminRPC();
+    m_server->registerServices({ m_adminrpc });
+    m_server->listen(QHostAddress(m_adminrpc->m_location.get_host_addr()),m_adminrpc->m_location.get_port_number());
 }

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -1,20 +1,39 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.io/
+ * Copyright (c) 2006 - 2018 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+
 #pragma once
+
+// ACE includes
+#include <ace/INET_Addr.h>
+#include <ace/Synch.h>
 
 #include <QObject>
 #include <QVariant>
+#include <QtCore/QDateTime>
 
 class AdminRPC : public QObject
 {
     Q_OBJECT
-    friend void startWebSocketServer(const char *addr,int port);
     class AuthHandler *m_auth_handler;
+    friend void startWebSocketServer();
 private:
     AdminRPC(); // restrict construction to startWebSocketServer
 public:
-
     Q_INVOKABLE bool heyServer();
     Q_INVOKABLE QString helloServer();
     Q_INVOKABLE QString getVersion();
+    Q_INVOKABLE QString getStartTime();
+    Q_INVOKABLE QString ping();
+protected:
+    ACE_INET_Addr                       m_location;     //!< address websockets will bind at.
+    ACE_Thread_Mutex                    m_mutex;        //!< used to prevent multiple threads accessing config reload function
+    bool                                ReadConfig();
+    void 								SetStartTime();
+    QString                             m_start_time;
 };
 
-void startWebSocketServer(const char *addr="127.0.0.1",int port=6001);
+void startWebSocketServer();


### PR DESCRIPTION
## Summary
Added additional RPC endpoints, as well as code to read RPC IP and port from settings.cfg

Closes #692 

### Additions/modifications proposed in this pull request:
- Related to issues #692 and #633
- Added code to read the pertinent section from settings.cfg. It looks for AdminRPC and loads IP and port string if it exists. If it does not, it uses a default of 127.0.0.1:6001
- Added RPC endpoint `getStartTime` to return server start time (as UNIX epoch). This enables SEGS WebUI to calculate uptime for the dashboard.
- Added RPC endpoint `ping` to return string "pong" as a check if the server is online. `heyServer` and `helloServer` already exist, but this endpoint and response seem to be a semi-standard method (in that I've seen it in multiple other RPC interfaces).

These RPC services can be seen in action at https://segs.verybadpanda.com (WebUI prototype with additional customizations) or http://segs-webui-demo.verybadpanda.com (vanilla WebUI prototype). Log in can be done with the username/password `demo/demo`.