### PR TITLE
Resolve issue causing out of bounds error when accessing m_visible_map_cells.

### DIFF
--- a/Components/serialization_types.h
+++ b/Components/serialization_types.h
@@ -106,20 +106,20 @@ inline void CEREAL_LOAD_FUNCTION_NAME(Archive & ar, ::QByteArray & str)
     ar( rd );
     str = QByteArray::fromStdString(rd);
 }
-//! Serialization for std::map<uint32_t,std::array<bool,1024> >
+//! Serialization for std::map<uint32_t,std::vector<bool> >
 template<class Archive, class C, class A,
     traits::EnableIf<traits::is_text_archive<Archive>::value> = traits::sfinae>
-inline void CEREAL_SAVE_FUNCTION_NAME(Archive & ar, std::map<uint32_t, std::array<bool, 1024>, C, A> map) // trying without &
+inline void CEREAL_SAVE_FUNCTION_NAME(Archive & ar, std::map<uint32_t, std::vector<bool>, C, A> map) // trying without &
 {
     for (const auto & pair : map)
     {
         ar(cereal::make_nvp(QVariant(pair.first).toString().toStdString(), pair.second));
     }
 }
-//! Serialization for std::map<uint32_t,std::array<bool,1024> >
+//! Serialization for std::map<uint32_t,std::vector<bool> >
 template<class Archive, class C, class A,
     traits::EnableIf<traits::is_text_archive<Archive>::value> = traits::sfinae>
-inline void CEREAL_LOAD_FUNCTION_NAME(Archive & ar, std::map<uint32_t, std::array<bool, 1024>, C, A> & map)
+inline void CEREAL_LOAD_FUNCTION_NAME(Archive & ar, std::map<uint32_t, std::vector<bool>, C, A> & map)
 {
     map.clear();
     auto hint = map.begin();
@@ -134,7 +134,7 @@ inline void CEREAL_LOAD_FUNCTION_NAME(Archive & ar, std::map<uint32_t, std::arra
         }
         
         uint32_t key = QVariant(node_name_pointer).toUInt();
-        std::array<bool,1024> values;
+        std::vector<bool> values;
         ar(values);
         hint = map.emplace_hint(hint, std::move(key), std::move(values));
     }

--- a/Projects/CoX/Common/GameData/PlayerProgress.h
+++ b/Projects/CoX/Common/GameData/PlayerProgress.h
@@ -13,7 +13,7 @@
 struct PlayerProgress
 {
     enum : uint32_t {class_version = 1};
-    std::map<uint32_t, std::array<bool, 1024> > m_visible_map_cells;
+    std::map<uint32_t, std::vector<bool> > m_visible_map_cells;
 
     template<class Archive>
     void serialize(Archive &archive, uint32_t const version);

--- a/Projects/CoX/Common/Messages/Map/VisitMapCells.h
+++ b/Projects/CoX/Common/Messages/Map/VisitMapCells.h
@@ -16,10 +16,9 @@ namespace SEGSEvents
     {
     public:
         explicit VisitMapCells() : GameCommandEvent(evVisitMapCells) {}
-        VisitMapCells(bool is_opaque, int32_t num_cells, std::vector<bool> visible_map_cells) : 
+        VisitMapCells(bool is_opaque, std::vector<bool> visible_map_cells) : 
             GameCommandEvent(evVisitMapCells),
             m_is_opaque(is_opaque),
-            m_num_cells(num_cells),
             m_visible_map_cells(visible_map_cells)
         {}
 
@@ -31,9 +30,10 @@ namespace SEGSEvents
             bs.StorePackedBits(1, type() - evFirstServerToClient); // Packet 22
             bs.StorePackedBits(1, 1);
             bs.StoreBits(1, m_is_opaque);
-            bs.StorePackedBits(1, m_num_cells);
+            uint32_t num_cells = m_visible_map_cells.size();
+            bs.StorePackedBits(1, num_cells);
             std::vector<uint8_t> cells_arr;
-            cells_arr.resize((m_num_cells + 7) / 8);
+            cells_arr.resize((num_cells + 7) / 8);
             std::fill(std::begin(cells_arr), std::end(cells_arr), 0);
 
             for (uint16_t i = 0; i < cells_arr.size(); i++)
@@ -49,15 +49,13 @@ namespace SEGSEvents
                 cells_arr[i] =  byte_sum;
             }
 
-            bs.StoreBitArray(cells_arr.data(), m_num_cells);
+            bs.StoreBitArray(cells_arr.data(), num_cells);
         }
 
         EVENT_IMPL(VisitMapCells)
     protected:
         // [[ev_def:field]]
         bool                m_is_opaque = false;
