### PR TITLE
Adds option for ticks per second

### DIFF
--- a/Projects/CoX/Common/GameData/Entity.cpp
+++ b/Projects/CoX/Common/GameData/Entity.cpp
@@ -26,10 +26,6 @@
 #include <sstream>
 #include <memory>
 
-//TODO: this file needs to know the MapInstance's WorldSimulation rate - Maybe extract it as a configuration object ?
-
-#define WORLD_UPDATE_TICKS_PER_SECOND 30
-
 void Entity::sendAllyID(BitStream &bs)
 {
     bs.StorePackedBits(2,0);

--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -38,6 +38,8 @@ namespace
 {
 constexpr uint32_t    stringcachecount_bitlength=12;
 constexpr uint32_t    colorcachecount_bitlength =10;
+constexpr int    minimumTicksPerSecond = 1;
+constexpr int    maximumTicksPerSecond = 1000;
 
 uint32_t color_to_4ub(const glm::vec3 &rgb)
 {
@@ -485,7 +487,16 @@ bool GameDataStore::read_settings(const QString &/*directory_path*/)
 
     qInfo() << "Loading Experimental settings...";
     config.beginGroup(QStringLiteral("Experimental"));
-        m_world_update_ticks_per_sec = config.value(QStringLiteral("world_update_ticks_per_sec"), "").toInt();
+    m_world_update_ticks_per_sec = config.value(QStringLiteral("world_update_ticks_per_sec"), "").toInt();
+    // constrain to a reasonable range
+    if (m_world_update_ticks_per_sec > maximumTicksPerSecond)
+    {
+        m_world_update_ticks_per_sec = maximumTicksPerSecond;
+    }
+    else if (m_world_update_ticks_per_sec < minimumTicksPerSecond)
+    {
+        m_world_update_ticks_per_sec = minimumTicksPerSecond;
+    }
     config.endGroup(); // Experiemental
 
     return true;

--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -487,16 +487,11 @@ bool GameDataStore::read_settings(const QString &/*directory_path*/)
 
     qInfo() << "Loading Experimental settings...";
     config.beginGroup(QStringLiteral("Experimental"));
-    m_world_update_ticks_per_sec = config.value(QStringLiteral("world_update_ticks_per_sec"), "").toInt();
+
     // constrain to a reasonable range
-    if (m_world_update_ticks_per_sec > maximumTicksPerSecond)
-    {
-        m_world_update_ticks_per_sec = maximumTicksPerSecond;
-    }
-    else if (m_world_update_ticks_per_sec < minimumTicksPerSecond)
-    {
-        m_world_update_ticks_per_sec = minimumTicksPerSecond;
-    }
+    int ticks = config.value(QStringLiteral("world_update_ticks_per_sec"), "").toInt();
+    m_world_update_ticks_per_sec = std::min(std::min(ticks, minimumTicksPerSecond), maximumTicksPerSecond);
+
     config.endGroup(); // Experiemental
 
     return true;

--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -483,6 +483,11 @@ bool GameDataStore::read_settings(const QString &/*directory_path*/)
              "M/d/yyyy h:mm AP");
     config.endGroup(); // Modifiers
 
+    qInfo() << "Loading Experimental settings...";
+    config.beginGroup(QStringLiteral("Experimental"));
+        m_world_update_ticks_per_sec = config.value(QStringLiteral("world_update_ticks_per_sec"), "").toInt();
+    config.endGroup(); // Experiemental
+
     return true;
 }
 

--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -490,7 +490,7 @@ bool GameDataStore::read_settings(const QString &/*directory_path*/)
 
     // constrain to a reasonable range
     int ticks = config.value(QStringLiteral("world_update_ticks_per_sec"), "").toInt();
-    m_world_update_ticks_per_sec = std::min(std::min(ticks, minimumTicksPerSecond), maximumTicksPerSecond);
+    m_world_update_ticks_per_sec = std::min(std::max(ticks, minimumTicksPerSecond), maximumTicksPerSecond);
 
     config.endGroup(); // Experiemental
 

--- a/Projects/CoX/Common/GameData/GameDataStore.h
+++ b/Projects/CoX/Common/GameData/GameDataStore.h
@@ -105,6 +105,9 @@ public:
         double                      m_xp_mod_multiplier;
         QDateTime                   m_xp_mod_startdate;
         QDateTime                   m_xp_mod_enddate;
+
+        // default of 30 for cases where settings are not yet loaded
+        int                         m_world_update_ticks_per_sec=30;
 };
 int getEntityOriginIndex(const GameDataStore &data,bool is_player, const QString &origin_name);
 int getEntityClassIndex(const GameDataStore &data,bool is_player, const QString &class_name);

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -24,7 +24,7 @@
 ##############################################################
 
 [MetaData]
