### PR TITLE
AdminRPC: change getVersion output and add getCodename

### DIFF
--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -87,11 +87,11 @@ QString AdminRPC::getVersion()
     return version;
 }
 
-QString AdminRPC::getCodename()
+QString AdminRPC::getVersionName()
 {
     qCDebug(logRPC) << "Someone requested the versions name...";
-    QString codename = VersionInfo::getVersionName();
-    return codename;
+    QString versionname = VersionInfo::getVersionName();
+    return versionname;
 }
 
 QString AdminRPC::ping()

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -83,8 +83,15 @@ QString AdminRPC::helloServer()
 QString AdminRPC::getVersion()
 {
     qCDebug(logRPC) << "Someone requested the version...";
-    QString version = VersionInfo::getAuthVersionNumber() + QString(" ") + VersionInfo::getVersionName();
+    QString version = VersionInfo::getAuthVersionNumber();
     return version;
+}
+
+QString AdminRPC::getCodename()
+{
+    qCDebug(logRPC) << "Someone requested the versions name...";
+    QString codename = VersionInfo::getVersionName();
+    return codename;
 }
 
 QString AdminRPC::ping()

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -83,15 +83,13 @@ QString AdminRPC::helloServer()
 QString AdminRPC::getVersion()
 {
     qCDebug(logRPC) << "Someone requested the version...";
-    QString version = VersionInfo::getAuthVersionNumber();
-    return version;
+    return VersionInfo::getAuthVersionNumber();
 }
 
 QString AdminRPC::getVersionName()
 {
     qCDebug(logRPC) << "Someone requested the versions name...";
-    QString versionname = VersionInfo::getVersionName();
-    return versionname;
+    return VersionInfo::getVersionName();
 }
 
 QString AdminRPC::ping()

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -33,6 +33,7 @@ public:
     Q_INVOKABLE bool heyServer();
     Q_INVOKABLE QString helloServer();
     Q_INVOKABLE QString getVersion();
+    Q_INVOKABLE QString getCodename();
     Q_INVOKABLE QString getStartTime();
     Q_INVOKABLE QString ping();
 protected:

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -33,7 +33,7 @@ public:
     Q_INVOKABLE bool heyServer();
     Q_INVOKABLE QString helloServer();
     Q_INVOKABLE QString getVersion();
-    Q_INVOKABLE QString getCodename();
+    Q_INVOKABLE QString getVersionName();
     Q_INVOKABLE QString getStartTime();
     Q_INVOKABLE QString ping();
 protected:


### PR DESCRIPTION
Removed the versions name from AdminRPC::getVersion and added  
the command AdminRPC::getCodename wich returns the versions name

## Summary
From a data processing point of view it is better if only one data type  
per field is used in the result output. (str, int, ..)  

inspired by:
```
 ⌁ root  ~   lsb_release -r
Release:        9.6
 ⌁ root  ~   lsb_release -c
Codename:       stretch
```
