### PR TITLE
Character creation bug fix and "EMPTY" string tidy

### DIFF
--- a/Projects/CoX/Common/GameData/Character.cpp
+++ b/Projects/CoX/Common/GameData/Character.cpp
@@ -56,11 +56,11 @@ Character::Character()
 
 void Character::reset()
 {
-    m_name                                  = "EMPTY";
+    m_name                                  = EMPTY_CHAR_NAME;
     m_char_data.m_level                     = 0;
     m_char_data.m_combat_level              = m_char_data.m_level;
-    m_char_data.m_class_name                = "EMPTY";
-    m_char_data.m_origin_name               = "EMPTY";
+    m_char_data.m_class_name                = EMPTY_CHAR_NAME;
+    m_char_data.m_origin_name               = EMPTY_CHAR_NAME;
     m_char_data.m_has_sg_costume            = false;
     m_char_data.m_current_costume_idx       = 0;
     m_char_data.m_using_sg_costume          = false;
@@ -74,8 +74,8 @@ void Character::reset()
 
 bool Character::isEmpty()
 {
-    return ( 0==m_name.compare("EMPTY",Qt::CaseInsensitive)&&
-            (0==m_char_data.m_class_name.compare("EMPTY",Qt::CaseInsensitive)));
+    return ( 0==m_name.compare(EMPTY_CHAR_NAME,Qt::CaseInsensitive)&&
+            (0==m_char_data.m_class_name.compare(EMPTY_CHAR_NAME,Qt::CaseInsensitive)));
 }
 
 void Character::setName(const QString &val )
@@ -83,7 +83,7 @@ void Character::setName(const QString &val )
     if(val.length()>0)
         m_name = val;
     else
-        m_name = "EMPTY";
+        m_name = EMPTY_CHAR_NAME;
 }
 
 void Character::sendTray(BitStream &bs) const
