### PR TITLE
On Linux, build SegsEngine as external project.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rd_party/Lutefisk3D"]
-	path = 3rd_party/Lutefisk3D
-	url = https://github.com/Lutefisk3D/lutefisk3d

--- a/3rd_party/ExternalProject_SegsEngine.cmake
+++ b/3rd_party/ExternalProject_SegsEngine.cmake
@@ -1,0 +1,45 @@
+set(SegsEngine_RELEASE 4.0.0.6-alpha)
+if(NOT MSVC)
+libname(editor_engine editor_engine)
+ExternalProject_Add(
+    editor_engine-${SegsEngine_RELEASE}
+    URL https://github.com/Segs/SegsEngine/archive/v${SegsEngine_RELEASE}.tar.gz
+    INSTALL_DIR ${PROJECT_SOURCE_DIR}/3rd_party/prebuilt
+    CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_STAGING_PREFIX:PATH=${ThirdParty_Install_Dir} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+    CMAKE_GENERATOR "${CMAKE_GENERATOR}"
+    CMAKE_GENERATOR_TOOLSET ${CMAKE_GENERATOR_TOOLSET}
+    BUILD_BYPRODUCTS ${SegsEngine_LIBRARY_STATIC}
+)
+
+add_library(SegsEngine::EASTL_Import INTERFACE IMPORTED)
+
+set_target_properties(SegsEngine::EASTL_Import PROPERTIES
+  INTERFACE_COMPILE_DEFINITIONS "EASTL_USER_CONFIG_HEADER=\"EASTL/SegsEngine_config.h\""
+  INTERFACE_INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/3rd_party/prebuilt/include"
+  
+)
+
+
+add_library(SegsEngine::editor_engine SHARED IMPORTED GLOBAL)
+add_dependencies(SegsEngine::editor_engine editor_engine-${SegsEngine_RELEASE})
+
+# Create imported target SegsEngine::editor_interface
+add_library(SegsEngine::editor_interface INTERFACE IMPORTED)
+
+set_target_properties(SegsEngine::editor_interface PROPERTIES
+  INTERFACE_COMPILE_DEFINITIONS "TOOLS_ENABLED"
+  INTERFACE_INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/3rd_party/prebuilt/include/SegsEngine;${PROJECT_SOURCE_DIR}/3rd_party/prebuilt/include/"
+  INTERFACE_LINK_LIBRARIES "Qt5::Core;SegsEngine::EASTL_Import"
+)
+set_property(TARGET SegsEngine::editor_engine APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+set_target_properties(SegsEngine::editor_engine PROPERTIES
+  IMPORTED_LOCATION_DEBUG "${PROJECT_SOURCE_DIR}/3rd_party/prebuilt/bin/libeditor_engine.so"
+  IMPORTED_SONAME_DEBUG "libeditor_engine.so"
+  INTERFACE_LINK_LIBRARIES "SegsEngine::editor_interface"
+)
+  
+else()
+
+check_and_update_binary_deps(SegsEngine SegsEngine ${PROJECT_SOURCE_DIR}/3rd_party/prebuilt ${SegsEngine_RELEASE})
+
+endif()

--- a/Projects/CoX/Editor/CMakeLists.txt
+++ b/Projects/CoX/Editor/CMakeLists.txt
@@ -1,14 +1,8 @@
 if(MSVC)
-
-check_and_update_binary_deps(SegsEngine SegsEngine ${PROJECT_SOURCE_DIR}/3rd_party/prebuilt 4.0.0.3-alpha)
+    find_package(SegsEngine REQUIRED)
 else()
-    # TODO: DISABLED editor in linux until we have SegsEngine integrated as a built dependency.
-    if(NOT EXISTS "${PROJECT_SOURCE_DIR}/3rd_party/prebuilt/include")
-        return()
-    endif()
+    include(${PROJECT_SOURCE_DIR}/3rd_party/ExternalProject_SegsEngine.cmake)
 endif()
-
-find_package(SegsEngine REQUIRED)
 
 ###########################################################################################
 macro(set_plugin_options )


### PR DESCRIPTION
We still need to solve problems with mono assembly generation.

This is related to the fact that the binding generator is not a stand-alone tool.
