### PR TITLE
feat: create ClientOptionService as part of map instance refactor

### DIFF
--- a/Projects/CoX/Common/Servers/CMakeLists.txt
+++ b/Projects/CoX/Common/Servers/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(target_CPP
     ${CMAKE_CURRENT_SOURCE_DIR}/HandlerLocator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/MessageBus.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/MessageBusEndpoint.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/EventHelpers.cpp
 )
 SET(target_INCLUDE
     ${CMAKE_CURRENT_SOURCE_DIR}/ClientManager.h
@@ -13,6 +14,7 @@ SET(target_INCLUDE
     ${CMAKE_CURRENT_SOURCE_DIR}/HandlerLocator.h
     ${CMAKE_CURRENT_SOURCE_DIR}/MessageBus.h
     ${CMAKE_CURRENT_SOURCE_DIR}/MessageBusEndpoint.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/EventHelpers.h
 )
 
 SET(target_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Projects/CoX/Common/Servers/EventHelpers.cpp
+++ b/Projects/CoX/Common/Servers/EventHelpers.cpp
@@ -1,0 +1,21 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.dev/
+ * Copyright (c) 2006 - 2019 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+
+#pragma once
+
+#include "EventHelpers.h"
+#include "Common/CRUDP_Protocol/ILink.h"
+
+uint64_t get_session_token(Event* ev)
+{
+    return static_cast<LinkBase *>(ev->src())->session_token();
+}
+
+uint64_t get_session_token(InternalEvent* ev)
+{
+    return ev->session_token();
+}

--- a/Projects/CoX/Common/Servers/EventHelpers.h
+++ b/Projects/CoX/Common/Servers/EventHelpers.h
@@ -1,0 +1,15 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.dev/
+ * Copyright (c) 2006 - 2019 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+
+#pragma once
+
+#include "InternalEvents.h"
+
+using namespace SEGSEvents;
+
+uint64_t get_session_token(Event* ev);
+uint64_t get_session_token(InternalEvent* ev);

--- a/Projects/CoX/Common/Servers/InternalEvents.h
+++ b/Projects/CoX/Common/Servers/InternalEvents.h
@@ -278,6 +278,21 @@ struct ServiceToClientData
     }
 };
 
+using EntityFoundAction = std::function<void(Entity* ent)>;
+
+struct ServiceToEntityData
+{
+    EntityFoundAction m_entity_found_action;
+    uint64_t m_token;
+
+    ServiceToEntityData(uint64_t token, EntityFoundAction action)
+    {
+        m_token = token;
+        m_entity_found_action = action;
+    }
+};
+
 using UPtrServiceToClientData = std::unique_ptr<SEGSEvents::ServiceToClientData>;
+using UPtrServiceToEntityData = std::unique_ptr<SEGSEvents::ServiceToEntityData>;
 
 } // end of SEGSEvents namespace

--- a/Projects/CoX/Servers/GameServer/CMakeLists.txt
+++ b/Projects/CoX/Servers/GameServer/CMakeLists.txt
@@ -27,8 +27,9 @@ target_link_libraries(GameServer INTERFACE SEGS_Components gameData )
 
 add_subdirectory(FriendshipService)
 add_subdirectory(EmailService)
+add_subdirectory(ClientOptionService)
 
-target_link_libraries(GameServer PUBLIC Qt5::Core FriendshipService EmailService )
+target_link_libraries(GameServer PUBLIC Qt5::Core FriendshipService EmailService ClientOptionService )
 target_link_libraries(GameServer INTERFACE SEGS_Components gameData)
 
 if(ENABLE_TESTS)