-        // [[ev_def:field]]
-        int32_t             m_num_cells = 1024;
         // [[ev_def:field]]
         std::vector<bool>   m_visible_map_cells;
     };

--- a/Projects/CoX/Common/Messages/Map/VisitMapCells.h
+++ b/Projects/CoX/Common/Messages/Map/VisitMapCells.h
@@ -16,9 +16,10 @@ namespace SEGSEvents
     {
     public:
         explicit VisitMapCells() : GameCommandEvent(evVisitMapCells) {}
-        VisitMapCells(bool is_opaque, std::array<bool, 1024> visible_map_cells) : 
+        VisitMapCells(bool is_opaque, int32_t num_cells, std::vector<bool> visible_map_cells) : 
             GameCommandEvent(evVisitMapCells),
             m_is_opaque(is_opaque),
+            m_num_cells(num_cells),
             m_visible_map_cells(visible_map_cells)
         {}
 
@@ -30,31 +31,34 @@ namespace SEGSEvents
             bs.StorePackedBits(1, type() - evFirstServerToClient); // Packet 22
             bs.StorePackedBits(1, 1);
             bs.StoreBits(1, m_is_opaque);
-            bs.StorePackedBits(1, 1024); // 1024 possible map cells to reveal
-            std::array<uint8_t, 128> cells_arr;
+            bs.StorePackedBits(1, m_num_cells);
+            std::vector<uint8_t> cells_arr;
+            cells_arr.resize((m_num_cells + 7) / 8);
             std::fill(std::begin(cells_arr), std::end(cells_arr), 0);
 
-            for (uint16_t i = 0; i < 128; i++)
+            for (uint16_t i = 0; i < cells_arr.size(); i++)
             {
                 int32_t byte_sum = 0;
                 for (uint16_t j = 0; j < 8; j++)
                 {
                     if (m_visible_map_cells[i * 8 + j])
                     {
-                        byte_sum += std::pow(2,j);
+                        byte_sum += std::pow(2, j);
                     }
                 }
                 cells_arr[i] =  byte_sum;
             }
 
-            bs.StoreBitArray(cells_arr.data(), 1024);
+            bs.StoreBitArray(cells_arr.data(), m_num_cells);
         }
 
         EVENT_IMPL(VisitMapCells)
     protected:
         // [[ev_def:field]]
-        bool                    m_is_opaque = false;
+        bool                m_is_opaque = false;
         // [[ev_def:field]]
-        std::array<bool,1024>   m_visible_map_cells;
+        int32_t             m_num_cells = 1024;
+        // [[ev_def:field]]
+        std::vector<bool>   m_visible_map_cells;
     };
 };

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -376,9 +376,9 @@ void sendFloatingNumbers(MapClientSession &sess, uint32_t tgt_idx, int32_t amoun
     sess.addCommand<FloatingDamage>(sess.m_ent->m_idx, tgt_idx, amount);
 }
 
-void sendVisitMapCells(MapClientSession &sess, bool is_opaque, std::array<bool, 1024> visible_map_cells)
+void sendVisitMapCells(MapClientSession &sess, bool is_opaque, uint32_t num_cells, std::vector<bool> visible_map_cells)
 {
-    sess.addCommand<VisitMapCells>(is_opaque, visible_map_cells);
+    sess.addCommand<VisitMapCells>(is_opaque, num_cells, visible_map_cells);
 }
 
 void sendLevelUp(MapClientSession &sess)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -376,9 +376,9 @@ void sendFloatingNumbers(MapClientSession &sess, uint32_t tgt_idx, int32_t amoun
     sess.addCommand<FloatingDamage>(sess.m_ent->m_idx, tgt_idx, amount);
 }
 
-void sendVisitMapCells(MapClientSession &sess, bool is_opaque, uint32_t num_cells, std::vector<bool> visible_map_cells)
+void sendVisitMapCells(MapClientSession &sess, bool is_opaque, std::vector<bool> visible_map_cells)
 {
-    sess.addCommand<VisitMapCells>(is_opaque, num_cells, visible_map_cells);
+    sess.addCommand<VisitMapCells>(is_opaque, visible_map_cells);
 }
 
 void sendLevelUp(MapClientSession &sess)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -68,7 +68,7 @@ void sendClientState(MapClientSession &sess, ClientStates client_state);
 void showMapXferList(MapClientSession &sess, bool has_location, glm::vec3 &location, QString &name);
 void sendFloatingInfo(MapClientSession &sess, QString &msg, FloatingInfoStyle style, float delay);
 void sendFloatingNumbers(MapClientSession &sess, uint32_t tgt_idx, int32_t amount);
