### PR TITLE
Delayed/repeat power effects

### DIFF
--- a/Projects/CoX/Common/GameData/Entity.h
+++ b/Projects/CoX/Common/GameData/Entity.h
@@ -177,6 +177,7 @@ public:
         std::deque<QueuedPowers>    m_queued_powers;
         std::vector<QueuedPowers>   m_auto_powers;
         std::vector<QueuedPowers>   m_recharging_powers;
+        std::vector<DelayedEffect>  m_delayed;
         PowerStance                 m_stance;
         bool                        m_update_buffs  = false;
 

--- a/Projects/CoX/Common/GameData/EntityHelpers.cpp
+++ b/Projects/CoX/Common/GameData/EntityHelpers.cpp
@@ -185,8 +185,8 @@ bool validTarget(Entity &target_ent, Entity &ent, StoredEntEnum const &target)
 
     if (target_ent.m_char->m_is_dead)
         if (!(target == StoredEntEnum::DeadPlayer || target == StoredEntEnum::DeadTeammate
-            || target == StoredEntEnum::DeadVillain || target == StoredEntEnum::DeadOrAliveTeammate)
-            || target == StoredEntEnum::Caster) // Caster is a valid target only if castable after death is true
+            || target == StoredEntEnum::DeadVillain || target == StoredEntEnum::DeadOrAliveTeammate
+            || target == StoredEntEnum::Caster)) // Caster is a valid target only if castable after death is true
             return false;
 
     if (&ent == &target_ent)

--- a/Projects/CoX/Common/GameData/EntityHelpers.cpp
+++ b/Projects/CoX/Common/GameData/EntityHelpers.cpp
@@ -182,6 +182,13 @@ bool validTarget(Entity &target_ent, Entity &ent, StoredEntEnum const &target)
     if (target == StoredEntEnum::DeadPlayer || target == StoredEntEnum::DeadTeammate || target == StoredEntEnum::DeadVillain)
         if (!target_ent.m_char->m_is_dead)
             return false;
+
+    if (target_ent.m_char->m_is_dead)
+        if (!(target == StoredEntEnum::DeadPlayer || target == StoredEntEnum::DeadTeammate
+            || target == StoredEntEnum::DeadVillain || target == StoredEntEnum::DeadOrAliveTeammate)
+            || target == StoredEntEnum::Caster) // Caster is a valid target only if castable after death is true
+            return false;
+
     if (&ent == &target_ent)
         return (target == StoredEntEnum::Caster || target == StoredEntEnum::Any || target == StoredEntEnum::Location || target == StoredEntEnum::Teleport);
     switch(target)

--- a/Projects/CoX/Common/GameData/Powers.h
+++ b/Projects/CoX/Common/GameData/Powers.h
@@ -338,11 +338,11 @@ static const int m_num_trays = 2; // was 3, displayed trays
 };
 struct DelayedEffect
 {
+    StoredAttribMod mod;
+    CharacterPower *power;
     int m_timer;
     int ticks;
     uint32_t src_ent;
-    StoredAttribMod mod;
-    CharacterPower *power;
 };
 
 /*

--- a/Projects/CoX/Common/GameData/Powers.h
+++ b/Projects/CoX/Common/GameData/Powers.h
@@ -336,7 +336,14 @@ static const int m_num_trays = 2; // was 3, displayed trays
     template<class Archive>
     void serialize(Archive &archive, uint32_t const version);
 };
-
+struct DelayedEffect
+{
+    int m_timer;
+    int ticks;
+    uint32_t src_ent;
+    StoredAttribMod mod;
+    CharacterPower *power;
+};
 
 /*
  * Powers Methods

--- a/Projects/CoX/Common/Messages/Map/MapEvents.h
+++ b/Projects/CoX/Common/Messages/Map/MapEvents.h
@@ -302,8 +302,7 @@ public:
     }
     void serializefrom(BitStream &/*bs*/) override
     {
-        // TODO: Seems like nothing is received server side.
-        qWarning() << "UnqueueAll unimplemented.";
+        // Seems to be properly handled elsewheres
     }
     EVENT_IMPL(UnqueueAll)
 };

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -780,18 +780,7 @@ bool checkPowerRange(Entity &ent, Entity &target_ent, float range)
             return false;
     return true;
 }
