### PR TITLE
mysql: Interim reconnection fix

### DIFF
--- a/Projects/CoX/Servers/AuthDatabase/AuthDBSyncContext.cpp
+++ b/Projects/CoX/Servers/AuthDatabase/AuthDBSyncContext.cpp
@@ -133,12 +133,13 @@ bool AuthDbSyncContext::loadAndConfigure()
 
     if(dbdriver == "QMYSQL")
     {
-      db2.setConnectOptions("MYSQL_OPT_RECONNECT=true");
+        db2->setConnectOptions("MYSQL_OPT_RECONNECT=true");
     }
 
     if(!m_db->open())
     {
         qCritical().noquote() << "Failed to open database:" << dbname;
+        db2->setConnectOptions();
         return false;
     }
 
@@ -147,7 +148,7 @@ bool AuthDbSyncContext::loadAndConfigure()
     {
         // we should just stop the server, it isn't going to work anyway
         qFatal("Wrong database version (%d) Auth database requires version: %d", db_version, REQUIRED_DB_VERSION);
-
+        db2->setConnectOptions();
         return false;
     }
 

--- a/Projects/CoX/Servers/AuthDatabase/AuthDBSyncContext.cpp
+++ b/Projects/CoX/Servers/AuthDatabase/AuthDBSyncContext.cpp
@@ -131,6 +131,11 @@ bool AuthDbSyncContext::loadAndConfigure()
     db2->setPassword(dbpass);
     m_db.reset(db2); // at this point we become owner of the db
 
+    if(dbdriver == "QMYSQL")
+    {
+      db2.setConnectOptions("MYSQL_OPT_RECONNECT=true");
+    }
+
     if(!m_db->open())
     {
         qCritical().noquote() << "Failed to open database:" << dbname;

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -122,6 +122,11 @@ bool GameDbSyncContext::loadAndConfigure()
     db2->setPassword(dbpass);
     m_db.reset(db2); // at this point we become owner of the db
 
+    if(dbdriver == "QMYSQL")
+    {
+      db2.setConnectOptions("MYSQL_OPT_RECONNECT=true");
+    }
+
     if(!m_db->open())
     {
         qFatal("Failed to open database: %s", dbname.toStdString().c_str());

--- a/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
+++ b/Projects/CoX/Servers/GameDatabase/GameDBSyncContext.cpp
@@ -124,12 +124,13 @@ bool GameDbSyncContext::loadAndConfigure()
 
     if(dbdriver == "QMYSQL")
     {
-      db2.setConnectOptions("MYSQL_OPT_RECONNECT=true");
+        db2->setConnectOptions("MYSQL_OPT_RECONNECT=true");
     }
 
     if(!m_db->open())
     {
         qFatal("Failed to open database: %s", dbname.toStdString().c_str());
+        db2->setConnectOptions();
         return false;
     }
 
@@ -138,7 +139,7 @@ bool GameDbSyncContext::loadAndConfigure()
     {
         // we should just stop the server, it isn't going to work anyway
         qFatal("Wrong database version (%d) Game database requires version: %d", db_version, REQUIRED_DB_VERSION);
-
+        db2->setConnectOptions();
         return false;
     }
 


### PR DESCRIPTION
## Summary
There is an option for automatic reconnect for the MySQL database backend.
Seeing as all reported incidents of connection timeouts come from MariaDB users, this quick interim fix feel validated.

### Issues closed
Partially #579 - don't close that one just yet.

### Additions/modifications proposed in this pull request:
- Add a connection setting for QMYSQL driver connections.
