### PR TITLE
Alleviate some build warnings

### DIFF
--- a/Projects/CoX/Common/GameData/particlesys_serializers.cpp
+++ b/Projects/CoX/Common/GameData/particlesys_serializers.cpp
@@ -14,7 +14,7 @@ std::vector<glm::vec3> convertToVec3Vector(const std::vector<float>& src) {
     std::vector<glm::vec3> res;
     assert((src.size() % 3) == 0);
     res.reserve(src.size()/3);
-    for(int i=0; i<src.size(); i+=3) {
+    for(size_t i=0; i<src.size(); i+=3) {
         res.emplace_back(src[i],src[i+1],src[i+2]);
     }
     return res;

--- a/Projects/CoX/Common/Messages/Map/VisitMapCells.h
+++ b/Projects/CoX/Common/Messages/Map/VisitMapCells.h
@@ -59,4 +59,4 @@ namespace SEGSEvents
         // [[ev_def:field]]
         std::vector<bool>   m_visible_map_cells;
     };
-};
+}

--- a/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
+++ b/Projects/CoX/Servers/AuthServer/AdminRPC.cpp
@@ -39,12 +39,12 @@ void AdminRPC::dispatch( Event *ev )
     }
 }
 
-void AdminRPC::serialize_from(std::istream &is)
+void AdminRPC::serialize_from(std::istream &/*is*/)
 {
     assert(false);
 }
 
-void AdminRPC::serialize_to(std::ostream &is)
+void AdminRPC::serialize_to(std::ostream &/*is*/)
 {
     assert(false);
 }

--- a/Projects/CoX/Servers/MapServer/CritterGenerator.cpp
+++ b/Projects/CoX/Servers/MapServer/CritterGenerator.cpp
@@ -18,7 +18,7 @@ void CritterGenerator::generate(MapInstance *map_instance)
 
 
     uint32_t count = 0;
-    bool spawn_all = false;
+    //bool spawn_all = false;
     bool m_victim_spawned = false;
 
     CritterSpawnDef spawn_def = sp->getSpawnGroup(this->m_critter_encounter.m_node_name);
@@ -31,7 +31,7 @@ void CritterGenerator::generate(MapInstance *map_instance)
         else
             break;
 
-        spawn_all = cd.m_spawn_all;
+        //spawn_all = cd.m_spawn_all;
 
         if(encounter_location.m_name.contains("encounter_e_", Qt::CaseInsensitive))
         {

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -1007,7 +1007,7 @@ void findAttrib(Entity &ent, Entity *target_ent, CharacterPower * ppower)
 
     if(powtpl.pAttribMod.empty())                                       //give the power an effect to either heal or hurt
     {
-        GameDataStore &data(getGameData());
+        //GameDataStore &data(getGameData());
         StoredAttribMod temp;
         temp.Scale = (powtpl.RechargeTime +  powtpl.TimeToActivate)/5;  //this is an aproximation of what the damage scales should be
         if(validTarget(*target_ent, ent, StoredEntEnum::Enemy))         //assume it is a damaging power
@@ -2002,7 +2002,7 @@ RelayRaceResult getRelayRaceResult(MapClientSession &cl, int segment)
 }
 
 
-void addEnemy(MapInstance &mi, QString &name, glm::vec3 &loc, int variation, glm::vec3 &ori, QString &npc_name, int level, QString &faction_name, int f_rank)
+void addEnemy(MapInstance &mi, QString &name, glm::vec3 &loc, int variation, glm::vec3 &ori, QString &npc_name, int level, QString &faction_name, int /*f_rank*/)
 {
     const NPCStorage & npc_store(getGameData().getNPCDefinitions());
     const Parse_NPC * npc_def = npc_store.npc_by_name(&name);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -646,9 +646,10 @@ void MapInstance::on_map_xfer_complete(MapXferComplete *ev)
     session.m_ent->m_map_swap_collided = false;
 }
 
-void MapInstance::on_idle(Idle *ev)
+void MapInstance::on_idle(Idle */*ev*/)
 {
-    MapLink * lnk = (MapLink *)ev->src();
+    // MapLink * lnk = (MapLink *)ev->src();
+
     // TODO: put idle sending on timer, which is reset each time some other packet is sent ?
     // we don't have to respond with an idle message here, check links will send idle events as needed.
     //lnk->putq(new Idle);
@@ -2307,7 +2308,7 @@ void MapInstance::on_set_destination(SetDestination * ev)
 void MapInstance::on_has_entered_door(HasEnteredDoor *ev)
 {
     MapClientSession &session(m_session_store.session_from_event(ev));
-    MapServer *map_server = (MapServer *)HandlerLocator::getMap_Handler(m_game_server_id);
+    //MapServer *map_server = (MapServer *)HandlerLocator::getMap_Handler(m_game_server_id);
 
     sendDoorAnimExit(session, false);
 
@@ -3061,12 +3062,6 @@ void MapInstance::on_email_header_response(EmailHeaderResponse* ev)
 // EmailHandler will send this event here
 void MapInstance::on_email_header_to_client(EmailHeaderToClientMessage* ev)
 {
-    EmailHeaders *header = new EmailHeaders(
-                    ev->m_data.m_email_id,
-                    ev->m_data.m_sender_name,
-                    ev->m_data.m_subject,
-                    ev->m_data.m_timestamp);
-
     MapClientSession &map_session(m_session_store.session_from_token(ev->session_token()));
     map_session.addCommandToSendNextUpdate(std::make_unique<EmailHeaders>(ev->m_data.m_email_id,
                                                                           ev->m_data.m_sender_name,


### PR DESCRIPTION
## Summary
Compilation outputs quite a few warnings for minor stuff such as unused variables and/or function arguments.
I decided to comment them out as they don't have any effect currently but could serve a good reminder if someone wants to use something similar in the future.

Look at my changes as deprecation before removal? :sweat_smile: 