### PR TITLE
SEGSAdmin fix for BinConverter on Linux/MacOS

### DIFF
--- a/Projects/CoX/Utilities/SEGSAdmin/Worker.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/Worker.cpp
@@ -69,7 +69,8 @@ bool Worker::processPiggFile(const QString &file)
 bool Worker::runBinConverter()
 {
     emit sendUIMessage("Starting BinConverter");
-    QString program = "utilities/binconverter data/ent_types";
+    //QString program = "utilities/binconverter data/ent_types";
+    QString program = "utilities/binConverter " + (QDir::currentPath() + "/data/ent_types");
 #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     program.prepend("./");
 #endif

--- a/Projects/CoX/Utilities/SEGSAdmin/Worker.cpp
+++ b/Projects/CoX/Utilities/SEGSAdmin/Worker.cpp
@@ -69,7 +69,6 @@ bool Worker::processPiggFile(const QString &file)
 bool Worker::runBinConverter()
 {
     emit sendUIMessage("Starting BinConverter");
-    //QString program = "utilities/binconverter data/ent_types";
     QString program = "utilities/binConverter " + (QDir::currentPath() + "/data/ent_types");
 #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     program.prepend("./");


### PR DESCRIPTION
## Summary
Made some changes to the path used when running BinConverter within SEGSAdmin to fix Linux not finding the executable and subsequently the data/ent_types directory

### Issues closed
Closes #921