--- a/Projects/CoX/Servers/GameServer/ClientOptionService/CMakeLists.txt
+++ b/Projects/CoX/Servers/GameServer/ClientOptionService/CMakeLists.txt
@@ -1,0 +1,27 @@
+SET(target_CPP
+${CMAKE_CURRENT_SOURCE_DIR}/ClientOptionService.cpp
+)
+SET(target_INCLUDE
+${CMAKE_CURRENT_SOURCE_DIR}/ClientOptionService.h
+)
+
+SET(target_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+INCLUDE_DIRECTORIES(${target_INCLUDE_DIR})
+
+SET (target_SOURCES
+${target_CPP}
+${target_INCLUDE}
+)
+add_handler(ClientOptionService ${target_SOURCES})
+target_link_libraries(ClientOptionService PUBLIC Qt5::Core gameData)
+target_link_libraries(ClientOptionService INTERFACE SEGS_Components )
+
+if(ENABLE_TESTS)
+#    add_subdirectory(UnitTests)
+endif()
+get_target_property(TARGET_SOURCES ClientOptionService SOURCES) 
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${TARGET_SOURCES}) 
+set_target_properties (ClientOptionService PROPERTIES
+    FOLDER Projects/CoX/Servers/GameServer_Handlers
+)

--- a/Projects/CoX/Servers/GameServer/ClientOptionService/CMakeLists.txt
+++ b/Projects/CoX/Servers/GameServer/ClientOptionService/CMakeLists.txt
@@ -14,6 +14,7 @@ ${target_CPP}
 ${target_INCLUDE}
 )
 add_handler(ClientOptionService ${target_SOURCES})
+add_messages_library(ClientOptionService ${SOURCES})
 target_link_libraries(ClientOptionService PUBLIC Qt5::Core gameData)
 target_link_libraries(ClientOptionService INTERFACE SEGS_Components )
 

