### PR TITLE
Add Doxygen main page [skip ci]

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -789,9 +789,14 @@ WARN_LOGFILE           = "segs_doxy.log"
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = Components \
+INPUT                  = LICENSE.md \
+                         README.md \
+                         Components \
                          Projects \
-                         Utilities
+                         Utilities \
+                         contrib \
+                         docs \
+                         include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -816,7 +821,8 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          =
+FILE_PATTERNS          = *.c *.cfg *.conf *.cpp *.cs *.dox *.h *.hpp *.inl \
+                         *.java *.md *.php *.py *.rb *.txt *.yaml *.yml
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -884,7 +890,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = "images/dump"
+IMAGE_PATH             = "images"
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program
@@ -940,7 +946,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = "docs/doxy_index.md"
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/doxy_index.md
+++ b/docs/doxy_index.md
@@ -14,4 +14,4 @@ physics, and more.
 - [IRC](irc://irc.segs.io/segs)
 - [Main](http://www.segs.io/)
 - [Twitter](https://twitter.com/segscode)
-- [Wiki](https://github.com/Segs/Segs/wiki
+- [Wiki](https://github.com/Segs/Segs/wiki)

--- a/docs/doxy_index.md
+++ b/docs/doxy_index.md
@@ -1,0 +1,17 @@
+%SEGS
+-----
+%SEGS is the Super %Entity Game Server. It is a free, open-source
+(under the terms of the [BSD License](https://opensource.org/licenses/BSD-3-Clause)),
+cross-platform, and object-oriented suite of protocols and services designed to interface with popular
+superhero-themed MMORPG clients. %SEGS is written in C++ and facilitates common MMORPG functionality
+such as account and character storage/retrieval using a database, secure client authentication, chat,
+physics, and more.
+
+- [Discord](https://discord.segs.io/)
+- [Doxygen](https://doxy.segs.io/)
+- [Forum](http://forum.segs.io/)
+- [GitHub](https://github.com/Segs/Segs)
+- [IRC](irc://irc.segs.io/segs)
+- [Main](http://www.segs.io/)
+- [Twitter](https://twitter.com/segscode)
+- [Wiki](https://github.com/Segs/Segs/wiki


### PR DESCRIPTION
## Summary
Created Doxygen landing page and tuned list of files for inclusion.

### Issues closed
Closes Segs/Segs.io#17

### Additions/modifications proposed in this pull request:
- Added Doxygen main page for http://doxy.segs.io/
- Changed image path
- Modified list of file extensions included by parser