-config_version     = 1
+config_version     = 2
 
 [AdminServer]
 AccountDatabase\db_driver   = QSQLITE

--- a/Projects/CoX/Data/settings_template.cfg
+++ b/Projects/CoX/Data/settings_template.cfg
@@ -97,6 +97,9 @@ xp_mod_multiplier  = 2
 xp_mod_startdate   = 1/1/2000 12:00 AM
 xp_mod_enddate     = 1/1/2000 12:00 AM
 
+[Experimental]
+world_update_ticks_per_sec = 30
+
 [Logging]
 combine_logs        = false
 log_generic         = *.debug=true\nqt.*.debug=false

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -86,7 +86,6 @@ namespace
     const ACE_Time_Value reaping_interval(0,1000*1000);
     const ACE_Time_Value link_is_stale_if_disconnected_for(5,0);
     const ACE_Time_Value link_update_interval(0,500*1000);
-    const ACE_Time_Value world_update_interval(0,1000*1000/WORLD_UPDATE_TICKS_PER_SECOND);
     const ACE_Time_Value sync_service_update_interval(0, 30000*1000);
     const ACE_Time_Value afk_update_interval(0, 1000 * 1000);
     const ACE_Time_Value lua_timer_interval(0, 1000 * 1000);
@@ -118,8 +117,10 @@ protected:
 
 using namespace std;
 MapInstance::MapInstance(const QString &mapdir_path, const ListenAndLocationAddresses &listen_addr)
-  : m_data_path(mapdir_path), m_index(getMapIndex(mapdir_path.mid(mapdir_path.indexOf('/')))),
-    m_addresses(listen_addr)
+  : m_data_path(mapdir_path),
+    m_index(getMapIndex(mapdir_path.mid(mapdir_path.indexOf('/')))),
+    m_addresses(listen_addr),
+    m_world_update_interval(0, 1000*1000/getGameData().m_world_update_ticks_per_sec)
 {
     m_world = new World(m_entities, getGameData().m_player_fade_in, this);
     m_scripting_interface.reset(new ScriptingEngine);
@@ -169,7 +170,7 @@ void MapInstance::start(const QString &scenegraph_path)
     m_sync_service->activate();
 
     // world simulation ticks
-    m_world_update_timer = std::make_unique<SEGSTimer>(this, World_Update_Timer, world_update_interval, false);
+    m_world_update_timer = std::make_unique<SEGSTimer>(this, World_Update_Timer, m_world_update_interval, false);
     // state broadcast ticks
     m_resend_timer = std::make_unique<SEGSTimer>(this, State_Transmit_Timer, resend_interval, false);
     m_link_timer   = std::make_unique<SEGSTimer>(this, Link_Idle_Timer, link_update_interval, false);

--- a/Projects/CoX/Servers/MapServer/MapInstance.h
+++ b/Projects/CoX/Servers/MapServer/MapInstance.h
@@ -21,8 +21,6 @@
 #include <memory>
 #include <vector>
 
-#define WORLD_UPDATE_TICKS_PER_SECOND 30
-
 class MapServer;
 class SEGSTimer;
 class World;
@@ -168,6 +166,7 @@ public:
         CritterGeneratorStore   m_critter_generators;
         SpawnDefinitions        m_enemy_spawn_definitions;
         std::vector<LuaTimer>   m_lua_timers;
+        const ACE_Time_Value    m_world_update_interval;
 
 public:
                                 IMPL_ID(MapInstance)

--- a/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
@@ -229,6 +229,10 @@ void SettingsDialog::read_config_file(QString filePath)
     ui->xp_mod_enddate_edit->setDateTime(QDateTime::fromString(config_file.value("xp_mod_enddate", "").toString(),
         "M/d/yyyy h:mm AP"));
     config_file.endGroup(); // Modifiers
+
+    config_file.beginGroup("Experimental");
+    ui->ticksPerSecond->setValue(config_file.value("world_update_ticks_per_sec", "").toInt());
+    config_file.endGroup(); // Experimental
 }
 
 void SettingsDialog::generate_default_config_file(QString ip)
