### PR TITLE
world_update_ticks_per_sec hotfix

### DIFF
--- a/Projects/CoX/Common/GameData/GameDataStore.cpp
+++ b/Projects/CoX/Common/GameData/GameDataStore.cpp
@@ -489,7 +489,7 @@ bool GameDataStore::read_settings(const QString &/*directory_path*/)
     config.beginGroup(QStringLiteral("Experimental"));
 
     // constrain to a reasonable range
-    int ticks = config.value(QStringLiteral("world_update_ticks_per_sec"), "").toInt();
+    int ticks = config.value(QStringLiteral("world_update_ticks_per_sec"), "30").toInt();
     m_world_update_ticks_per_sec = std::min(std::max(ticks, minimumTicksPerSecond), maximumTicksPerSecond);
 
     config.endGroup(); // Experiemental

--- a/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/SettingsDialog.cpp
@@ -231,7 +231,7 @@ void SettingsDialog::read_config_file(QString filePath)
     config_file.endGroup(); // Modifiers
 
     config_file.beginGroup("Experimental");
-    ui->ticksPerSecond->setValue(config_file.value("world_update_ticks_per_sec", "").toInt());
+    ui->ticksPerSecond->setValue(config_file.value("world_update_ticks_per_sec", "30").toInt());
     config_file.endGroup(); // Experimental
 }
 

--- a/include/Version.h
+++ b/include/Version.h
@@ -22,7 +22,7 @@
 #define VersionString ProjectName " v" SEGS_VERSION "-" SEGS_BRANCH " (" VersionName ") [" SEGS_DESCRIPTION "]"
 #define CopyrightString "Super Entity Game Server\nhttp://github.com/Segs/\nCopyright (c) 2006-2019 Super Entity Game Server Team (see AUTHORS.md)\nThis software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.\n";
 
-static constexpr int s_config_version = 1;
+static constexpr int s_config_version = 2;
 static constexpr int s_auth_db_version = 1;
 static constexpr int s_game_db_version = 9;
 


### PR DESCRIPTION
## Summary
Hotfix for the `world_update_ticks_per_sec == 0` issue

### Issues closed
Closes #886 

### Additions/modifications proposed in this pull request:
- Iterate s_config_version to 2
- Added default value of 30 to world_update_ticks_per_sec in two files
