### PR TITLE
logging: Name logs with ISO-8601 compliant dates

### DIFF
--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -218,13 +218,13 @@ void segsLogMessageOutput(QtMsgType type, const QMessageLogContext &context, con
         file_name.replace("]", "");
         if (file_name.isEmpty())
             file_name = "generic";
-        file_name.append("_" + todays_date.toString("yyyy-MM-dd"));
+        file_name = todays_date.toString("yyyy-MM-dd") + "_" + file_name;
         QString log_path = QString("logs/") + file_name + ".log";
         segs_log_target.setFileName(log_path);
     }
     else // If combine_logs is on will log all to a single file.
     {
-        QString log_path = QString("logs/all_") + todays_date.toString("yyyy-MM-dd") + ".log";
+        QString log_path = QString("logs/") + todays_date.toString("yyyy-MM-dd") + "_all.log";
         segs_log_target.setFileName(log_path);
     }
     settings.endGroup();

--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -218,13 +218,13 @@ void segsLogMessageOutput(QtMsgType type, const QMessageLogContext &context, con
         file_name.replace("]", "");
         if (file_name.isEmpty())
             file_name = "generic";
-        file_name.append("_" + todays_date.toString("ddMMyy"));
+        file_name.append("_" + todays_date.toString("yyyy-MM-dd"));
         QString log_path = QString("logs/") + file_name + ".log";
         segs_log_target.setFileName(log_path);
     }
     else // If combine_logs is on will log all to a single file.
     {
-        QString log_path = QString("logs/all_") + todays_date.toString("ddMMyy") + ".log";
+        QString log_path = QString("logs/all_") + todays_date.toString("yyyy-MM-dd") + ".log";
         segs_log_target.setFileName(log_path);
     }
     settings.endGroup();

--- a/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
@@ -454,7 +454,7 @@ void SettingsDialog::purge_logs()
         QStringList parts = file.split("_");
         if (!parts.isEmpty())
         {
-            QDate date = QDate::fromString(parts.value(parts.length() - 1).replace(".log", ""), "yyyy-MM-dd");
+            QDate date = QDate::fromString(parts.value(0), "yyyy-MM-dd");
             if (date < todays_date)
                 logs_to_delete.append(file);
         }

--- a/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
@@ -444,7 +444,7 @@ void SettingsDialog::send_maps_dir_config_check()
 
 void SettingsDialog::purge_logs()
 {
-    QString todays_date = QDate(QDate::currentDate()).toString("ddMMyy");
+    QDate todays_date = QDate::currentDate();
     QString log_dir = "logs/";
     QStringList existing_logs = QDir(log_dir).entryList(QDir::Files);
     QStringList logs_to_delete;
@@ -454,10 +454,8 @@ void SettingsDialog::purge_logs()
         QStringList parts = file.split("_");
         if (!parts.isEmpty())
         {
-            QString date = parts.value(parts.length() - 1);
-            date.replace(".log", "");
-            int compare = QString::compare(date, todays_date, Qt::CaseInsensitive);
-            if (compare < 0)
+            QDate date = QDate::fromString(parts.value(parts.length() - 1).replace(".log", ""), "yyyy-MM-dd");
+            if (date < todays_date)
                 logs_to_delete.append(file);
         }
     }


### PR DESCRIPTION
### Summary:
Parsing big endian dates is hard. ( 30th of April `300419` should not be less than 31st of March `310319` )
There is a date format ISO standard for a reason.
Let's use it.

And while we're at it, change the file name format from `[logname]_[date].log` to `[date]_[logname].log` as suggested (and agreed upon) in Discord chat.
