### PR TITLE
Adjust stale link ACE_Time values

### DIFF
--- a/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
@@ -46,7 +46,7 @@ namespace
     };
 
     const ACE_Time_Value session_reaping_interval(0,1000*1000);
-    const ACE_Time_Value link_is_stale_if_disconnected_for(0,2*1000*1000);
+    const ACE_Time_Value link_is_stale_if_disconnected_for(5,0);
 } // namespace
 
 void AuthHandler::dispatch( Event *ev )

--- a/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
+++ b/Projects/CoX/Servers/AuthServer/AuthHandler.cpp
@@ -46,7 +46,7 @@ namespace
     };
 
     const ACE_Time_Value session_reaping_interval(0,1000*1000);
-    const ACE_Time_Value link_is_stale_if_disconnected_for(5,0);
+    const ACE_Time_Value link_is_stale_if_disconnected_for(2,0);
 } // namespace
 
 void AuthHandler::dispatch( Event *ev )

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -84,7 +84,7 @@ namespace
     };
 
     const ACE_Time_Value reaping_interval(0,1000*1000);
-    const ACE_Time_Value link_is_stale_if_disconnected_for(0,5*1000*1000);
+    const ACE_Time_Value link_is_stale_if_disconnected_for(5,0);
     const ACE_Time_Value link_update_interval(0,500*1000);
     const ACE_Time_Value world_update_interval(0,1000*1000/WORLD_UPDATE_TICKS_PER_SECOND);
     const ACE_Time_Value sync_service_update_interval(0, 30000*1000);


### PR DESCRIPTION
## Summary
Standardizing `link_is_stale_if_disconnected_for` values

### Issues closed
No open issues

### Additions/modifications proposed in this pull request:
- modified `link_is_stale_if_disconnected_for` to 5 sec across all servers