### PR TITLE
Categorize the "Sending new Powerstance" message [skip ci] 

### DIFF
--- a/Projects/CoX/Common/AuthProtocol/AuthLink.cpp
+++ b/Projects/CoX/Common/AuthProtocol/AuthLink.cpp
@@ -12,6 +12,7 @@
 
 #include "AuthLink.h"
 #include "Buffer.h"
+#include "Logging.h"
 
 #include "AuthProtocol/AuthOpcodes.h"
 #include "AuthProtocol/AuthEventFactory.h"
@@ -257,7 +258,7 @@ int AuthLink::handle_input( ACE_HANDLE )
     ssize_t recv_cnt;
     if((recv_cnt = m_peer.recv(buffer, sizeof(buffer))) <= 0)
     {
-        ACE_DEBUG ((LM_DEBUG,ACE_TEXT ("(%P|%t) Connection closed\n")));
+        qCDebug(logConnection) << "Connection closed";
         return -1;
     }
     ACE_Guard<ACE_Thread_Mutex> guard_buffer(m_buffer_mutex);

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -591,7 +591,7 @@ void sendWaypoint(MapClientSession &sess, int point_idx, glm::vec3 &location)
 
 void sendStance(MapClientSession &sess, PowerStance &stance)
 {
-    qCDebug(logSlashCommand) << "Sending new PowerStance";
+    qCDebug(logAnimations) << "Sending new PowerStance";
     sess.addCommand<SendStance>(stance);
 }
 
@@ -609,7 +609,7 @@ void sendSouvenirList(MapClientSession &sess)
 
 void sendDeadNoGurney(MapClientSession &sess)
 {
-    qCDebug(logSlashCommand) << "Sending new PowerStance";
+    qCDebug(logSlashCommand) << "Sending DeadNoGurney message";
     sess.addCommand<DeadNoGurney>();
 }
 


### PR DESCRIPTION
## Summary
This message fires too frequently, because toggle powers are constantly sending stance. It clutters the logs and makes them hard to follow on Red/Blue

We may want to actually change that behavior to only send on activation/deactivation, but for now, let's move this to Animations where it makes more sense and can be toggled.
