### PR TITLE
Fix PostgreSQL scripts [skip ci]

### DIFF
--- a/Projects/CoX/Data/pgsql/segs_game_postgres_create.sql
+++ b/Projects/CoX/Data/pgsql/segs_game_postgres_create.sql
@@ -1,33 +1,25 @@
-CREATE TABLE "table_versions" (
-    "id" serial NOT NULL,
-    "table_name" varchar NOT NULL UNIQUE,
-    "version" integer NOT NULL DEFAULT '0',
-    "last_update" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT table_versions_pk PRIMARY KEY ("id")
-) WITH (
-  OIDS=FALSE
-);
-
-INSERT INTO table_versions VALUES(1,'db_version',9,'2018-10-22 22:56:43');
-INSERT INTO table_versions VALUES(2,'table_versions',0,'2017-11-11 08:57:42');
-INSERT INTO table_versions VALUES(3,'accounts',1,'2018-05-03 14:06:03');
-INSERT INTO table_versions VALUES(4,'characters',9,'2018-10-22 22:56:43');
-INSERT INTO table_versions VALUES(7,'supergroups',1,'2018-10-22 22:56:43');
-INSERT INTO table_versions VALUES(8,'emails',0,'2018-09-23 08:00:00');
+DROP TABLE IF EXISTS "table_versions";
+DROP TABLE IF EXISTS "supergroups";
+DROP TABLE IF EXISTS "progress";
+-- The costume table is no more, but for compatibility with older releases
+-- we want to make sure to still remove it.
+DROP TABLE IF EXISTS "costume";
+DROP TABLE IF EXISTS "emails";
+DROP TABLE IF EXISTS "characters";
+DROP TABLE IF EXISTS "accounts";
 
 CREATE TABLE "accounts" (
     "id" integer NOT NULL,
     "max_slots" integer NOT NULL DEFAULT '8',
     CONSTRAINT accounts_pk PRIMARY KEY ("id")
 ) WITH (
-  OIDS=FALSE
+    OIDS=FALSE
 );
 
 CREATE TABLE "characters" (
     "id" serial NOT NULL,
-    "char_level" integer NOT NULL DEFAULT '1',
-    "slot_index" integer NOT NULL DEFAULT '0',
     "account_id" integer NOT NULL DEFAULT '0',
+    "slot_index" integer NOT NULL DEFAULT '0',
     "char_name" varchar(20) NOT NULL,
     "costume_data" bytea NOT NULL,
     "chardata" bytea NOT NULL,
@@ -36,7 +28,7 @@ CREATE TABLE "characters" (
     "supergroup_id" integer NOT NULL DEFAULT '0',
     CONSTRAINT characters_pk PRIMARY KEY ("id")
 ) WITH (
-  OIDS=FALSE
+    OIDS=FALSE
 );
 
 CREATE TABLE "supergroups" (
@@ -46,18 +38,35 @@ CREATE TABLE "supergroups" (
     "sg_members" bytea NOT NULL,
     CONSTRAINT supergroups_pk PRIMARY KEY ("id")
 ) WITH (
-  OIDS=FALSE
+    OIDS=FALSE
 );
 
-CREATE TABLE 'emails'(
-	`id`	serial NOT NULL,
-	`sender_id`	integer NOT NULL,
-	`recipient_id` integer NOT NULL,
-	`email_data` bytea NOT NULL,
-	CONSTRAINT emails_pk PRIMARY KEY ("id")
+CREATE TABLE "emails" (
+    "id" serial NOT NULL,
+    "sender_id" integer NOT NULL,
+    "recipient_id" integer NOT NULL,
+    "email_data" bytea NOT NULL,
+    CONSTRAINT emails_pk PRIMARY KEY ("id")
 );
+
+CREATE TABLE "table_versions" (
+    "id" serial NOT NULL,
+    "table_name" varchar NOT NULL UNIQUE,
+    "version" integer NOT NULL DEFAULT '0',
+    "last_update" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT table_versions_pk PRIMARY KEY ("id")
+) WITH (
+    OIDS=FALSE
+);
+
+INSERT INTO table_versions VALUES(1,'db_version',9,'2018-10-22 22:56:43');
+INSERT INTO table_versions VALUES(2,'table_versions',0,'2017-11-11 08:57:42');
+INSERT INTO table_versions VALUES(3,'accounts',1,'2018-05-03 12:52:03');
+INSERT INTO table_versions VALUES(4,'characters',9,'2018-10-22 22:56:43');
+INSERT INTO table_versions VALUES(7,'supergroups',2,'2018-10-22 22:56:43');
+INSERT INTO table_versions VALUES(8,'emails',0,'2018-09-23 08:00:00');
+
+ALTER TABLE "characters" ADD CONSTRAINT "characters_fk0" FOREIGN KEY ("account_id") REFERENCES "accounts"("id");
 
 ALTER TABLE "emails" ADD CONSTRAINT "emails_fk0" FOREIGN KEY ("sender_id") REFERENCES "characters"("id");
 ALTER TABLE "emails" ADD CONSTRAINT "emails_fk1" FOREIGN KEY ("recipient_id") REFERENCES "characters"("id");
-
-ALTER TABLE "characters" ADD CONSTRAINT "characters_fk0" FOREIGN KEY ("account_id") REFERENCES "accounts"("id");

--- a/Projects/CoX/Data/pgsql/segs_postgres_create.sql
+++ b/Projects/CoX/Data/pgsql/segs_postgres_create.sql
@@ -1,65 +1,56 @@
-CREATE TABLE "table_versions" (
-	"id" serial NOT NULL,
-	"table_name" varchar NOT NULL UNIQUE,
-	"version" integer NOT NULL,
-	"last_update" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	CONSTRAINT table_versions_pk PRIMARY KEY ("id")
-) WITH (
-  OIDS=FALSE
-);
-
-
-
-INSERT INTO table_versions VALUES(1,'db_version',0,'2018-04-08 11:45:54');
-INSERT INTO table_versions VALUES(2,'table_versions',0,'2017-11-11 08:55:54');
-INSERT INTO table_versions VALUES(3,'accounts',0,'2017-11-11 08:55:54');
-INSERT INTO table_versions VALUES(4,'game_servers',0,'2017-11-11 09:12:37');
-INSERT INTO table_versions VALUES(5,'bans',0,'2017-11-11 09:12:37');
-
-
+DROP TABLE IF EXISTS "table_versions";
+DROP TABLE IF EXISTS "game_servers";
+DROP TABLE IF EXISTS "bans";
+DROP TABLE IF EXISTS "accounts";
 
 CREATE TABLE "accounts" (
-	"id" serial NOT NULL,
-	"username" TEXT NOT NULL UNIQUE,
-	"access_level" integer NOT NULL DEFAULT '1',
-	"creation_date" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	"passw" bytea NOT NULL,
-	CONSTRAINT accounts_pk PRIMARY KEY ("id")
+    "id" serial NOT NULL,
+    "username" TEXT NOT NULL UNIQUE,
+    "access_level" integer NOT NULL DEFAULT '1',
+    "creation_date" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "passw" bytea NOT NULL,
+    "salt" bytea NOT NULL,
+    CONSTRAINT accounts_pk PRIMARY KEY ("id")
 ) WITH (
-  OIDS=FALSE
+    OIDS=FALSE
 );
-
-
-
-INSERT INTO accounts VALUES(1,'segsadmin',1,'2017-11-11 17:41:19','7365677331323300000000000000'::bytea);
-
 
 CREATE TABLE "bans" (
-	"id" serial NOT NULL,
-	"account_id" integer NOT NULL,
-	"offending_ip" varchar(39) NOT NULL,
-	"started" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	"reason" varchar(1024) NOT NULL,
-	CONSTRAINT bans_pk PRIMARY KEY ("id")
+    "id" serial NOT NULL,
+    "account_id" integer NOT NULL,
+    "offending_ip" varchar(39) NOT NULL,
+    "started" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reason" varchar(1024) NOT NULL,
+    CONSTRAINT bans_pk PRIMARY KEY ("id")
 ) WITH (
-  OIDS=FALSE
+    OIDS=FALSE
 );
-
-
 
 CREATE TABLE "game_servers" (
-	"id" serial NOT NULL,
-	"addr" varchar(39) NOT NULL,
-	"port" integer NOT NULL,
-	"name" varchar(100) NOT NULL,
-	"token" integer NOT NULL,
-	CONSTRAINT game_servers_pk PRIMARY KEY ("id")
+    "id" serial NOT NULL,
+    "addr" varchar(39) NOT NULL,
+    "port" integer NOT NULL,
+    "name" varchar(100) NOT NULL,
+    "token" integer NOT NULL,
+    CONSTRAINT game_servers_pk PRIMARY KEY ("id")
 ) WITH (
-  OIDS=FALSE
+    OIDS=FALSE
 );
 
+CREATE TABLE "table_versions" (
+    "id" serial NOT NULL,
+    "table_name" varchar NOT NULL UNIQUE,
+    "version" integer NOT NULL,
+    "last_update" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT table_versions_pk PRIMARY KEY ("id")
+) WITH (
+    OIDS=FALSE
+);
 
-
-
+INSERT INTO table_versions VALUES(1,'db_version',0,'2018-01-06 16:27:58');
+INSERT INTO table_versions VALUES(2,'table_versions',0,'2017-11-11 08:55:54');
+INSERT INTO table_versions VALUES(3,'accounts',1,'2018-01-06 11:18:01');
+INSERT INTO table_versions VALUES(4,'game_servers',0,'2017-11-11 09:12:37');
+INSERT INTO table_versions VALUES(5,'bans',0,'2017-11-11 09:12:37');
 
 ALTER TABLE "bans" ADD CONSTRAINT "bans_fk0" FOREIGN KEY ("account_id") REFERENCES "accounts"("id");


### PR DESCRIPTION
## Summary
Fixes the syntax of the PostgreSQL scripts allowing dbtool to use them without error.

### Issues closed
Relates to #827

### Additions/modifications proposed in this pull request:
- Fixed `emails` table syntax
- Resolved `(42601) QPSQL: Unable to create query ((null):0, (null))` error
- Added `salt` column to `accounts` table to resolve `SQL_ERROR: QSqlError("42703", "QPSQL: Unable to prepare statement", "ERROR:  column \"salt\" of relation \"accounts\" does not exist\nLINE 1: ...INSERT INTO accounts (username,passw,access_level,salt) VALU...\n` error
- Added `DROP TABLE ...` to head of scripts to mirror MySQL script functionality
- Used standard 4-space indent
- Incremented `supergroups` version field from `1` to `2` in `table_versions` table
- Incremented `accounts` version field from `0` to `1` in `table_versions` table
- Synchronized all `last_update` timestamps in both `table_versions` tables with MySQL script timestamps
- Removed `char_level` column from `characters` table