-bool checkPowerRange(Entity &ent, uint32_t tgt_idx, uint32_t pset_idx, uint32_t pow_idx)
-{
-    CharacterPower * ppower =  getOwnedPowerByVecIdx(ent, pset_idx, pow_idx);
-    const Power_Data powtpl = ppower->getPowerTemplate();
-    if(powtpl.Range != 0.0f)
-    {
-        Entity *target_ent = getEntity(ent.m_client, tgt_idx);
-        if(glm::distance(ent.m_entity_data.m_pos,target_ent->m_entity_data.m_pos) > powtpl.Range)
-            return false;
-    }
-    return true;
-}
+
 void queuePower(Entity &ent, uint32_t pset_idx, uint32_t pow_idx, uint32_t tgt_idx)
 {
     CharacterPower * ppower =  getOwnedPowerByVecIdx(ent, pset_idx, pow_idx);
@@ -987,7 +976,14 @@ void findAttrib(Entity &ent, Entity *target_ent, CharacterPower * ppower)
             {
                 target_ent = &ent;
             }
-            doAtrrib(ent, target_ent, powtpl.pAttribMod[i], ppower);
+
+            if (powtpl.pAttribMod[i].Delay == 0 && powtpl.pAttribMod[i].Period == 0)
+                doAtrrib(ent, target_ent, powtpl.pAttribMod[i], ppower);
+            else
+            {           //queue the power up to fire later or multiple times
+                target_ent->m_delayed.push_back(
+                {powtpl.pAttribMod[i].Delay, powtpl.pAttribMod[i].Period,ent.m_idx, powtpl.pAttribMod[i], ppower});
+            }
         }
     }
 

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -130,7 +130,23 @@ Entity * getEntity(MapInstance* mi, uint32_t idx)
     //sendInfoMessage(MessageChannel::USER_ERROR, errormsg, *src);
     return nullptr;
 }