--- a/Projects/CoX/Servers/GameServer/ClientOptionService/ClientOptionService.cpp
+++ b/Projects/CoX/Servers/GameServer/ClientOptionService/ClientOptionService.cpp
@@ -18,14 +18,14 @@ UPtrServiceToEntityData ClientOptionService::on_set_keybind(Event *ev)
 {
     SetKeybind* casted_ev = static_cast<SetKeybind *>(ev);
 
-    auto func = [casted_ev](Entity* ent) -> void
+    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
     {
-        KeyName key = static_cast<KeyName>(casted_ev->key);
-        ModKeys mod = static_cast<ModKeys>(casted_ev->mods);
+        KeyName key = static_cast<KeyName>(content_data->key);
+        ModKeys mod = static_cast<ModKeys>(content_data->mods);
 
-        ent->m_player->m_keybinds.setKeybind(casted_ev->profile, key, mod, casted_ev->command, casted_ev->is_secondary);
-        qCDebug(logKeybinds) << "Setting keybind: " << casted_ev->profile << QString::number(casted_ev->key)
-                              << QString::number(casted_ev->mods) << casted_ev->command << casted_ev->is_secondary;
+        ent->m_player->m_keybinds.setKeybind(content_data->profile, key, mod, content_data->command, content_data->is_secondary);
+        qCDebug(logKeybinds) << "Setting keybind: " << content_data->profile << QString::number(content_data->key)
+                              << QString::number(content_data->mods) << content_data->command << content_data->is_secondary;
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -35,10 +35,10 @@ UPtrServiceToEntityData ClientOptionService::on_save_client_options(Event *ev)
 {
     SaveClientOptions* casted_ev = static_cast<SaveClientOptions *>(ev);
 
-    auto func = [casted_ev](Entity* ent) -> void
+    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
     {
         markEntityForDbStore(ent,DbStoreFlags::PlayerData);
-        ent->m_player->m_options = casted_ev->data;
+        ent->m_player->m_options = content_data->data;
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -48,10 +48,10 @@ UPtrServiceToEntityData ClientOptionService::on_remove_keybind(Event *ev)
 {
     RemoveKeybind* casted_ev = static_cast<RemoveKeybind *>(ev);
 
-    auto func = [casted_ev](Entity* ent) -> void
+    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
     {
-        ent->m_player->m_keybinds.removeKeybind(casted_ev->profile,(KeyName &)casted_ev->key,(ModKeys &)casted_ev->mods);
-        qCDebug(logKeybinds) << "Clearing Keybind: " << casted_ev->profile << QString::number(casted_ev->key) << QString::number(casted_ev->mods);
+        ent->m_player->m_keybinds.removeKeybind(content_data->profile,(KeyName &)content_data->key,(ModKeys &)content_data->mods);
+        qCDebug(logKeybinds) << "Clearing Keybind: " << content_data->profile << QString::number(content_data->key) << QString::number(content_data->mods);
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -61,10 +61,10 @@ UPtrServiceToEntityData ClientOptionService::on_select_keybind_profile(Event *ev
 {
     SelectKeybindProfile* casted_ev = static_cast<SelectKeybindProfile *>(ev);
 
-    auto func = [casted_ev](Entity* ent) -> void
+    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
     {
-        ent->m_player->m_keybinds.setKeybindProfile(casted_ev->profile);
-        qCDebug(logKeybinds) << "Saving currently selected Keybind Profile. Profile name: " << casted_ev->profile;
+        ent->m_player->m_keybinds.setKeybindProfile(content_data->profile);
+        qCDebug(logKeybinds) << "Saving currently selected Keybind Profile. Profile name: " << content_data->profile;
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -74,7 +74,7 @@ UPtrServiceToEntityData ClientOptionService::on_reset_keybinds(Event *ev)
 {
     ResetKeybinds* casted_ev = static_cast<ResetKeybinds *>(ev);
 
-    auto func = [casted_ev](Entity* ent) -> void
+    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
     {
         const GameDataStore &data(getGameData());
         const Parse_AllKeyProfiles &default_profiles(data.m_keybind_profiles);
@@ -90,10 +90,10 @@ UPtrServiceToEntityData ClientOptionService::on_switch_viewpoint(Event *ev)
 {
     SwitchViewPoint* casted_ev = static_cast<SwitchViewPoint *>(ev);
 
-    auto func = [casted_ev](Entity* ent) -> void
+    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
     {
-        ent->m_player->m_options.m_first_person_view = casted_ev->new_viewpoint_is_firstperson;
-        qCDebug(logKeybinds) << "Saving viewpoint mode to ClientOptions" << casted_ev->new_viewpoint_is_firstperson;
+        ent->m_player->m_options.m_first_person_view = content_data->new_viewpoint_is_firstperson;
+        qCDebug(logKeybinds) << "Saving viewpoint mode to ClientOptions" << content_data->new_viewpoint_is_firstperson;
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);

--- a/Projects/CoX/Servers/GameServer/ClientOptionService/ClientOptionService.cpp
+++ b/Projects/CoX/Servers/GameServer/ClientOptionService/ClientOptionService.cpp
@@ -1,0 +1,100 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.io/
+ * Copyright (c) 2006 - 2019 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+
+#include "Common/CRUDP_Protocol/ILink.h"
+#include "Common/Servers/EventHelpers.h"
+#include "ClientOptionService.h"
+#include "GameData/Entity.h"
+#include "GameData/playerdata_definitions.h"
+#include "GameData/map_definitions.h"
+#include "GameData/EntityHelpers.h"
+#include "Messages/Map/MapEvents.h"
+
+UPtrServiceToEntityData ClientOptionService::on_set_keybind(Event *ev)
+{
+    SetKeybind* casted_ev = static_cast<SetKeybind *>(ev);
+
+    auto func = [casted_ev](Entity* ent) -> void
+    {
+        KeyName key = static_cast<KeyName>(casted_ev->key);
+        ModKeys mod = static_cast<ModKeys>(casted_ev->mods);
+
+        ent->m_player->m_keybinds.setKeybind(casted_ev->profile, key, mod, casted_ev->command, casted_ev->is_secondary);
+        qCDebug(logKeybinds) << "Setting keybind: " << casted_ev->profile << QString::number(casted_ev->key)
+                              << QString::number(casted_ev->mods) << casted_ev->command << casted_ev->is_secondary;
+    };
+
+    return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
+}
+
+UPtrServiceToEntityData ClientOptionService::on_save_client_options(Event *ev)
+{
+    SaveClientOptions* casted_ev = static_cast<SaveClientOptions *>(ev);
+
+    auto func = [casted_ev](Entity* ent) -> void
+    {
+        markEntityForDbStore(ent,DbStoreFlags::PlayerData);
+        ent->m_player->m_options = casted_ev->data;
+    };
+
+    return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
+}
+
+UPtrServiceToEntityData ClientOptionService::on_remove_keybind(Event *ev)
+{
+    RemoveKeybind* casted_ev = static_cast<RemoveKeybind *>(ev);
+
+    auto func = [casted_ev](Entity* ent) -> void
+    {
+        ent->m_player->m_keybinds.removeKeybind(casted_ev->profile,(KeyName &)casted_ev->key,(ModKeys &)casted_ev->mods);
+        qCDebug(logKeybinds) << "Clearing Keybind: " << casted_ev->profile << QString::number(casted_ev->key) << QString::number(casted_ev->mods);
+    };
+
+    return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
+}
+
+UPtrServiceToEntityData ClientOptionService::on_select_keybind_profile(Event *ev)
+{
+    SelectKeybindProfile* casted_ev = static_cast<SelectKeybindProfile *>(ev);
+
+    auto func = [casted_ev](Entity* ent) -> void
+    {
+        ent->m_player->m_keybinds.setKeybindProfile(casted_ev->profile);
+        qCDebug(logKeybinds) << "Saving currently selected Keybind Profile. Profile name: " << casted_ev->profile;
+    };
+
+    return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
+}
+
+UPtrServiceToEntityData ClientOptionService::on_reset_keybinds(Event *ev)
+{
+    ResetKeybinds* casted_ev = static_cast<ResetKeybinds *>(ev);
+
+    auto func = [casted_ev](Entity* ent) -> void
+    {
+        const GameDataStore &data(getGameData());
+        const Parse_AllKeyProfiles &default_profiles(data.m_keybind_profiles);
+
+        ent->m_player->m_keybinds.resetKeybinds(default_profiles);
+        qCDebug(logKeybinds) << "Resetting Keybinds to defaults.";
+    };
+
+    return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
+}
+
+UPtrServiceToEntityData ClientOptionService::on_switch_viewpoint(Event *ev)
+{
+    SwitchViewPoint* casted_ev = static_cast<SwitchViewPoint *>(ev);
+
+    auto func = [casted_ev](Entity* ent) -> void
+    {
+        ent->m_player->m_options.m_first_person_view = casted_ev->new_viewpoint_is_firstperson;
+        qCDebug(logKeybinds) << "Saving viewpoint mode to ClientOptions" << casted_ev->new_viewpoint_is_firstperson;
+    };
+
+    return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
+}

--- a/Projects/CoX/Servers/GameServer/ClientOptionService/ClientOptionService.cpp
+++ b/Projects/CoX/Servers/GameServer/ClientOptionService/ClientOptionService.cpp
@@ -16,9 +16,7 @@
 
 UPtrServiceToEntityData ClientOptionService::on_set_keybind(Event *ev)
 {
-    SetKeybind* casted_ev = static_cast<SetKeybind *>(ev);
-
-    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
+    auto func = [content_data = static_cast<SetKeybind*>(ev->shallow_copy())](Entity* ent) -> void
     {
         KeyName key = static_cast<KeyName>(content_data->key);
         ModKeys mod = static_cast<ModKeys>(content_data->mods);
@@ -26,6 +24,8 @@ UPtrServiceToEntityData ClientOptionService::on_set_keybind(Event *ev)
         ent->m_player->m_keybinds.setKeybind(content_data->profile, key, mod, content_data->command, content_data->is_secondary);
         qCDebug(logKeybinds) << "Setting keybind: " << content_data->profile << QString::number(content_data->key)
                               << QString::number(content_data->mods) << content_data->command << content_data->is_secondary;
+
+        content_data->release();
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -33,12 +33,12 @@ UPtrServiceToEntityData ClientOptionService::on_set_keybind(Event *ev)
 
 UPtrServiceToEntityData ClientOptionService::on_save_client_options(Event *ev)
 {
-    SaveClientOptions* casted_ev = static_cast<SaveClientOptions *>(ev);
-
-    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
+    auto func = [content_data = static_cast<SaveClientOptions*>(ev->shallow_copy())](Entity* ent) -> void
     {
         markEntityForDbStore(ent,DbStoreFlags::PlayerData);
         ent->m_player->m_options = content_data->data;
+
+        content_data->release();
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -46,12 +46,12 @@ UPtrServiceToEntityData ClientOptionService::on_save_client_options(Event *ev)
 
 UPtrServiceToEntityData ClientOptionService::on_remove_keybind(Event *ev)
 {
-    RemoveKeybind* casted_ev = static_cast<RemoveKeybind *>(ev);
-
-    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
+    auto func = [content_data = static_cast<RemoveKeybind*>(ev->shallow_copy())](Entity* ent) -> void
     {
         ent->m_player->m_keybinds.removeKeybind(content_data->profile,(KeyName &)content_data->key,(ModKeys &)content_data->mods);
         qCDebug(logKeybinds) << "Clearing Keybind: " << content_data->profile << QString::number(content_data->key) << QString::number(content_data->mods);
+
+        content_data->release();
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -59,12 +59,12 @@ UPtrServiceToEntityData ClientOptionService::on_remove_keybind(Event *ev)
 
 UPtrServiceToEntityData ClientOptionService::on_select_keybind_profile(Event *ev)
 {
-    SelectKeybindProfile* casted_ev = static_cast<SelectKeybindProfile *>(ev);
-
-    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
+    auto func = [content_data = static_cast<SelectKeybindProfile*>(ev->shallow_copy())](Entity* ent) -> void
     {
         ent->m_player->m_keybinds.setKeybindProfile(content_data->profile);
         qCDebug(logKeybinds) << "Saving currently selected Keybind Profile. Profile name: " << content_data->profile;
+
+        content_data->release();
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -72,15 +72,15 @@ UPtrServiceToEntityData ClientOptionService::on_select_keybind_profile(Event *ev
 
 UPtrServiceToEntityData ClientOptionService::on_reset_keybinds(Event *ev)
 {
-    ResetKeybinds* casted_ev = static_cast<ResetKeybinds *>(ev);
-
-    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
+    auto func = [content_data = static_cast<ResetKeybinds*>(ev->shallow_copy())](Entity* ent) -> void
     {
         const GameDataStore &data(getGameData());
         const Parse_AllKeyProfiles &default_profiles(data.m_keybind_profiles);
 
         ent->m_player->m_keybinds.resetKeybinds(default_profiles);
         qCDebug(logKeybinds) << "Resetting Keybinds to defaults.";
+
+        content_data->release();
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);
@@ -88,12 +88,12 @@ UPtrServiceToEntityData ClientOptionService::on_reset_keybinds(Event *ev)
 
 UPtrServiceToEntityData ClientOptionService::on_switch_viewpoint(Event *ev)
 {
-    SwitchViewPoint* casted_ev = static_cast<SwitchViewPoint *>(ev);
-
-    auto func = [content_data = std::move(casted_ev)](Entity* ent) -> void
+    auto func = [content_data = static_cast<SwitchViewPoint *>(ev->shallow_copy())](Entity* ent) -> void
     {
         ent->m_player->m_options.m_first_person_view = content_data->new_viewpoint_is_firstperson;
         qCDebug(logKeybinds) << "Saving viewpoint mode to ClientOptions" << content_data->new_viewpoint_is_firstperson;
+
+        content_data->release();
     };
 
     return std::make_unique<ServiceToEntityData>(get_session_token(ev), func);

--- a/Projects/CoX/Servers/GameServer/ClientOptionService/ClientOptionService.h
+++ b/Projects/CoX/Servers/GameServer/ClientOptionService/ClientOptionService.h
@@ -1,0 +1,26 @@
+/*
+ * SEGS - Super Entity Game Server
+ * http://www.segs.io/
+ * Copyright (c) 2006 - 2019 SEGS Team (see AUTHORS.md)
+ * This software is licensed under the terms of the 3-clause BSD License. See LICENSE.md for details.
+ */
+
+#pragma once
+
+#include "Common/Servers/InternalEvents.h"
+
+using namespace SEGSEvents;
+
+// The Client Option Services handles the player settings
+class ClientOptionService
+{
+public:
+    UPtrServiceToEntityData on_save_client_options(Event* ev);
+    UPtrServiceToEntityData on_set_keybind(Event* ev);
+    UPtrServiceToEntityData on_select_keybind_profile(Event* ev);
+    UPtrServiceToEntityData on_remove_keybind(Event* ev);
+    UPtrServiceToEntityData on_reset_keybinds(Event* ev);
+    UPtrServiceToEntityData on_switch_viewpoint(Event* ev);
+
+protected:
+};

--- a/Projects/CoX/Servers/MapServer/MapInstance.h
+++ b/Projects/CoX/Servers/MapServer/MapInstance.h
@@ -18,6 +18,7 @@
 #include "CritterGenerator.h"
 
 #include "GameServer/EmailService/EmailService.h"
+#include "GameServer/ClientOptionService/ClientOptionService.h"
 
 #include <map>
 #include <memory>
@@ -68,8 +69,6 @@ class AbortQueuedPower;
 class DescriptionAndBattleCry;
 class EntityInfoRequest;
 class ChatReconfigure;
-class SwitchViewPoint;
-class SaveClientOptions;
 class SetDefaultPower;
 class UnsetDefaultPower;
 class UnqueueAll;
@@ -79,10 +78,6 @@ class ActivatePowerAtLocation;
 class ActivateInspiration;
 class PowersDockMode;
 class SwitchTray;
-class SelectKeybindProfile;
-class ResetKeybinds;
-class SetKeybind;
-class RemoveKeybind;
 class InteractWithEntity;
 class MoveInspiration;
 class RecvSelectedTitles;
@@ -148,6 +143,7 @@ class MapInstance final : public EventProcessor
         uint8_t                        m_game_server_id = 255; // 255 is `invalid` id
 
         EmailService                    m_email_service;
+        ClientOptionService             m_client_option_service;
 
         // I think there's probably a better way to do this..
         // We load all transfers for the map to map_transfers, then on first access to zones or doors, we
@@ -261,8 +257,6 @@ protected:
         void on_description_and_battlecry(SEGSEvents::DescriptionAndBattleCry *ev);
         void on_entity_info_request(SEGSEvents::EntityInfoRequest *ev);
         void on_chat_reconfigured(SEGSEvents::ChatReconfigure *ev);
-        void on_switch_viewpoint(SEGSEvents::SwitchViewPoint *ev);
-        void on_client_options(SEGSEvents::SaveClientOptions *ev);
         void on_set_default_power(SEGSEvents::SetDefaultPower *ev);
         void on_unset_default_power(SEGSEvents::UnsetDefaultPower *ev);
         void on_unqueue_all(SEGSEvents::UnqueueAll *ev);
@@ -272,10 +266,6 @@ protected:
         void on_activate_inspiration(SEGSEvents::ActivateInspiration *ev);
         void on_powers_dockmode(SEGSEvents::PowersDockMode *ev);
         void on_switch_tray(SEGSEvents::SwitchTray *ev);
-        void on_select_keybind_profile(SEGSEvents::SelectKeybindProfile *ev);
-        void on_reset_keybinds(SEGSEvents::ResetKeybinds *ev);
-        void on_set_keybind(SEGSEvents::SetKeybind *ev);
-        void on_remove_keybind(SEGSEvents::RemoveKeybind *ev);
         void on_emote_command(const QString &command, Entity *ent);
         void on_interact_with(SEGSEvents::InteractWithEntity *ev);
         void on_move_inspiration(SEGSEvents::MoveInspiration *ev);
@@ -303,5 +293,6 @@ protected:
         void on_store_buy_item(SEGSEvents::StoreBuyItem* ev);
 
         // Service <--> MapInstance
-        void on_service_to_client_response(std::unique_ptr<SEGSEvents::ServiceToClientData> data);
+        void on_service_to_client_response(SEGSEvents::UPtrServiceToClientData data);
+        void on_service_to_entity_response(SEGSEvents::UPtrServiceToEntityData data);
 };


### PR DESCRIPTION
New stuff I made:
- EventHelpers to help get the session token from an event. I don't want to use m_session_store in the services so the closest compromise is to get the tokens and let MapInstance find the sessions directly from the token instead
- ClientOptionService as the PR suggests
- ServiceToEntityData which is different from the already-used ServiceToClientData of course

Some points for discussion:
- In MapInstance's service response functions, the method to get the sessions are identical, maybe we could create a new function for it instead?
- What else we could/should put on ClientOptionService?

Also, I would like some help with troubleshooting. I tried to build my PR but I encountered this error. Was there something missing from the CMakeLists?
![Annotation 2020-05-01 212556](https://user-images.githubusercontent.com/38433056/80812585-6de08a80-8bf2-11ea-82d7-1e16289e4b10.png)