### PR TITLE
Fix funky layout after Doxy generation [skip ci]

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1191,7 +1191,7 @@ HTML_TIMESTAMP         = YES
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_DYNAMIC_MENUS     = YES
+HTML_DYNAMIC_MENUS     = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the


### PR DESCRIPTION
## Summary
Using `HTML_DYNAMIC_MENUS` in Doxygen 1.8.13 generates HTML that does not render properly within several popular browsers including Firefox and IE. In order to make the generated content appear properly, this option should be disabled.

### Issues closed
N/A

### Additions/modifications proposed in this pull request:
- Set `HTML_DYNAMIC_MENUS` to `NO` in Doxyfile
