### PR TITLE
Updating version for -dev build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,51 @@ PROJECT(SEGS)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# for version and revision info. Derived from https://github.com/dolphin-emu/dolphin/blob/master/CMakeLists.txt#L132
+find_package(Git)
+if(GIT_FOUND)
+  # defines SEGS_REVISION
+  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+      OUTPUT_VARIABLE SEGS_REVISION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  # defines SEGS_DESCRIPTION
+  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} describe --always --long --dirty
+      OUTPUT_VARIABLE SEGS_DESCRIPTION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # remove hash (and trailing "-0" if needed) from description
+  string(REGEX REPLACE "(-0)?-[^-]+((-dirty)?)$" "\\2" SEGS_DESCRIPTION "${SEGS_DESCRIPTION}")
+
+  # defines SEGS_BRANCH
+  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+      OUTPUT_VARIABLE SEGS_BRANCH
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+# version number
+set(SEGS_VERSION_MAJOR "0")
+set(SEGS_VERSION_MINOR "6")
+if(SEGS_BRANCH STREQUAL "master")
+  set(SEGS_VERSION_PATCH "0")
+else()
+  set(SEGS_VERSION_PATCH ${SEGS_DESCRIPTION})
+endif()
+
+# If SEGS is not built from a Git repository, default the version info to
+# reasonable values.
+if(NOT SEGS_REVISION)
+  set(SEGS_DESCRIPTION "${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}")
+  set(SEGS_REVISION "${SEGS_DESCRIPTION} (no further info)")
+  set(SEGS_BRANCH "develop")
+endif()
+
+add_definitions(
+    "-DSEGS_VERSION=\"${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}.${SEGS_VERSION_PATCH}\""
+    "-DSEGS_BRANCH=\"${SEGS_BRANCH}\""
+    "-DSEGS_DESCRIPTION=\"${SEGS_DESCRIPTION}\""
+    "-DSEGS_REVISION=\"${SEGS_REVISION}\""
+    )
+
 IF(MSVC)
     add_definitions( -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -DNOMINMAX -D_USE_MATH_DEFINES)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
@@ -161,41 +206,3 @@ foreach(MAPDIR ${MAPNAMES})
   file(MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DefaultMapInstances/${MAPDIR})
 endforeach(MAPDIR)
 file(MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/logs)
-
-# for version and revision info. Derived from https://github.com/dolphin-emu/dolphin/blob/master/CMakeLists.txt#L132
-find_package(Git)
-if(GIT_FOUND)
-  # defines SEGS_REVISION
-  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
-      OUTPUT_VARIABLE SEGS_REVISION
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-  # defines SEGS_DESCRIPTION
-  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} describe --always --long --dirty
-      OUTPUT_VARIABLE SEGS_DESCRIPTION
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  # remove hash (and trailing "-0" if needed) from description
-  string(REGEX REPLACE "(-0)?-[^-]+((-dirty)?)$" "\\2" SEGS_DESCRIPTION "${SEGS_DESCRIPTION}")
-
-  # defines SEGS_BRANCH
-  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-      OUTPUT_VARIABLE SEGS_BRANCH
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
-
-# version number
-set(SEGS_VERSION_MAJOR "0")
-set(SEGS_VERSION_MINOR "6")
-if(SEGS_BRANCH STREQUAL "master")
-  set(SEGS_VERSION_PATCH "1")
-else()
-  set(SEGS_VERSION_PATCH ${SEGS_REVISION})
-endif()
-
-# If SEGS is not built from a Git repository, default the version info to
-# reasonable values.
-if(NOT SEGS_REVISION)
-  set(SEGS_DESCRIPTION "${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}")
-  set(SEGS_REVISION "${SEGS_DESCRIPTION} (no further info)")
-  set(SEGS_BRANCH "develop")
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ endif()
 # If SEGS is not built from a Git repository, default the version info to
 # reasonable values.
 if(NOT SEGS_REVISION)
-  set(SEGS_DESCRIBE "${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}")
+  set(SEGS_DESCRIPTION "${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}")
   set(SEGS_REVISION "${SEGS_DESCRIPTION} (no further info)")
   set(SEGS_BRANCH "develop")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,3 +161,41 @@ foreach(MAPDIR ${MAPNAMES})
   file(MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DefaultMapInstances/${MAPDIR})
 endforeach(MAPDIR)
 file(MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/logs)
