### PR TITLE
Extend AdminRPC server and update settings_template.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ out/
 
 # Environment activation script
 activate.env
+.directory

--- a/Components/Logging.cpp
+++ b/Components/Logging.cpp
@@ -51,6 +51,7 @@ SEGS_LOGGING_CATEGORY(logScripts,      "log.scripts")
 SEGS_LOGGING_CATEGORY(logSceneGraph,   "log.scenegraph")
 SEGS_LOGGING_CATEGORY(logStores,       "log.stores")
 SEGS_LOGGING_CATEGORY(logTasks,        "log.tasks")
+SEGS_LOGGING_CATEGORY(logRPC,          "log.rpc")
 
 void setLoggingFilter()
 {
@@ -89,6 +90,7 @@ void setLoggingFilter()
     filter_rules += "\nlog.scenegraph="     + config.value("log_scenegraph","false").toString();
     filter_rules += "\nlog.stores="         + config.value("log_stores","false").toString();
     filter_rules += "\nlog.tasks="          + config.value("log_tasks","false").toString();
+    filter_rules += "\nlog.rpc="            + config.value("log_rpc","false").toString();
     config.endGroup(); // Logging
 
     QLoggingCategory::setFilterRules(filter_rules);
@@ -165,6 +167,8 @@ void toggleLogging(QString &category)
         cat = &logStores();
     else if(category.contains("tasks",Qt::CaseInsensitive))
         cat = &logTasks();
+    else if(category.contains("rpc",Qt::CaseInsensitive))
+        cat = &logRPC();
     else
         return;
 
@@ -207,6 +211,9 @@ void dumpLogging()
     output += "\n\t tailor: "       + QString::number(logTailor().isDebugEnabled());
     output += "\n\t scripts: "      + QString::number(logScripts().isDebugEnabled());
     output += "\n\t scenegraph: "   + QString::number(logSceneGraph().isDebugEnabled());
+    output += "\n\t stores: "       + QString::number(logStores().isDebugEnabled());
+    output += "\n\t tasks: "        + QString::number(logTasks().isDebugEnabled());
+    output += "\n\t rpc: "          + QString::number(logRPC().isDebugEnabled());
 
     qDebug().noquote() << output;
 }

--- a/Components/Logging.h
+++ b/Components/Logging.h
@@ -44,6 +44,7 @@ SEGS_DECLARE_LOGGING_CATEGORY(logScripts)
 SEGS_DECLARE_LOGGING_CATEGORY(logSceneGraph)
 SEGS_DECLARE_LOGGING_CATEGORY(logStores)
 SEGS_DECLARE_LOGGING_CATEGORY(logTasks)
+SEGS_DECLARE_LOGGING_CATEGORY(logRPC)
 
 void    setLoggingFilter();
 void    toggleLogging(QString &category);

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -12,13 +12,14 @@
 #      for example: 10.0.0.2
 #
 #    Default ports are listed below:
-#      AccountDatabase db_port:		5432
-#      CharacterDatabase db_port:	5432
-#      AuthServer location_addr:	2106
-#      GameServer listen_addr:		7002
-#      GameServer location_addr:	7002
-#      MapServer listen_addr:		7003
-#      MapServer location_addr:		7003
+#      AccountDatabase      db_port:            5432
+#      CharacterDatabase    db_port:            5432
+#      AuthServer           location_addr:      2106
+#      GameServer           listen_addr:        7002
+#      GameServer           location_addr:      7002
+#      MapServer            listen_addr:        7003
+#      MapServer            location_addr:      7003
+#      AdminRPC             location_addr:      6001
 #
 ##############################################################
 
@@ -40,23 +41,16 @@ CharacterDatabase\db_pass   = segs123
 location_addr           = 127.0.0.1:2106
 
 ##############################################################
