### PR TITLE
Updated travis badge to new dot com address [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <img src="docs/segs-medallion-med.png" align="right" alt="SEGS Logo">
 
-[![master Build Status](https://travis-ci.org/Segs/Segs.svg)](https://travis-ci.org/Segs/Segs)
+[![master Build Status](https://travis-ci.com/Segs/Segs.svg)](https://travis-ci.org/Segs/Segs)
 [![master Build Status](https://ci.appveyor.com/api/projects/status/github/segs/segs?svg=true)](https://ci.appveyor.com/project/nemerle/Segs)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/SEGS/segs.svg)](http://isitmaintained.com/project/SEGS/segs "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/SEGS/segs.svg)](http://isitmaintained.com/project/SEGS/segs "Percentage of issues still open")


### PR DESCRIPTION
## Summary
Updated travis badge to new dot com address.

This means it'll go Red now that builds are failing.
