### PR TITLE
rpc: Add WebUI statistics procedure

### DIFF
--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -105,10 +105,11 @@ QString AdminRPC::getStartTime()
     return m_start_time;
 }
 
-QVariantList AdminRPC::getWebUIData()
+QVariantMap AdminRPC::getWebUIData()
 {
     qCDebug(logRPC) << "Someone requested WebUI information...";
-    return {VersionInfo::getAuthVersionNumber(), m_start_time};
+    return {std::pair<QString,QString>("version",VersionInfo::getAuthVersionNumber()),
+	    std::pair<QString,QString>("starttime", m_start_time)};
 }
 
 void startRPCServer()

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -105,6 +105,12 @@ QString AdminRPC::getStartTime()
     return m_start_time;
 }
 
+QVariantList AdminRPC::getWebUIData()
+{
+    qCDebug(logRPC) << "Someone requested WebUI information...";
+    return {VersionInfo::getAuthVersionNumber(), m_start_time};
+}
+
 void startRPCServer()
 {
     static jcon::JsonRpcServer *m_server;

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -110,12 +110,21 @@ QString AdminRPC::getStartTime()
  * @return Returns a QMap<QString,QVariant> with server information
  */
 
-QVariantMap AdminRPC::getWebUIData()
+QVariantMap AdminRPC::getWebUIData(QString const& version)
 {
     qCDebug(logRPC) << "Someone requested WebUI information...";
     QMap<QString,QVariant> ret;
-    ret.insert("version", VersionInfo::getAuthVersionNumber());
-    ret.insert("starttime", m_start_time);
+    if (version.compare("0.6.1") == 0)
+    {
+      ret.insert("version", VersionInfo::getAuthVersionNumber());
+      ret.insert("starttime", m_start_time);
+    }
+    else
+    {
+      // Default to v0.6.1 format
+      ret.insert("version", VersionInfo::getAuthVersionNumber());
+      ret.insert("starttime", m_start_time);
+    }      
     return ret;
 }
 

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -105,11 +105,18 @@ QString AdminRPC::getStartTime()
     return m_start_time;
 }
 
+/*!
+ * @brief Get a dictionary of information as used by the WebUI
+ * @return Returns a QMap<QString,QVariant> with server information
+ */
+
 QVariantMap AdminRPC::getWebUIData()
 {
     qCDebug(logRPC) << "Someone requested WebUI information...";
-    return {std::pair<QString,QString>("version",VersionInfo::getAuthVersionNumber()),
-	    std::pair<QString,QString>("starttime", m_start_time)};
+    QMap<QString,QVariant> ret;
+    ret.insert("version", VersionInfo::getAuthVersionNumber());
+    ret.insert("starttime", m_start_time);
+    return ret;
 }
 
 void startRPCServer()

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -35,7 +35,7 @@ public:
     Q_INVOKABLE QString getVersion();
     Q_INVOKABLE QString getVersionName();
     Q_INVOKABLE QString getStartTime();
-    Q_INVOKABLE QVariantMap getWebUIData();
+    Q_INVOKABLE QVariantMap getWebUIData(QString const& version);
     Q_INVOKABLE QString ping();
 protected:
     ACE_INET_Addr                       m_location;     //!< address rpc server will bind at.

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -35,7 +35,7 @@ public:
     Q_INVOKABLE QString getVersion();
     Q_INVOKABLE QString getVersionName();
     Q_INVOKABLE QString getStartTime();
-    Q_INVOKABLE QVariantList getWebUIData();
+    Q_INVOKABLE QVariantMap getWebUIData();
     Q_INVOKABLE QString ping();
 protected:
     ACE_INET_Addr                       m_location;     //!< address rpc server will bind at.

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.h
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.h
@@ -35,6 +35,7 @@ public:
     Q_INVOKABLE QString getVersion();
     Q_INVOKABLE QString getVersionName();
     Q_INVOKABLE QString getStartTime();
+    Q_INVOKABLE QVariantList getWebUIData();
     Q_INVOKABLE QString ping();
 protected:
     ACE_INET_Addr                       m_location;     //!< address rpc server will bind at.


### PR DESCRIPTION
## Summary
Send all data used for the WebUI statistics table in one command.

This will have to be expanded in the future, but number of online characters, accounts and characters in general is not available at this time afaik.