-# By default, the JSON-RPC server only listens on the servers
-# loopback interface (127.0.0.1) on port 6001. The RPC server
-# also supports TCP and Websocket connections, using TCP by
-# by default. Uncommenting the following section and setting
-# the parameters to an alternative interface IP and port
-# values will allow the RPC server to listen on those values. 
+#    AdminRPC is the JSON-RPC server. It supports TCP and
+#    Websocket connections, using TCP by default.
+#
+#    Uncommenting the following section and setting the
+#    parameters will allow the RPC server to listen on an
+#    alternative interface IP address and port. The server type
+#    can be changed as well. 
 # 
 #  location_addr  Can be any valid IP and port combination
-#                 for the server. To find your IP:
-#                 * If running on a linux system, run 
-#                   'ip address' or 'ifconfig' in a terminal
-#                   window to show the available IPs.
-#                 * On Windows, open a command prompt and run
-#                   'ipconfig' to show the available IPs.
-#                 Choose a displayed IP that corresponds to an
-#                 interface connected to your local network.
-#                 DEFAULT: 127.0.0.1:6001
+#                 for the server.
 #
 #  server_type    Can be either 'websockets' or 'tcp'.
 #                 DEFAULT: tcp

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -39,6 +39,34 @@ CharacterDatabase\db_pass   = segs123
 [AuthServer]
 location_addr           = 127.0.0.1:2106
 
+##############################################################
+# By default, the JSON-RPC server only listens on the servers
+# loopback interface (127.0.0.1) on port 6001. The RPC server
+# also supports TCP and Websocket connections, using TCP by
+# by default. Uncommenting the following section and setting
+# the parameters to an alternative interface IP and port
+# values will allow the RPC server to listen on those values. 
+# 
+#  location_addr  Can be any valid IP and port combination
+#                 for the server. To find your IP:
+#                 * If running on a linux system, run 
+#                   'ip address' or 'ifconfig' in a terminal
+#                   window to show the available IPs.
+#                 * On Windows, open a command prompt and run
+#                   'ipconfig' to show the available IPs.
+#                 Choose a displayed IP that corresponds to an
+#                 interface connected to your local network.
+#                 DEFAULT: 127.0.0.1:6001
+#
+#  server_type    Can be either 'websockets' or 'tcp'.
+#                 DEFAULT: tcp
+#
+##############################################################
+
+#[AdminRPC]
+#location_addr           = 127.0.0.1:6001
+#server_type             = tcp
+
 [GameServer] 
 listen_addr             = 127.0.0.1:7002
 location_addr           = 127.0.0.1:7002

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -52,7 +52,7 @@ location_addr           = 127.0.0.1:2106
 #  location_addr  Can be any valid IP and port combination
 #                 for the server.
 #
-#  server_type    Can be either 'websockets' or 'tcp'.
+#  server_type    Can be either 'websocket' or 'tcp'.
 #                 DEFAULT: tcp
 #
 ##############################################################

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -119,3 +119,6 @@ log_trades          = false
 log_tailor          = false
 log_scripts         = false
 log_scenegraph      = false
