### PR TITLE
Add updateClientContext declaration

### DIFF
--- a/Projects/CoX/Servers/MapServer/ScriptingEngine_Null.cpp
+++ b/Projects/CoX/Servers/MapServer/ScriptingEngine_Null.cpp
@@ -18,6 +18,11 @@ ScriptingEngine::ScriptingEngine() {}
 ScriptingEngine::~ScriptingEngine() {}
 void ScriptingEngine::registerTypes() {}
 
+void updateClientContext(MapClientSession * client)
+{
+    Q_UNUSED(client);
+}
+
 int ScriptingEngine::runScript(const QString &script_contents, const char *script_name)
 {
     Q_UNUSED(script_contents);


### PR DESCRIPTION
## Summary
Fixes the missing updateClientContext() errors for those with ENABLE_SCRIPTING_ENGINE set to OFF

### Additions/modifications proposed in this pull request:
- add updateClientContext declaration to ScriptingEngine_NULL.cpp
