### PR TITLE
Fix bug of tells to unfound targets causing crash

### DIFF
--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -1380,7 +1380,7 @@ void MapInstance::process_chat(Entity *sender, QString &msg_text)
                              << "\n\t" << "target_name:" << target_name
                              << "\n\t" << "msg_text:" << msg_text;
 
-            Entity *tgt;
+            Entity *tgt = nullptr;
             for(MapClientSession *cl : m_session_store)
             {
                 if(cl->m_ent->name() == target_name)


### PR DESCRIPTION
Doesn't help find the targets on other maps, but this should remove some crashes for now