+
+# for version and revision info. Derived from https://github.com/dolphin-emu/dolphin/blob/master/CMakeLists.txt#L132
+find_package(Git)
+if(GIT_FOUND)
+  # defines SEGS_REVISION
+  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+      OUTPUT_VARIABLE SEGS_REVISION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  # defines SEGS_DESCRIPTION
+  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} describe --always --long --dirty
+      OUTPUT_VARIABLE SEGS_DESCRIPTION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # remove hash (and trailing "-0" if needed) from description
+  string(REGEX REPLACE "(-0)?-[^-]+((-dirty)?)$" "\\2" SEGS_DESCRIPTION "${SEGS_DESCRIPTION}")
+
+  # defines SEGS_BRANCH
+  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+      OUTPUT_VARIABLE SEGS_BRANCH
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+# version number
+set(SEGS_VERSION_MAJOR "0")
+set(SEGS_VERSION_MINOR "6")
+if(SEGS_BRANCH STREQUAL "master")
+  set(SEGS_VERSION_PATCH "1")
+else()
+  set(SEGS_VERSION_PATCH ${SEGS_REVISION})
+endif()
+
+# If SEGS is not built from a Git repository, default the version info to
+# reasonable values.
+if(NOT SEGS_REVISION)
+  set(SEGS_DESCRIBE "${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}")
+  set(SEGS_REVISION "${SEGS_DESCRIPTION} (no further info)")
+  set(SEGS_BRANCH "develop")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,16 +28,12 @@ endif()
 # version number
 set(SEGS_VERSION_MAJOR "0")
 set(SEGS_VERSION_MINOR "6")
-if(SEGS_BRANCH STREQUAL "master")
-  set(SEGS_VERSION_PATCH "0")
-else()
-  set(SEGS_VERSION_PATCH ${SEGS_DESCRIPTION})
-endif()
+set(SEGS_VERSION_PATCH "1")
 
 # If SEGS is not built from a Git repository, default the version info to
 # reasonable values.
 if(NOT SEGS_REVISION)
-  set(SEGS_DESCRIPTION "${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}")
+  set(SEGS_DESCRIPTION "${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}.${SEGS_VERSION_PATCH}")
   set(SEGS_REVISION "${SEGS_DESCRIPTION} (no further info)")
   set(SEGS_BRANCH "develop")
 endif()
@@ -46,7 +42,6 @@ add_definitions(
     "-DSEGS_VERSION=\"${SEGS_VERSION_MAJOR}.${SEGS_VERSION_MINOR}.${SEGS_VERSION_PATCH}\""
     "-DSEGS_BRANCH=\"${SEGS_BRANCH}\""
     "-DSEGS_DESCRIPTION=\"${SEGS_DESCRIPTION}\""
-    "-DSEGS_REVISION=\"${SEGS_REVISION}\""
     )
 
 IF(MSVC)

--- a/Projects/CoX/Common/GameData/Task.cpp
+++ b/Projects/CoX/Common/GameData/Task.cpp
@@ -5,8 +5,6 @@
  * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
  */
 
-#pragma once
-
 #include "Task.h"
 #include "cereal/cereal.hpp"
 #include "Logging.h"

--- a/Projects/CoX/Common/GameData/VisitLocation.cpp
+++ b/Projects/CoX/Common/GameData/VisitLocation.cpp
@@ -5,7 +5,6 @@
  * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
  */
 
-#pragma once
 #include "VisitLocation.h"
 #include "serialization_common.h"
 #include "serialization_types.h"

--- a/Projects/CoX/Common/GameData/shop_serializers.cpp
+++ b/Projects/CoX/Common/GameData/shop_serializers.cpp
@@ -9,7 +9,6 @@
  * @addtogroup GameData Projects/CoX/Common/GameData
  * @{
  */
-#pragma once
 
 #include "shop_serializers.h"
 #include "serialization_common.h"

--- a/Projects/CoX/Servers/AuthServer/main.cpp
+++ b/Projects/CoX/Servers/AuthServer/main.cpp
@@ -312,8 +312,6 @@ ACE_INT32 ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     qInfo().noquote() << VersionInfo::getCopyright();
     qInfo().noquote() << VersionInfo::getAuthVersion();
 
-    qInfo().noquote() << "main";
-
     // Create jsonrpc admin interface
     startRPCServer();
 

--- a/Projects/CoX/Servers/MapServer/UnitTests/MapEventRegistry.cpp
+++ b/Projects/CoX/Servers/MapServer/UnitTests/MapEventRegistry.cpp
@@ -3,7 +3,7 @@
 #include "SEGSEventFactory.h"
 
 using namespace SEGSEvents;
-extern void register_MapEvents();
+extern void register_MapServerEvents();
 namespace
 {
     const char *event_names[] =
@@ -98,7 +98,8 @@ namespace
     };
 }
 
