### PR TITLE
Simplify byte_sum adjustment in VisitMapCells.h

### DIFF
--- a/Projects/CoX/Common/Messages/Map/VisitMapCells.h
+++ b/Projects/CoX/Common/Messages/Map/VisitMapCells.h
@@ -42,9 +42,7 @@ namespace SEGSEvents
                 for (uint16_t j = 0; j < 8; j++)
                 {
                     if (m_visible_map_cells[i * 8 + j])
-                    {
-                        byte_sum += std::pow(2, j);
-                    }
+                        byte_sum |= 1<<j;
                 }
                 cells_arr[i] =  byte_sum;
             }


### PR DESCRIPTION
## Summary
Small tweak to VisitMapCells.h to simplify the math on byte_sum to `byte_sum |= 1<<j;`