@@ -327,7 +327,7 @@ void Character::serializetoCharsel( BitStream &bs, const QString& entity_map_nam
 
     if(m_costumes.empty())
     {
-        assert(m_name.compare("EMPTY")==0); // only empty characters can have no costumes
+        assert(m_name.compare(EMPTY_CHAR_NAME)==0); // only empty characters can have no costumes
         Costume::NullCostume.storeCharsel(bs);
     }
     else

--- a/Projects/CoX/Common/GameData/Character.cpp
+++ b/Projects/CoX/Common/GameData/Character.cpp
@@ -56,11 +56,11 @@ Character::Character()
 
 void Character::reset()
 {
-    m_name                                  = EMPTY_CHAR_NAME;
+    m_name                                  = EMPTY_STRING;
     m_char_data.m_level                     = 0;
     m_char_data.m_combat_level              = m_char_data.m_level;
-    m_char_data.m_class_name                = EMPTY_CHAR_NAME;
-    m_char_data.m_origin_name               = EMPTY_CHAR_NAME;
+    m_char_data.m_class_name                = EMPTY_STRING;
+    m_char_data.m_origin_name               = EMPTY_STRING;
     m_char_data.m_has_sg_costume            = false;
     m_char_data.m_current_costume_idx       = 0;
     m_char_data.m_using_sg_costume          = false;
@@ -74,8 +74,8 @@ void Character::reset()
 
 bool Character::isEmpty()
 {
-    return ( 0==m_name.compare(EMPTY_CHAR_NAME,Qt::CaseInsensitive)&&
-            (0==m_char_data.m_class_name.compare(EMPTY_CHAR_NAME,Qt::CaseInsensitive)));
+    return ( 0==m_name.compare(EMPTY_STRING,Qt::CaseInsensitive)&&
+            (0==m_char_data.m_class_name.compare(EMPTY_STRING,Qt::CaseInsensitive)));
 }
 
 void Character::setName(const QString &val )
@@ -83,7 +83,7 @@ void Character::setName(const QString &val )
     if(val.length()>0)
         m_name = val;
     else
-        m_name = EMPTY_CHAR_NAME;
+        m_name = EMPTY_STRING;
 }
 
 void Character::sendTray(BitStream &bs) const
@@ -327,7 +327,7 @@ void Character::serializetoCharsel( BitStream &bs, const QString& entity_map_nam
 
     if(m_costumes.empty())
     {
-        assert(m_name.compare(EMPTY_CHAR_NAME)==0); // only empty characters can have no costumes
+        assert(m_name.compare(EMPTY_STRING)==0); // only empty characters can have no costumes
         Costume::NullCostume.storeCharsel(bs);
     }
     else

--- a/Projects/CoX/Common/Messages/Game/GameEvents.cpp
+++ b/Projects/CoX/Common/Messages/Game/GameEvents.cpp
@@ -120,7 +120,7 @@ void CharacterResponse::serializeto( BitStream &bs ) const
     toActualCharacter(indexed_character, converted, player_data, entity_data);
     bs.StorePackedBits(1,6); // opcode
 
-    if(indexed_character.m_name.compare(EMPTY_CHAR_NAME)!=0)// actual character was read from db
+    if(indexed_character.m_name.compare(EMPTY_STRING)!=0)// actual character was read from db
     {
         bs.StorePackedBits(1, m_index);
         converted.getCurrentCostume()->storeCharselParts(bs);

--- a/Projects/CoX/Common/Messages/Game/GameEvents.cpp
+++ b/Projects/CoX/Common/Messages/Game/GameEvents.cpp
@@ -120,7 +120,7 @@ void CharacterResponse::serializeto( BitStream &bs ) const
     toActualCharacter(indexed_character, converted, player_data, entity_data);
     bs.StorePackedBits(1,6); // opcode
 
-    if(indexed_character.m_name.compare("EMPTY")!=0)// actual character was read from db
+    if(indexed_character.m_name.compare(EMPTY_CHAR_NAME)!=0)// actual character was read from db
     {
         bs.StorePackedBits(1, m_index);
         converted.getCurrentCostume()->storeCharselParts(bs);

--- a/Projects/CoX/Common/Messages/GameDatabase/GameDBSyncEvents.h
+++ b/Projects/CoX/Common/Messages/GameDatabase/GameDBSyncEvents.h
@@ -14,6 +14,8 @@
 namespace SEGSEvents
 {
 
+const QString EMPTY_CHAR_NAME = "EMPTY"; // "EMPTY" is used as CharSel screen in client expects this in some cases
+
 enum GameDBEventTypes : uint32_t
 {
     BEGINE_EVENTS(GameDBEventTypes,Internal_EventTypes)
@@ -138,12 +140,13 @@ struct GameAccountResponseCharacterData
 
     void reset()
     {
-        m_name="EMPTY";
+        m_name=EMPTY_CHAR_NAME;
+        m_serialized_entity_data.clear(); // Clearing entity data on character delete
     }
 
     bool isEmpty() const
     {
-        return 0==m_name.compare("EMPTY", Qt::CaseInsensitive);
+        return 0==m_name.compare(EMPTY_CHAR_NAME, Qt::CaseInsensitive);
     }
 
     template <class Archive>
@@ -177,7 +180,7 @@ struct GameAccountResponseData
         int8_t res = 0;
         for(const auto & c : m_characters)
         {
-            if(c.m_name.compare("EMPTY")==0)
+            if(c.m_name.compare(EMPTY_CHAR_NAME)==0)
                 return res;
             res++;
         }

--- a/Projects/CoX/Common/Messages/GameDatabase/GameDBSyncEvents.h
+++ b/Projects/CoX/Common/Messages/GameDatabase/GameDBSyncEvents.h
@@ -140,13 +140,13 @@ struct GameAccountResponseCharacterData
 
     void reset()
     {
-        m_name=EMPTY_CHAR_NAME;
+        m_name=EMPTY_STRING;
         m_serialized_entity_data.clear(); // Clearing entity data on character delete
     }
 
     bool isEmpty() const
     {
-        return 0==m_name.compare(EMPTY_CHAR_NAME, Qt::CaseInsensitive);
+        return 0==m_name.compare(EMPTY_STRING, Qt::CaseInsensitive);
     }
 
     template <class Archive>
@@ -180,7 +180,7 @@ struct GameAccountResponseData
         int8_t res = 0;
         for(const auto & c : m_characters)
         {
-            if(c.m_name.compare(EMPTY_CHAR_NAME)==0)
+            if(c.m_name.compare(EMPTY_STRING)==0)
                 return res;
             res++;
         }

--- a/Projects/CoX/Common/Messages/GameDatabase/GameDBSyncEvents.h
+++ b/Projects/CoX/Common/Messages/GameDatabase/GameDBSyncEvents.h
@@ -14,7 +14,7 @@
 namespace SEGSEvents
 {
 
-const QString EMPTY_CHAR_NAME = "EMPTY"; // "EMPTY" is used as CharSel screen in client expects this in some cases
+const QString EMPTY_STRING = "EMPTY"; // Client expects value "EMPTY" in several places
 
 enum GameDBEventTypes : uint32_t
 {

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -310,7 +310,7 @@ bool GameDbSyncContext::getAccount(const GameAccountRequestData &data,GameAccoun
         character.m_db_id = (m_prepared_char_select->value("id").toUInt());
         character.m_account_id = (m_prepared_char_select->value("account_id").toUInt());
         QString name=m_prepared_char_select->value("char_name").toString();
-        character.m_name =  name.isEmpty() ? EMPTY_CHAR_NAME : name;
+        character.m_name =  name.isEmpty() ? EMPTY_STRING : name;
         character.m_serialized_costume_data = m_prepared_char_select->value("costume_data").toString();
         character.m_serialized_chardata = m_prepared_char_select->value("chardata").toString();
         character.m_serialized_entity_data = m_prepared_char_select->value("entitydata").toString();

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -310,7 +310,7 @@ bool GameDbSyncContext::getAccount(const GameAccountRequestData &data,GameAccoun
         character.m_db_id = (m_prepared_char_select->value("id").toUInt());
         character.m_account_id = (m_prepared_char_select->value("account_id").toUInt());
         QString name=m_prepared_char_select->value("char_name").toString();
-        character.m_name =  name.isEmpty() ? "EMPTY" : name;
+        character.m_name =  name.isEmpty() ? EMPTY_CHAR_NAME : name;
         character.m_serialized_costume_data = m_prepared_char_select->value("costume_data").toString();
         character.m_serialized_chardata = m_prepared_char_select->value("chardata").toString();
         character.m_serialized_entity_data = m_prepared_char_select->value("entitydata").toString();


### PR DESCRIPTION
- Fix new character not spawning in default map (Outbreak) in certain scenarios
- Add const QString EMPTY_CHAR_NAME = "EMPTY" to replace all uses of "EMPTY" to provide clearer use. Added const in GameDBSyncEvents.h as this file is common across all places "EMPTY" is used.

### Issues closed
Closes #753 



