### PR TITLE
rpc: Build jcon-cpp with -DNDEBUG

### DIFF
--- a/3rd_party/jcon-cpp/src/jcon/CMakeLists.txt
+++ b/3rd_party/jcon-cpp/src/jcon/CMakeLists.txt
@@ -23,3 +23,4 @@ install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib
 		PUBLIC_HEADER DESTINATION include/jcon
 )
+target_compile_definitions(jcon PUBLIC NDEBUG)

--- a/3rd_party/jcon-cpp/src/jcon/json_rpc_endpoint.cpp
+++ b/3rd_party/jcon-cpp/src/jcon/json_rpc_endpoint.cpp
@@ -137,6 +137,10 @@ QByteArray JsonRpcEndpoint::processBuffer(const QByteArray& buffer,
     QByteArray buf(buffer);
 
     JCON_ASSERT(buf[0] == '{');
+    if (buf[0] != '{') {
+        m_logger->logInfo(QString("malformed request"));
+        return nullptr;
+    }
 
     bool in_string = false;
     int brace_nesting_level = 0;


### PR DESCRIPTION
## Summary
Disables asserts which crashes the server when a single bad byte has been received.
Also modify `json_rpc_endpoint.cpp` to be on par with upstream repo.