+log_stores          = false
+log_tasks           = false
+log_rpc             = false

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -37,7 +37,7 @@ bool AdminRPC::ReadConfig()
 {
     ACE_Guard<ACE_Thread_Mutex> guard(m_mutex);
 
-    qCInfo(logRPC) << "Loading AdminRPC settings...";
+    qInfo() << "Loading AdminRPC settings...";
     QSettings config(Settings::getSettingsPath(),QSettings::IniFormat,nullptr);
 
     config.beginGroup(QStringLiteral("AdminRPC"));
@@ -45,6 +45,10 @@ bool AdminRPC::ReadConfig()
         qCDebug(logRPC) << "Config file is missing 'location_addr' entry in AdminRPC group, will try to use default";
 
     QString location_addr = config.value(QStringLiteral("location_addr"),"127.0.0.1:6001").toString();
+
+    if(!config.contains(QStringLiteral("server_type")))
+        qCDebug(logRPC) << "Config file is missing 'server_type' entry in AdminRPC group, will try to use default";
+
     QString server_type = config.value(QStringLiteral("server_type"),"tcp").toString();
 
     if(server_type == "websocket")
@@ -56,7 +60,7 @@ bool AdminRPC::ReadConfig()
 
     if(!parseAddress(location_addr,m_location))
     {
-        qCCritical(logRPC) << "Badly formed IP address: " << location_addr;
+        qCritical() << "Badly formed IP address '" << location_addr << "' in AdminRPC.";
         return false;
     }
     qCInfo(logRPC) << "Loading AdminRPC settings complete...";
@@ -104,12 +108,12 @@ void startRPCServer()
     {
         if (m_adminrpc->m_socket_type == SocketType::tcp)
         {
-            qCDebug(logRPC) << "Creating TCP server...";
+            qCDebug(logRPC) << "Creating RPC server using TCP...";
             m_server = new jcon::JsonRpcTcpServer();
         }
         else
         {
-            qCDebug(logRPC) << "Creating WebSocket server";
+            qCDebug(logRPC) << "Creating RPC server using WebSocket...";
             m_server = new jcon::JsonRpcWebSocketServer();
         }
     }

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -2,21 +2,27 @@
 #include "AuthHandler.h"
 #include "version.h"
 #include "ConfigExtension.h"
+
 #include "Settings.h"
 
 #include "jcon/json_rpc_server.h"
 #include "jcon/json_rpc_tcp_server.h"
+#include "jcon/json_rpc_websocket_server.h"
 
 #include <QVariant>
 #include <QJsonDocument>
 #include <QtCore/QSettings>
 #include <QtCore/QString>
+#include <QtCore/QDebug>
 
 using namespace jcon;
 AdminRPC::AdminRPC()
 {
     SetStartTime();
     ReadConfig();
+}
+AdminRPC::~AdminRPC()
+{
 }
 
 void AdminRPC::SetStartTime()
@@ -33,62 +39,81 @@ bool AdminRPC::ReadConfig()
 {
     ACE_Guard<ACE_Thread_Mutex> guard(m_mutex);
 
-    qInfo() << "Loading AdminRPC settings...";
+    qDebug() << "[ADMINRPC]: Start loading settings...";
     QSettings config(Settings::getSettingsPath(),QSettings::IniFormat,nullptr);
 
     config.beginGroup(QStringLiteral("AdminRPC"));
     if(!config.contains(QStringLiteral("location_addr")))
-        qDebug() << "Config file is missing 'location_addr' entry in AdminRPC group, will try to use default";
+        qDebug() << "[ADMINRPC]: Config file is missing 'location_addr' entry in AdminRPC group, will try to use default";
 
     QString location_addr = config.value(QStringLiteral("location_addr"),"127.0.0.1:6001").toString();
+    QString server_type = config.value(QStringLiteral("server_type"),"tcp").toString();
+    if(server_type == "tcp")
+    {
+        m_socket_type     = SocketType::tcp;
+    }
+    else
+    {
+        m_socket_type     = SocketType::websocket;
+    }
     config.endGroup(); // AdminRPC
 
     if(!parseAddress(location_addr,m_location))
     {
-        qCritical() << "Badly formed IP address: " << location_addr;
+        qCritical() << "[ADMINRPC]: Badly formed IP address: " << location_addr;
         return false;
     }
-
+    qDebug() << "[ADMINRPC]: Finished loading settings...";
     return true;
 }
 
 bool AdminRPC::heyServer()
 {
-    qDebug() << "Someone said hello !";
+    qDebug() << "[ADMINRPC::heyServer()]: Someone said hey!";
     return true;
 }
 
 QString AdminRPC::helloServer()
 {
+    qDebug() << "[ADMINRPC::helloServer()]: Someone said hello!";
     QString response = "Hello Web Browser!";
     return response;
 }
 
 QString AdminRPC::getVersion()
 {
+    qDebug() << "[ADMINRPC::getVersion()]: Someone got the version!";
     QString version = VersionInfo::getAuthVersionNumber() + QString(" ") + VersionInfo::getVersionName();
     return version;
 }
 
 QString AdminRPC::ping()
 {
+    qDebug() << "[ADMINRPC::ping()]: Someone sent a ping!";
     QString response = "pong";
     return response;
 }
 
 QString AdminRPC::getStartTime()
 {
+    qDebug() << "[ADMINRPC::getStartTime()]: Someone asked for the start time!";
     return m_start_time;
 }
 
 void startRPCServer()
 {
-    static jcon::JsonRpcTcpServer *m_server;
+    static jcon::JsonRpcServer *m_server;
+    AdminRPC* m_adminrpc = new AdminRPC();
     if(!m_server)
     {
-        m_server = new JsonRpcTcpServer();
+        if (m_adminrpc->m_socket_type == SocketType::tcp) {
+            qDebug() << "[ADMINRPC]: Creating TCP server";
+            m_server = new jcon::JsonRpcTcpServer();
+        } else {
+            qDebug() << "[ADMINRPC]: Creating WebSocket server";
+            m_server = new jcon::JsonRpcWebSocketServer();
+        }
     }
-    AdminRPC* m_adminrpc = new AdminRPC();
     m_server->registerServices({ m_adminrpc });
     m_server->listen(QHostAddress(m_adminrpc->m_location.get_host_addr()),m_adminrpc->m_location.get_port_number());
 }

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -27,7 +27,7 @@ class AdminRPC : public QObject
     class AuthHandler *m_auth_handler;
     friend void startRPCServer();
 private:
-    AdminRPC(); // restrict construction to startWebSocketServer
+    AdminRPC(); // restrict construction to startRPCServer
     ~AdminRPC();
 public:
     Q_INVOKABLE bool heyServer();
@@ -36,7 +36,7 @@ public:
     Q_INVOKABLE QString getStartTime();
     Q_INVOKABLE QString ping();
 protected:
-    ACE_INET_Addr                       m_location;     //!< address websockets will bind at.
+    ACE_INET_Addr                       m_location;     //!< address rpc server will bind at.
     ACE_Thread_Mutex                    m_mutex;        //!< used to prevent multiple threads accessing config reload function
     bool                                ReadConfig();
     void                                SetStartTime();

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -15,6 +15,11 @@
 #include <QVariant>
 #include <QtCore/QDateTime>
 
+enum class SocketType {
+    tcp,
+    websocket
+};
+
 class AdminRPC : public QObject
 {
     Q_OBJECT
@@ -22,6 +27,7 @@ class AdminRPC : public QObject
     friend void startRPCServer();
 private:
     AdminRPC(); // restrict construction to startWebSocketServer
+    ~AdminRPC();
 public:
     Q_INVOKABLE bool heyServer();
     Q_INVOKABLE QString helloServer();
@@ -34,6 +40,7 @@ protected:
     bool                                ReadConfig();
     void                                SetStartTime();
     QString                             m_start_time;
+    SocketType                          m_socket_type;
 };
 
 void startRPCServer();

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -15,7 +15,8 @@
 #include <QVariant>
 #include <QtCore/QDateTime>
 
-enum class SocketType {
+enum class SocketType
+{
     tcp,
     websocket
 };


### PR DESCRIPTION
## Summary
Update settings_template.cfg with AdminRPC section, with default values and instructions for use. Also added ability for user to specify RPC server type (tcp or websockets) that will be created by AuthServer. 

### Issues closed
Does not fully close any issue.

### Additions/modifications proposed in this pull request:
These features are referenced in issues #633, #692, and #742.

- Added:
Config section in settings_template.cfg for AdminRPC settings. 
- Modified:
`Projects/CoX/Servers/AuthServer/AdminRPC.cpp` and `Projects/CoX/Servers/AuthServer/AdminRPC.h` to support selection of RPC server type via config file.