+Entity * getEntity(Entity * srcEnt, MapInstance* mi, uint32_t idx)
+{
+    EntityManager &em(mi->m_entities);
+    QString errormsg;
 
+    if(idx!=0) // Entity idx 0 is always self
+    {
+        // Iterate through all active entities and return entity by idx
+        for (Entity* pEnt : em.m_live_entlist)
+        {
+            if(pEnt->m_idx == idx)
+                return pEnt;
+        }
+    }
+    // if no valid targets found by idx, return self
+    return srcEnt;
+}
 /**
  * @brief Finds the Entity in the MapInstance
  * @param mi map instance
@@ -674,17 +690,10 @@ void checkPower(Entity &ent, uint32_t pset_idx, uint32_t pow_idx, uint32_t tgt_i
         sendFloatingInfo(*ent.m_client, from_msg, FloatingInfoStyle::FloatingInfo_Info, 0.0);
         return;
     }
-    // Target IDX of 0 is actually SELF
-    if(tgt_idx == 0)
-        tgt_idx = getIdx(ent);
 
-    // Get target and check that it's a valid entity
-    Entity *target_ent = getEntity(ent.m_client, tgt_idx);
-    if(target_ent == nullptr)
-    {
-        qCDebug(logPowers) << "Failed to find target:" << tgt_idx;
-        return;
-    }
+    // Get target, if not valid, returns self entity
+    Entity *target_ent = getEntity(&ent, ent.m_client->m_current_map, tgt_idx);
+
     if (!checkPowerTarget(ent, target_ent, tgt_idx, powtpl))
     {
         from_msg = "Invalid target";
@@ -720,9 +729,10 @@ void usePower(Entity &ent, uint32_t pset_idx, uint32_t pow_idx, uint32_t tgt_idx
     QString from_msg, to_msg;
     CharacterPower * ppower =  getOwnedPowerByVecIdx(ent, pset_idx, pow_idx);
     const Power_Data powtpl = ppower->getPowerTemplate();
-    if(tgt_idx == 0)
-        tgt_idx = getIdx(ent);
-    Entity *target_ent = getEntity(ent.m_client, tgt_idx);
+
+    // Get target, if not valid, returns self entity
+    Entity *target_ent = getEntity(&ent, ent.m_client->m_current_map, tgt_idx);
+
     if(ent.m_char->m_is_dead && powtpl.CastableAfterDeath == 0)   //Allows self rez
         return;
     if (!checkPowerTarget(ent, target_ent, tgt_idx, powtpl))
@@ -739,24 +749,17 @@ void usePower(Entity &ent, uint32_t pset_idx, uint32_t pow_idx, uint32_t tgt_idx
  */
 bool checkPowerTarget(Entity &ent, Entity *target_ent, uint32_t &tgt_idx, Power_Data powtpl)
 {
-    if(validTarget(ent, ent, powtpl.Target))                    //check self targetting first
-    {
-        target_ent = &ent;
-        tgt_idx = ent.m_idx;
-        return true;
-    }
-    else if(validTarget(*target_ent, ent, powtpl.Target))      //if not self, and if not select target...
+    if(validTarget(*target_ent, ent, powtpl.Target))      //if not self, and if not select target...
         return true;
     if (ent.m_assist_target_idx != 0)                      //try assist target
         tgt_idx = ent.m_assist_target_idx;
     else if (target_ent->m_target_idx != 0)                //try target of target
         tgt_idx = target_ent->m_target_idx;
 
-    target_ent = getEntity(ent.m_client, tgt_idx);  //check the entity is valid
+    // Get target, if not valid, returns self entity
+    target_ent = getEntity(&ent, ent.m_client->m_current_map, tgt_idx);
 
-    if (target_ent == nullptr || !validTarget(*target_ent, ent, powtpl.Target))
-        return false;
-    return true;
+    return validTarget(*target_ent, ent, powtpl.Target);
 }
 /*
  * checkPowerRecharge returns false if the power is found in the recharging power vector
@@ -844,19 +847,16 @@ void doPower(Entity &ent, QueuedPowers powerinput)
 {
     QString from_msg, to_msg;
     uint32_t tgt_idx = powerinput.m_tgt_idx;
-    if(tgt_idx == 0)
-        tgt_idx = getIdx(ent);
 
-    Entity *target_ent = getEntity(ent.m_client, tgt_idx);
-    if(target_ent == nullptr)
-    {
-        qCDebug(logPowers) << "Failed to find target:" << tgt_idx;
-        return;
-    }
+    // Get target, if not valid, returns self entity
+    Entity *target_ent = getEntity(&ent, ent.m_client->m_current_map, tgt_idx);
 
     CharacterPower * ppower = nullptr;
     ppower = getOwnedPowerByVecIdx(ent, powerinput.m_pow_idxs.m_pset_vec_idx, powerinput.m_pow_idxs.m_pow_vec_idx);
     const Power_Data powtpl = ppower->getPowerTemplate();
+
+    if (!checkPowerTarget(ent, target_ent, tgt_idx, powtpl))
+        return;
 
     // Face towards your target
     sendFaceEntity(*ent.m_client, tgt_idx);
@@ -1165,7 +1165,8 @@ void grantRewards(EntityManager &em, Entity &e)
                 giveXp(*pEnt->m_client,  e.m_char->m_char_data.m_combat_level*10);
            }
       }
-      em.removeEntityFromActiveList(&e);         //todo: some sort of delay
+      e.m_is_fading = true;
+      e.m_fading_direction=FadeDirection::Out;
 }
 
 void increaseLevel(Entity &ent)

--- a/Projects/CoX/Servers/MapServer/DataHelpers.cpp
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.cpp
@@ -981,8 +981,8 @@ void findAttrib(Entity &ent, Entity *target_ent, CharacterPower * ppower)
                 doAtrrib(ent, target_ent, powtpl.pAttribMod[i], ppower);
             else
             {           //queue the power up to fire later or multiple times
-                target_ent->m_delayed.push_back(
-                {powtpl.pAttribMod[i].Delay, powtpl.pAttribMod[i].Period,ent.m_idx, powtpl.pAttribMod[i], ppower});
+                target_ent->m_delayed.emplace_back(DelayedEffect{powtpl.pAttribMod[i], ppower,
+                                            powtpl.pAttribMod[i].Delay, powtpl.pAttribMod[i].Period,ent.m_idx});
             }
         }
     }
@@ -1025,6 +1025,8 @@ void doAtrrib(Entity &ent, Entity *target_ent, StoredAttribMod const &mod, Chara
 
     if (lower_name == "damage")
     {
+        if (target_ent->m_char->m_is_dead)              //prevent beating a dead horse
+            return;
         GameDataStore &data(getGameData());             //TODO: apply this to all power effects, once we have strengths for every stat
         scale *= data.m_player_classes[uint32_t(getEntityClassIndex(data, true,
             ent.m_char->m_char_data.m_class_name))].m_ModTable[mod.Table.toUInt()].Values[ent.m_char->m_char_data.m_combat_level];
@@ -1871,11 +1873,8 @@ void changeHP(Entity &e, float val)
             e.m_char->m_char_data.m_current_attribs.m_HitPoints = 0.0f;
             e.m_char->m_char_data.m_current_attribs.m_Endurance = 0.0f;
 
-            if(e.m_type == EntType::PLAYER)
-            {
-                setStateMode(e, ClientStates::DEAD);
-                checkMovement(e);
-            }
+            setStateMode(e, ClientStates::DEAD);
+            checkMovement(e);
         }
     }
 }

--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -43,6 +43,7 @@ enum class ClientStates : uint8_t;
 Entity * getEntity(MapClientSession *src, const QString &name);
 Entity * getEntity(MapClientSession *src, uint32_t idx);
 Entity * getEntity(class MapInstance *mi, uint32_t idx);
+Entity * getEntity(Entity *srcEnt, class MapInstance *mi, uint32_t idx);
 Entity * getEntityByDBID(class MapInstance *mi,uint32_t idx);
 void    sendServerMOTD(MapClientSession *sess);
 void    positionTest(MapClientSession *tgt);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -2331,8 +2331,8 @@ void MapInstance::on_abort_queued_power(AbortQueuedPower * ev)
         return;
 
     // remove last queued power
-    session.m_ent->m_queued_powers.end()->m_activation_state = false;
-    session.m_ent->m_queued_powers.end()->m_active_state_change = true;
+    session.m_ent->m_queued_powers.back().m_activation_state = false;
+    session.m_ent->m_queued_powers.back().m_active_state_change = true;
     session.m_ent->m_char->m_char_data.m_has_updated_powers = true; // this must be true, because we're updating queued powers
 
     qCWarning(logMapEvents) << "Aborting queued power";

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -2331,7 +2331,8 @@ void MapInstance::on_abort_queued_power(AbortQueuedPower * ev)
         return;
 
     // remove last queued power
-    session.m_ent->m_queued_powers.pop_back();
+    session.m_ent->m_queued_powers.end()->m_activation_state = false;
+    session.m_ent->m_queued_powers.end()->m_active_state_change = true;
     session.m_ent->m_char->m_char_data.m_has_updated_powers = true; // this must be true, because we're updating queued powers
 
     qCWarning(logMapEvents) << "Aborting queued power";
@@ -2446,12 +2447,6 @@ void MapInstance::on_activate_power(ActivatePower *ev)
     session.m_ent->m_has_input_on_timeframe = true;
     int tgt_idx = ev->target_idx;
 
-    Entity *target_ent = getEntity(&session, tgt_idx);
-    if(target_ent == nullptr)
-    {
-        qCDebug(logPowers) << "Failed to find target:" << tgt_idx;
-        return;
-    }
     checkPower(*session.m_ent, ev->pset_idx, ev->pow_idx, tgt_idx);
 }
 
@@ -2465,12 +2460,6 @@ void MapInstance::on_activate_power_at_location(ActivatePowerAtLocation *ev)
     const Power_Data powtpl = ppower->getPowerTemplate();
     int tgt_idx = ev->target_idx;
 
-    Entity *target_ent = getEntity(&session, tgt_idx);
-    if(target_ent == nullptr)
-    {
-        qCDebug(logPowers) << "Failed to find target:" << tgt_idx;
-        return;
-    }
     if ((powtpl.EntsAffected[0] == StoredEntEnum::Caster ))
         tgt_idx = session.m_ent->m_idx;
     session.m_ent->m_target_loc = ev->location;

--- a/Projects/CoX/Servers/MapServer/WorldSimulation.h
+++ b/Projects/CoX/Servers/MapServer/WorldSimulation.h
@@ -27,6 +27,7 @@ public:
         float           accumulated_time=0;
 protected:
         void            physicsStep(Entity *e, uint32_t msec);
+        void            checkDelayedEffects(Entity *e, uint32_t msec);
         void            effectsStep(Entity *e, uint32_t msec);
         void            checkPowerTimers(Entity *e, uint32_t msec);
         void            regenHealthEnd(Entity *e, uint32_t msec);

--- a/Projects/CoX/Servers/MapServer/WorldSimulation.h
+++ b/Projects/CoX/Servers/MapServer/WorldSimulation.h
@@ -27,9 +27,12 @@ public:
         float           accumulated_time=0;
 protected:
         void            physicsStep(Entity *e, uint32_t msec);
+        void            checkActivationTimers(Entity *e, uint32_t msec);
         void            checkDelayedEffects(Entity *e, uint32_t msec);
+        void            checkRechargeTimers(Entity *e, uint32_t msec);
+        void            checkAutoToggleTimers(Entity *e, uint32_t msec);
+        void            checkBuffTimers(Entity *e, uint32_t msec);
         void            effectsStep(Entity *e, uint32_t msec);
-        void            checkPowerTimers(Entity *e, uint32_t msec);
         void            regenHealthEnd(Entity *e, uint32_t msec);
         void            updateEntity(Entity *e, const ACE_Time_Value &dT);
         void            collisionStep(Entity *e, uint32_t msec);

--- a/Projects/CoX/Servers/MapServer/WorldSimulation.h
+++ b/Projects/CoX/Servers/MapServer/WorldSimulation.h
@@ -27,13 +27,13 @@ public:
         float           accumulated_time=0;
 protected:
         void            physicsStep(Entity *e, uint32_t msec);
-        void            checkActivationTimers(Entity *e, uint32_t msec);
+        void            checkActivationTimers(Entity *e);
         void            checkDelayedEffects(Entity *e, uint32_t msec);
-        void            checkRechargeTimers(Entity *e, uint32_t msec);
-        void            checkAutoToggleTimers(Entity *e, uint32_t msec);
-        void            checkBuffTimers(Entity *e, uint32_t msec);
+        void            checkRechargeTimers(Entity *e);
+        void            checkAutoToggleTimers(Entity *e);
+        void            checkBuffTimers(Entity *e);
         void            effectsStep(Entity *e, uint32_t msec);
-        void            regenHealthEnd(Entity *e, uint32_t msec);
+        void            regenHealthEnd(Entity *e);
         void            updateEntity(Entity *e, const ACE_Time_Value &dT);
         void            collisionStep(Entity *e, uint32_t msec);
         EntityManager & ref_ent_mager;


### PR DESCRIPTION
Added "delayedEffect", for power effects that start after a timer, and/or repeat
Added a vector of delayedEffects to each entity, which works with players and critters

I was testing logging out/zoning/dying while an effect was ticking down, and found that activation didn't properly check those as well. Oops! So I refactored checks for power range, to catch any null entity. Worked in every variation of player vs player vs critter I could think of.

Minor issue: the effects use the "character power" of the source to determine the strength of the effect, which isn't accessible without the entity. Ideally the strength would be calculated first. For now the effects end early, which was not as it was on live.