### PR TITLE
SEGSAdmin and serialization_common fixes

### DIFF
--- a/Components/serialization_common.h
+++ b/Components/serialization_common.h
@@ -52,8 +52,10 @@ void commonSaveTo(const T & target, const char *classname, const QString & baseN
     {
         if(text_format) {
             std::ostringstream tgt;
-            cereal::JSONOutputArchive ar( tgt );
-            ar(cereal::make_nvp(classname,target));
+            {
+                cereal::JSONOutputArchive ar( tgt );
+                ar(cereal::make_nvp(classname,target));
+            }
             if(!tgt_fle.open(QFile::WriteOnly|QFile::Text)) {
                 qCritical() << "Failed to open"<<target_fname<<"in write mode";
                 return;

--- a/Utilities/SEGSAdmin/SEGSAdminTool.cpp
+++ b/Utilities/SEGSAdmin/SEGSAdminTool.cpp
@@ -163,12 +163,14 @@ void SEGSAdminTool::commit_user(QString username, QString password, QString accl
     ui->createUser->setText("Please Wait...");
     qApp->processEvents();
     qDebug() << "Setting arguments...";
-    QString program = "utilities/dbtool adduser -l " + username + " -p " + password + " -a " + acclevel;
+
+    QString program = "dbtool";
+    QStringList arguments = {"adduser", "-l", username, "-p", password, "-a", acclevel};
     #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
         program.prepend("./");
     #endif
     m_createUser = new QProcess(this);
-    m_createUser->start(program);
+    m_createUser->start(program, arguments);
 
     if(m_createUser->waitForStarted())
     {
@@ -272,16 +274,17 @@ void SEGSAdminTool::create_databases(bool overwrite)
     ui->output->appendPlainText("Setting arguments...");
     qApp->processEvents();
     qDebug() << "Setting arguments...";
-    QString program = "utilities/dbtool create";
+    QString program = "dbtool";
+    QStringList arguments = {"create"};
     if(overwrite)
     {
-        program.append(" -f");
+        arguments.append("-f");
     }
     #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     program.prepend("./");
     #endif
     m_createDB = new QProcess(this);
-    m_createDB->start(program);
+    m_createDB->start(program, arguments);
 
     if(m_createDB->waitForStarted())
     {
@@ -340,11 +343,12 @@ void SEGSAdminTool::start_segs_server()
     ui->output->appendPlainText("Setting arguments...");
     qApp->processEvents();
     QString program = "segs_server";
+    QStringList arguments = {""};
     #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     program.prepend("./");
     #endif
     m_start_segs_server = new QProcess(this);
-    m_start_segs_server->start(program);
+    m_start_segs_server->start(program, arguments);
 
     if(m_start_segs_server->waitForStarted())
     {
@@ -369,8 +373,6 @@ void SEGSAdminTool::start_segs_server()
             ui->user_box->setEnabled(false);
             ui->server_setup_box->setEnabled(false);
             ui->server_config->setEnabled(false);
-            //qint64 pid = m_start_segs_server->processId();
-            //qDebug()<<pid;
             m_server_running = true;
         }
         if(m_start_segs_server->state()==QProcess::NotRunning)

--- a/Utilities/SEGSAdmin/SetUpData.cpp
+++ b/Utilities/SEGSAdmin/SetUpData.cpp
@@ -188,7 +188,6 @@ bool SetUpData::copyPiggFiles()
     {
         targetDir.mkdir(targetDir.absolutePath());
     }
-
     QFileInfoList fileInfoList = sourceDir.entryInfoList(source_file_list);
     foreach(QFileInfo fileInfo, fileInfoList)
     {
@@ -197,12 +196,10 @@ bool SetUpData::copyPiggFiles()
         {
             targetDir.remove(fileInfo.fileName());
         }
-
-        QFile::copy(fileInfo.filePath(),  // Copy files
-                    targetDir.filePath(fileInfo.fileName()));
-
+        QFile::copy(fileInfo.filePath(),targetDir.filePath(fileInfo.fileName())); // Copy files
         ui->progressBar->setValue(counter / fileInfoList.count() * 100);
         counter++;
+        qDebug() << fileInfo.filePath() << targetDir.filePath(fileInfo.fileName()); // DEBUG
     }
     ui->icon_cox_directory->show();
     ui->piggtool_output->appendPlainText("File Copy Complete");
@@ -243,29 +240,6 @@ bool SetUpData::createDefaultDirectorys() // Creates default directories
     ui->icon_create_directory->show();
     ui->buttonBox->setEnabled(true);
     return true;
-}
-
-void SetUpData::runBinConverter() // Runs binconverter for ent_types conversion after piggtool extraction
-{
-    ui->piggtool_output->appendPlainText("Running BinConverter");
-    QString program = "utilities\binconverter";
-#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
-    program.prepend("./");
-#endif
-    bin_converter = new QProcess(this);
-    bin_converter->setProcessChannelMode(QProcess::MergedChannels);
-    bin_converter->start(program);
-
-    if(!bin_converter->waitForStarted())
-    {
-        QString error = "BinConverter Error: " + bin_converter->errorString();
-        ui->piggtool_output->appendPlainText(error);
-    }
-
-    bin_converter->waitForFinished();
-    QString output = bin_converter->readAll();
-    ui->piggtool_output->appendPlainText(output);
-    ui->piggtool_output->appendPlainText("BinConverter Completed");
 }
 
 // Worker thread will signal once everything is done so main UI can re-check data.

--- a/Utilities/SEGSAdmin/SetUpData.h
+++ b/Utilities/SEGSAdmin/SetUpData.h
@@ -48,9 +48,6 @@ signals:
 
 private:
     Ui::SetUpData *ui;
-    QProcess *bin_converter;
-    void runBinConverter();
-
 };
 
 #endif // SETUPDATA_H

--- a/Utilities/SEGSAdmin/Worker.cpp
+++ b/Utilities/SEGSAdmin/Worker.cpp
@@ -26,13 +26,14 @@ void Worker::piggDispatcher()
 
     foreach(QFileInfo fileInfo, piggInfoList)
     {
-        QString program = "utilities/piggtool -x " + fileInfo.absoluteFilePath();
+        QString program = "piggtool";
+        QStringList arguments = {"-x", fileInfo.absoluteFilePath(), QDir::currentPath().append("/data")};
         #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
             program.prepend("./");
         #endif
 
         emit sendUIMessage("Processing: " + fileInfo.fileName());
-        if(!processPiggFile(program))
+        if(!processPiggFile(program, arguments))
         {
             emit sendUIMessage("Failed to process: " + fileInfo.fileName());
         }
@@ -52,10 +53,10 @@ void Worker::piggDispatcher()
 }
 
 // Process PiggFile
-bool Worker::processPiggFile(const QString &file)
+bool Worker::processPiggFile(const QString program, const QStringList arguments)
 {
-    QProcess* pigg_tool = new QProcess(this);
-    pigg_tool->start(file);
+    QProcess* pigg_tool = new QProcess();
+    pigg_tool->start(program, arguments);
 
     if(!pigg_tool->waitForStarted())
         return false;
@@ -69,12 +70,13 @@ bool Worker::processPiggFile(const QString &file)
 bool Worker::runBinConverter()
 {
     emit sendUIMessage("Starting BinConverter");
-    QString program = "utilities/binConverter " + (QDir::currentPath() + "/data/ent_types");
+    QString program = "binConverter";
+    QStringList arguments = {QDir::currentPath().append("/data/ent_types")};
 #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     program.prepend("./");
 #endif
     QProcess* bin_converter = new QProcess(this);
-    bin_converter->start(program);
+    bin_converter->start(program, arguments);
 
     if(!bin_converter->waitForStarted())
     {

--- a/Utilities/SEGSAdmin/Worker.h
+++ b/Utilities/SEGSAdmin/Worker.h
@@ -22,7 +22,7 @@ public slots:
     void piggDispatcher();
 
 private:
-    bool processPiggFile(const QString &file);
+    bool processPiggFile(const QString program, const QStringList arguments);
     bool runBinConverter();
 
 };


### PR DESCRIPTION
## Summary
- SEGSAdmin was using deprecated version of the QProcess.start() method. Updated. 
- dbtool, binConverter, segs_server, and piggtool were trying to run from a 'utilities' sub directory which no longer exists as these tools were moved into the root 'out' directory. Updated. 
- Forcing call of destructor earlier in serialization_common.commonSaveTo() to fix json file not being closed correctly with curly brace. 
- Some general tidy up of some SEGSAdmin disused methods.

