### PR TITLE
Fix jcon build under macOS and re-enable Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,11 +64,10 @@ matrix:
       compiler: "gcc-7"
       env: BUILD='Debug' CC=gcc-7 CXX=g++-7
       addons: *gcc7
-# Disabling macOS builds temporarily until the app bundle issue can be resolved
-#   - os: osx
-#     osx_image: xcode9.2
-#     compiler: clang
-#     env: BUILD='Debug'
+    - os: osx
+      osx_image: xcode9.2
+      compiler: clang
+      env: BUILD='Debug'
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo add-apt-repository ppa:beineri/opt-qt593-trusty -y; fi

--- a/3rd_party/jcon-cpp/src/CMakeLists.txt
+++ b/3rd_party/jcon-cpp/src/CMakeLists.txt
@@ -26,21 +26,21 @@ if(USE_QT)
     find_program(QT_UIC_EXECUTABLE uic)
 endif()
 
-if(APPLE)
-    # icon
-    if(EXISTS "${PROJECT_NAME}.icns")
-        # set how it shows up in the Info.plist file
-        set(MACOSX_BUNDLE_ICON_FILE ${PROJECT_NAME}.icns)
-
-        # set where in the bundle to put the icns file
-        set_source_files_properties(${PROJECT_NAME}.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-
-        # include the icns file in the target
-        set(${PROJECT_NAME}_sources ${${PROJECT_NAME}_sources} ${PROJECT_NAME}.icns)
-    endif()
-
-    add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${${PROJECT_NAME}_headers} ${${PROJECT_NAME}_sources} ${UI_HEADERS})
-elseif(WIN32)
+#if(APPLE)
+#    # icon
+#    if(EXISTS "${PROJECT_NAME}.icns")
+#        # set how it shows up in the Info.plist file
+#        set(MACOSX_BUNDLE_ICON_FILE ${PROJECT_NAME}.icns)
+#
+#        # set where in the bundle to put the icns file
+#        set_source_files_properties(${PROJECT_NAME}.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+#
+#        # include the icns file in the target
+#        set(${PROJECT_NAME}_sources ${${PROJECT_NAME}_sources} ${PROJECT_NAME}.icns)
+#    endif()
+#
+#    add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${${PROJECT_NAME}_headers} ${${PROJECT_NAME}_sources} ${UI_HEADERS})
+if(WIN32)
     add_executable(${PROJECT_NAME} WIN32 ${${PROJECT_NAME}_headers} ${${PROJECT_NAME}_sources} ${UI_HEADERS})
 else()
     add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_headers} ${${PROJECT_NAME}_sources} ${UI_HEADERS})
@@ -53,23 +53,23 @@ if(USE_QT)
     qt5_use_modules(${PROJECT_NAME} Core Network Test WebSockets Widgets)
 endif()
 
-if(APPLE)
-    set(APPS "\${CMAKE_INSTALL_PREFIX}/bin/${PROJECT_NAME}")
-
-    set(plugin_dest_dir ${PROJECT_NAME}.app/Contents/MacOS)
-    set(APPS "\${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}.app")
-
-    install(CODE "
-            include(BundleUtilities)
-            fixup_bundle(\"${APPS}\" \"\" \"${DIRS}\")
-            " COMPONENT Runtime)
-
-else()
+#if(APPLE)
+#    set(APPS "\${CMAKE_INSTALL_PREFIX}/bin/${PROJECT_NAME}")
+#
+#    set(plugin_dest_dir ${PROJECT_NAME}.app/Contents/MacOS)
+#    set(APPS "\${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}.app")
+#
+#    install(CODE "
+#            include(BundleUtilities)
+#            fixup_bundle(\"${APPS}\" \"\" \"${DIRS}\")
+#            " COMPONENT Runtime)
+#
+#else()
     install(TARGETS ${EXECUTABLE_NAME}
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib/static)
-endif()
+#endif()
 
 if(MINGW)
     get_filename_component(MINGW_DIR ${CMAKE_C_COMPILER} PATH)

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -124,7 +124,7 @@ bool GameDbSyncContext::loadAndConfigure()
 
     if(!m_db->open())
     {
-        qFatal("Failed to open database: %s", dbname);
+        qFatal("Failed to open database: %s", dbname.toStdString().c_str());
         return false;
     }
 


### PR DESCRIPTION
## Summary
This PR provides a workaround for the failing jcon build under macOS and also re-enables Travis builds for the same platform.

### Issues closed
Closes #714
