### PR TITLE
[ci skip] Changed URL to segs.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For legal information, please see [LICENSE.md](./LICENSE.md).
 For a list of SEGS authors and contributors, please see [AUTHORS.md](./docs/AUTHORS.md).
 
 Some other useful links:
-* Our [Discord](https://discord.segs.io/)
+* Our [Discord](https://discord.segs.dev/)
 * Our [wiki](https://github.com/Segs/Segs/wiki)
 * The [Issue Queue](https://github.com/Segs/Segs/issues)
 * How Can I Help? [Specific Tasks to Help](https://github.com/Segs/Segs/issues/519)
@@ -46,7 +46,7 @@ CONTRIBUTE TO DEVELOPMENT
 ------
 **SEGS needs your help!** From editing README's like this one, to coding the MapServer, there are tasks that can be tackled by contributors of all skill level!
 
-Basic instructions for compiling SEGS in Linux and Windows are above, however for more detailed visual instructions, visit https://segs.io/developers
+Basic instructions for compiling SEGS in Linux and Windows are above, however for more detailed visual instructions, visit https://segs.dev/developers
 
 Please read [CONTRIBUTING.md](./docs/CONTRIBUTING.md) and see the links below to begin:
 
@@ -60,7 +60,7 @@ Please read [CONTRIBUTING.md](./docs/CONTRIBUTING.md) and see the links below to
 HELP AND MORE INFORMATION
 ------
 
-For Help with installation and configuration of your local SEGS, please see visit us on discord at https://discord.segs.io/
+For Help with installation and configuration of your local SEGS, please see visit us on discord at https://discord.segs.dev/
 
 
 FAQs


### PR DESCRIPTION
## Summary
Changed url in the readme from `segs.io` to `segs.dev`

Note: this change needs to happen throughout the codebase. So I'll open a new issue to track that greater work.