-void sendVisitMapCells(MapClientSession &sess, bool is_opaque, std::array<bool, 1024> visible_map_cells);
+void sendVisitMapCells(MapClientSession &sess, bool is_opaque, uint32_t num_cells, std::vector<bool> visible_map_cells);
 void sendLevelUp(MapClientSession &sess);
 void sendEnhanceCombineResponse(MapClientSession &sess, bool success, bool destroy);
 void sendChangeTitle(MapClientSession &sess, bool select_origin);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -68,7 +68,7 @@ void sendClientState(MapClientSession &sess, ClientStates client_state);
 void showMapXferList(MapClientSession &sess, bool has_location, glm::vec3 &location, QString &name);
 void sendFloatingInfo(MapClientSession &sess, QString &msg, FloatingInfoStyle style, float delay);
 void sendFloatingNumbers(MapClientSession &sess, uint32_t tgt_idx, int32_t amount);
-void sendVisitMapCells(MapClientSession &sess, bool is_opaque, uint32_t num_cells, std::vector<bool> visible_map_cells);
+void sendVisitMapCells(MapClientSession &sess, bool is_opaque, std::vector<bool> visible_map_cells);
 void sendLevelUp(MapClientSession &sess);
 void sendEnhanceCombineResponse(MapClientSession &sess, bool success, bool destroy);
 void sendChangeTitle(MapClientSession &sess, bool select_origin);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -2091,7 +2091,20 @@ void MapInstance::on_minimap_state(MiniMapState *ev)
     Entity *ent = session.m_ent;
     uint32_t map_idx = session.m_current_map->m_index;
 
-    std::array<bool, 1024> * map_cells = &ent->m_player->m_player_progress.m_visible_map_cells[map_idx];
+    std::vector<bool> * map_cells = &ent->m_player->m_player_progress.m_visible_map_cells[map_idx];
+
+    if (map_cells->empty())
+    {
+        map_cells->resize(1024);
+    }
+
+    if (ev->tile_idx > map_cells->size())
+    {
+        map_cells->resize(map_cells->size() + (ev->tile_idx - map_cells->size() + 1023) / 1024 * 1024);
+    }
+
+    // #818 map_cells of type array with a size of 1024 threw 
+    // out of range exception on maps that had index tiles larger than 1024
     map_cells->at(ev->tile_idx) = true;
 
     qCDebug(logMiniMap) << "MiniMapState tile "<< ev->tile_idx << " for player" << ent->name();
@@ -2155,8 +2168,14 @@ void MapInstance::on_client_resumed(ClientResumedRendering *ev)
         map_server->session_xfer_complete(session.link()->session_token());
     }
 
-    // TODO: Check map type to determine if is_opaque is true / false
-    sendVisitMapCells(session, false, session.m_ent->m_player->m_player_progress.m_visible_map_cells[session.m_current_map->m_index]);
+    std::vector<bool> * visible_map_cells = &session.m_ent->m_player->m_player_progress.m_visible_map_cells[session.m_current_map->m_index];
+
+    if (!visible_map_cells->empty())
+    {
+        // TODO: Check map type to determine if is_opaque is true / false
+        sendVisitMapCells(session, false, visible_map_cells->size(), *visible_map_cells);
+    }
+    
     initializeCharacter(*session.m_ent->m_char);
 
     // Call Lua Connected function.

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -2173,7 +2173,7 @@ void MapInstance::on_client_resumed(ClientResumedRendering *ev)
     if (!visible_map_cells->empty())
     {
         // TODO: Check map type to determine if is_opaque is true / false
-        sendVisitMapCells(session, false, visible_map_cells->size(), *visible_map_cells);
+        sendVisitMapCells(session, false, *visible_map_cells);
     }
     
     initializeCharacter(*session.m_ent->m_char);


### PR DESCRIPTION
## Summary
Resolved an issue that, when attempting to access m_visible_map_cells with a map tile index greater than 1024, would throw an array out of bounds error. Problem maps were Talos Island and Peregrine Island.
All instances of type `std::array<bool, 1024>` has been replaced with type `std::vector<bool>` from #818 to allow for resizing of the collection when necessary.

### Issues closed
Closes #371 

### Additions/modifications proposed in this pull request:
- Replaced type `std::array<bool, 1024>` with type `std::vector<bool>` in all committed files.
- `VisitMapCells::serializeto` now allocates enough space by using the size of `m_visible_map_cells`.
- `MapInstance::on_minimap_state` resizes the vector to 1024 by default if there is no vector for that specific map. It will also resize the vector if the map tile index is larger than the size of the vector.
- `MapInstance::on_client_resumed` will not invoke `sendVisitMapCells` if the vector is empty. 