### PR TITLE
rpc: Switch from websockets to TCP

### DIFF
--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -5,7 +5,7 @@
 #include "Settings.h"
 
 #include "jcon/json_rpc_server.h"
-#include "jcon/json_rpc_websocket_server.h"
+#include "jcon/json_rpc_tcp_server.h"
 
 #include <QVariant>
 #include <QJsonDocument>
@@ -81,12 +81,12 @@ QString AdminRPC::getStartTime()
     return m_start_time;
 }
 
-void startWebSocketServer()
+void startRPCServer()
 {
-    static jcon::JsonRpcWebSocketServer *m_server;
+    static jcon::JsonRpcTcpServer *m_server;
     if(!m_server)
     {
-        m_server = new JsonRpcWebSocketServer();
+        m_server = new JsonRpcTcpServer();
     }
     AdminRPC* m_adminrpc = new AdminRPC();
     m_server->registerServices({ m_adminrpc });

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -19,7 +19,7 @@ class AdminRPC : public QObject
 {
     Q_OBJECT
     class AuthHandler *m_auth_handler;
-    friend void startWebSocketServer();
+    friend void startRPCServer();
 private:
     AdminRPC(); // restrict construction to startWebSocketServer
 public:
@@ -36,4 +36,4 @@ protected:
     QString                             m_start_time;
 };
 
-void startWebSocketServer();
+void startRPCServer();

--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -286,8 +286,8 @@ ACE_INT32 ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
     qInfo().noquote() << "main";
 
-    // Create websocket jsonrpc admin interface
-    startWebSocketServer();
+    // Create jsonrpc admin interface
+    startRPCServer();
 
     bool no_err = CreateServers();
     if(!no_err)


### PR DESCRIPTION
## Summary
Switch the jcon-cpp interface from websockets to TCP.
This is needed for the WebUI to actually work as we don't have any security measures in place and thus preferably only allow local connections to the RPC interface.

Please note that this change breaks the current SEGSAdmin RPC implementation.

### Additions/modifications proposed in this pull request:
- RPC protocol changed from WebSockets to "regular" TCP
- `startWebSocketServer()` renamed to `startRPCServer()`