### PR TITLE
Fix build issues in SEGSEventFactory.h

### DIFF
--- a/Components/SEGSEventFactory.h
+++ b/Components/SEGSEventFactory.h
@@ -6,6 +6,7 @@
  */
 #pragma once
 #include <functional>
+#include <iosfwd>
 /*!
  * @addtogroup Components
  * @{


### PR DESCRIPTION
## Summary
Added missing include of `<iosfwd>` in `SEGSEventFactory.h`