-class MapEventRegistry : public QObject {
+class MapEventRegistry : public QObject
+{
     Q_OBJECT
 private slots:
     void creationByName()
@@ -108,7 +109,7 @@ private slots:
             QVERIFY2(create_by_name(ev_name)==nullptr,"no types registered yet, create_by_name result should be null");
         }
         // TODO: call register_all_events();
-        register_MapEvents();
+        register_MapServerEvents();
         for(const char *ev_name : event_names)
         {
             QVERIFY2(create_by_name(ev_name) != nullptr,

--- a/include/Version.h
+++ b/include/Version.h
@@ -7,7 +7,7 @@
 
 #pragma once
 #define ProjectName "SEGS"
-#define VersionNumber "0.6.5" // dev build
+#define VersionNumber "${SEGS_DESCRIPTION}" // compiled from cmake and git revision
 #define VersionName "Outbreak"
 #define VersionString ProjectName " v" VersionNumber " (" VersionName ")"
 #define CopyrightString "Super Entity Game Server\nhttp://github.com/Segs/\nCopyright (c) 2006-2018 Super Entity Game Server Team (see AUTHORS.md)\nThis software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.\n";

--- a/include/Version.h
+++ b/include/Version.h
@@ -6,10 +6,20 @@
  */
 
 #pragma once
+
+#ifndef SEGS_VERSION
+#define SEGS_VERSION "0.6.1" // set in cmake, but defined here if not available
+#endif
+#ifndef SEGS_BRANCH
+#define SEGS_BRANCH "unknown"
+#endif
+#ifndef SEGS_DESCRIPTION
+#define SEGS_DESCRIPTION "unknown"
+#endif
+
 #define ProjectName "SEGS"
-#define VersionNumber SEGS_VERSION // from cmake and git revision
 #define VersionName "Outbreak"
-#define VersionString ProjectName " v" VersionNumber " (" VersionName ") [" SEGS_BRANCH ": " SEGS_REVISION "]"
+#define VersionString ProjectName " v" SEGS_VERSION "-" SEGS_BRANCH " (" VersionName ") [" SEGS_DESCRIPTION "]"
 #define CopyrightString "Super Entity Game Server\nhttp://github.com/Segs/\nCopyright (c) 2006-2019 Super Entity Game Server Team (see AUTHORS.md)\nThis software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.\n";
 
 static constexpr int s_config_version = 1;
@@ -21,7 +31,7 @@ class VersionInfo
 {
 public:
     static const char *getAuthVersion(void) { return VersionString; }
-    static const char *getAuthVersionNumber(void) { return VersionNumber;}
+    static const char *getAuthVersionNumber(void) { return SEGS_VERSION; }
     static const char *getVersionName(void) { return VersionName; }
     static const char *getCopyright(void){ return CopyrightString; }
     static constexpr int getConfigVersion(void) { return s_config_version; }
@@ -31,7 +41,9 @@ public:
 
 #undef ProjectName
 #undef VersionName
-#undef VersionNumber
 #undef VersionString
 #undef CopyrightString
+#undef SEGS_VERSION
+#undef SEGS_BRANCH
+#undef SEGS_DESCRIPTION
 

--- a/include/Version.h
+++ b/include/Version.h
@@ -7,31 +7,23 @@
 
 #pragma once
 #define ProjectName "SEGS"
-#define VersionNumber "${SEGS_DESCRIPTION}" // compiled from cmake and git revision
+#define VersionNumber SEGS_VERSION // from cmake and git revision
 #define VersionName "Outbreak"
-#define VersionString ProjectName " v" VersionNumber " (" VersionName ")"
-#define CopyrightString "Super Entity Game Server\nhttp://github.com/Segs/\nCopyright (c) 2006-2018 Super Entity Game Server Team (see AUTHORS.md)\nThis software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.\n";
+#define VersionString ProjectName " v" VersionNumber " (" VersionName ") [" SEGS_BRANCH ": " SEGS_REVISION "]"
+#define CopyrightString "Super Entity Game Server\nhttp://github.com/Segs/\nCopyright (c) 2006-2019 Super Entity Game Server Team (see AUTHORS.md)\nThis software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.\n";
 
 static constexpr int s_config_version = 1;
 static constexpr int s_auth_db_version = 1;
 static constexpr int s_game_db_version = 9;
 
-//const char *AdminVersionString="Undefined";
-//const char *AuthVersionString="Undefined";
-//const char *GameVersionString="Undefined";
-//const char *MapVersionString="Undefined";
-
 // Contains version information for the various server modules
 class VersionInfo
 {
 public:
-    static const char *getAdminVersion(void);
     static const char *getAuthVersion(void) { return VersionString; }
     static const char *getAuthVersionNumber(void) { return VersionNumber;}
     static const char *getVersionName(void) { return VersionName; }
-    static const char *getGameVersion(void);
-    static const char *getMapVersion(void);
-    static const char *getCopyright(void){ return CopyrightString;}
+    static const char *getCopyright(void){ return CopyrightString; }
     static constexpr int getConfigVersion(void) { return s_config_version; }
     static constexpr int getRequiredAuthDBVersion(void) { return s_auth_db_version; }
     static constexpr int getRequiredGameDBVersion(void) { return s_game_db_version; }

--- a/include/Version.h
+++ b/include/Version.h
@@ -7,7 +7,7 @@
 
 #pragma once
 #define ProjectName "SEGS"
-#define VersionNumber "0.6.1"
+#define VersionNumber "0.6.5" // dev build
 #define VersionName "Outbreak"
 #define VersionString ProjectName " v" VersionNumber " (" VersionName ")"
 #define CopyrightString "Super Entity Game Server\nhttp://github.com/Segs/\nCopyright (c) 2006-2018 Super Entity Game Server Team (see AUTHORS.md)\nThis software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.\n";


### PR DESCRIPTION
## Summary
Releases should have their own fixed version number, so we can tell from the logs if someone is using a release package or a dev build. Would be great if there were a way to append build number so we know what build someone is running from github. I can't think of a way to automate that easily.

**Comments on how to handle this moving forward are welcome**

### Issues closed
None filed.

### Additions/modifications proposed in this pull request:
- Iterate build number to v0.6.5