@@ -312,6 +316,12 @@ void SettingsDialog::generate_default_config_file(QString ip)
     settings_template.endGroup(); // settings_template Modifiers
     config_file_write.endGroup(); // Modifiers
 
+    config_file_write.beginGroup("Experimental");
+    settings_template.beginGroup("Experimental");
+    config_file_write.setValue("world_update_ticks_per_sec", settings_template.value("world_update_ticks_per_sec").toInt());
+    settings_template.endGroup(); // settings_template Experimental
+    config_file_write.endGroup(); // Experimental
+
     config_file_write.sync();
     emit checkForConfigFile();
     emit check_data_and_dir(ui->map_location->text());
@@ -388,6 +398,10 @@ void SettingsDialog::save_changes_config_file()
     config_file_write.setValue("xp_mod_startdate", ui->xp_mod_startdate_edit->dateTime().toString("M/d/yyyy h:mm AP"));
     config_file_write.setValue("xp_mod_enddate", ui->xp_mod_enddate_edit->dateTime().toString("M/d/yyyy h:mm AP"));
     config_file_write.endGroup(); // Modifiers
+
+    config_file_write.beginGroup("Experimental");
+    config_file_write.setValue("world_update_ticks_per_sec", ui->ticksPerSecond->value());
+    config_file_write.endGroup(); // Experimental
 
     config_file_write.sync();
 

--- a/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.ui
+++ b/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.ui
@@ -118,7 +118,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <property name="tabsClosable">
       <bool>false</bool>
@@ -1624,6 +1624,51 @@
              <width>141</width>
              <height>26</height>
             </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+      <widget class="QGroupBox" name="groupBox_9">
+       <property name="geometry">
+        <rect>
+         <x>289</x>
+         <y>9</y>
+         <width>301</width>
+         <height>141</height>
+        </rect>
+       </property>
+       <property name="title">
+        <string>Tick Rate</string>
+       </property>
+       <widget class="QWidget" name="horizontalLayoutWidget_4">
+        <property name="geometry">
+         <rect>
+          <x>9</x>
+          <y>30</y>
+          <width>271</width>
+          <height>80</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_14">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Ticks Per Second</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="ticksPerSecond">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>30</number>
            </property>
           </widget>
          </item>

--- a/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.ui
+++ b/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.ui
@@ -118,7 +118,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <property name="tabsClosable">
       <bool>false</bool>


### PR DESCRIPTION
Adds option for ticks per second.
Default is 30. 0 errors, and over 100 acts strange. 
Added ui for setting and saving ticks per second option with reasonable minimum and maximum.

The faster the tick rate, the more updates are pushed per second, pretty straightforward.

## Summary
Please include a summary of this pull request here.

### Issues closed
Closes #791
https://github.com/Segs/Segs/issues/791
