### PR TITLE
Teleport slash cmd, fix for multiple target names, adjust access lvls

### DIFF
--- a/Projects/CoX/Servers/MapServer/DataHelpers.h
+++ b/Projects/CoX/Servers/MapServer/DataHelpers.h
@@ -45,6 +45,7 @@ Entity * getEntity(MapClientSession *src, uint32_t idx);
 Entity * getEntity(class MapInstance *mi, uint32_t idx);
 Entity * getEntity(Entity *srcEnt, class MapInstance *mi, uint32_t idx);
 Entity * getEntityByDBID(class MapInstance *mi,uint32_t idx);
+Entity * getCmdTargetByNameOrIdx(MapClientSession &sess, const QString &name_from_cmd);
 void    sendServerMOTD(MapClientSession *sess);
 void    positionTest(MapClientSession *tgt);
 bool    isFriendOnline(Entity &sess, uint32_t db_id);

--- a/Projects/CoX/Servers/MapServer/MapInstance.cpp
+++ b/Projects/CoX/Servers/MapServer/MapInstance.cpp
@@ -1143,7 +1143,7 @@ void MapInstance::on_window_state(WindowState * ev)
         e->m_player->m_gui.m_wnds.at(idx).guiWindowDump();
 }
 
-QString process_replacement_strings(MapClientSession *sender,const QString &msg_text)
+QString processReplacementStrings(MapClientSession *sender, const QString &msg_text)
 {
     /*
     // $$           - newline
@@ -1153,8 +1153,6 @@ QString process_replacement_strings(MapClientSession *sender,const QString &msg_
     // $name        - your character's name
     // $origin      - your character's origin
     // $target      - your currently selected target's name
-
-    msg_text = msg_text.replace("$target",sender->m_ent->target->name());
     */
 
     QString new_msg = msg_text;
@@ -1176,15 +1174,11 @@ QString process_replacement_strings(MapClientSession *sender,const QString &msg_
     QString  sender_char_name   = c.getName();
     QString  sender_origin      = getOrigin(c);
     uint32_t target_idx         = getTargetIdx(*sender->m_ent);
-    QString  target_char_name   = c.getName();
 
     qCDebug(logChat) << "src -> tgt: " << sender->m_ent->m_idx  << "->" << target_idx;
 
-    if(target_idx > 0)
-    {
-        Entity   *tgt    = getEntity(sender,target_idx);
-        target_char_name = tgt->name(); // change name
-    }
+    Entity *tgt = getEntity(sender, target_idx);
+    QString target_char_name = tgt->name(); // change name
 
     foreach (const QString &str, replacements)
     {
@@ -1262,17 +1256,16 @@ void MapInstance::process_chat(Entity *sender, QString &msg_text)
     if(!sender)
       return;
 
-
     sender_char_name = sender->name();
 
-     for(MapClientSession *cl : m_session_store)
-     {
-         if(cl->m_ent->m_db_id == sender->m_db_id)
-         {
-             sender_sess = cl;
-             break;
-         }
-     }
+    for(MapClientSession *cl : m_session_store)
+    {
+        if(cl->m_ent->m_db_id == sender->m_db_id)
+        {
+            sender_sess = cl;
+            break;
+        }
+    }
 
     switch(kind)
     {
@@ -1462,24 +1455,18 @@ void MapInstance::on_console_command(ConsoleCommand * ev)
     Entity *ent = session.m_ent;
 
     if(contents.contains("$")) // does it contain replacement strings?
-        contents = process_replacement_strings(&session, contents);
+        contents = processReplacementStrings(&session, contents);
 
-    //printf("Console command received %s\n",qPrintable(ev->contents));
+    //qCDebug(logChat, "Console command received %1").arg(qPrintable(ev->contents);
 
     ent->m_has_input_on_timeframe = true;
 
     if(isChatMessage(contents))
-    {
         process_chat(ent,contents);
-    }
     else if(has_emote_prefix(contents))
-    {
         on_emote_command(contents, ent);
-    }
     else
-    {
-        runCommand(contents,session);
-    }
+        runCommand(contents, session);
 }
 
 void MapInstance::on_emote_command(const QString &command, Entity *ent)

--- a/Projects/CoX/Servers/MapServer/SlashCommand.h
+++ b/Projects/CoX/Servers/MapServer/SlashCommand.h
@@ -9,5 +9,4 @@
 
 class QString;
 
-void runCommand(const QString &str,struct MapClientSession &e);
-
+void runCommand(const QString &str, struct MapClientSession &sess);


### PR DESCRIPTION
## Summary
Teleport slash cmd, fix for multiple target names, adjust access lvls

### Issues closed
Closes #888 
Closes #874 

### Additions/modifications proposed in this pull request:
- Created `/teleport {target_name}` slash command, alias: `/tp` see #874 
- In situations where a command takes a target_name, check to see if name matches the idx of the currently selected target, if so, use the current_target instead. This prevents issues where NPCs that share a name will always return the NPC with the lowest IDX, see #888 
- Adjust access levels for `/fly` and `/jumppack` to level 2 so that GMs can use them.
