### PR TITLE
Cleanup MSVC2022 warnings at the W3 level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(SEGS)
 
+cmake_policy(VERSION 3.16)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -54,6 +56,7 @@ if(MSVC)
     add_definitions( -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -DNOMINMAX -D_USE_MATH_DEFINES)
     add_compile_options (/wd4251) # disable warning related to dll interface needed ... clients of class
     if (NOT (MSVC_VERSION LESS 1910))
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3")
       #add_compile_options (/MP)
       add_compile_options (/permissive-)
       #add_compile_options (/d2cgsummary)

--- a/Common/AuthProtocol/AuthLink.cpp
+++ b/Common/AuthProtocol/AuthLink.cpp
@@ -46,7 +46,7 @@ void encode_buffer(AuthLinkState &state,const AuthLinkEvent *ev)
     // put 0 as size for now
     state.m_unsent_bytes_storage.uPut((uint16_t)0);
     // remember start location
-    size_t actual_packet_start = state.m_unsent_bytes_storage.GetReadableDataSize();
+    uint32_t actual_packet_start = state.m_unsent_bytes_storage.GetReadableDataSize();
     // store bytes
     ev->serializeto(state.m_unsent_bytes_storage);
     // calculate the number of stored bytes, and set it in packet_size,

--- a/Common/CRUDP_Protocol/CRUDP_Packet.cpp
+++ b/Common/CRUDP_Protocol/CRUDP_Packet.cpp
@@ -88,7 +88,7 @@ void CrudP_Packet::StoreBits(uint32_t nBits, uint32_t dataBits)
     m_stream->StoreBits(nBits, dataBits);
 }
 
-void CrudP_Packet::StoreBitArray(uint8_t *array, size_t nBits)
+void CrudP_Packet::StoreBitArray(uint8_t *array, uint32_t nBits)
 {
     m_stream->StoreBitArray(array, nBits);
 }

--- a/Common/CRUDP_Protocol/CRUDP_Packet.h
+++ b/Common/CRUDP_Protocol/CRUDP_Packet.h
@@ -35,7 +35,7 @@ public:
 
     float GetFloat();
     void StoreBits(uint32_t nBits, uint32_t dataBits);
-    void StoreBitArray(uint8_t *array, size_t nBits);
+    void StoreBitArray(uint8_t *array, uint32_t nBits);
     void StorePackedBits(uint32_t nBits, uint32_t dataBits);
     void StoreString(const char *str);
     void CompressAndStoreString(const char *str);
@@ -62,7 +62,7 @@ public:
     uint32_t getNumSibs()           const   { return m_numSibs;}
     uint32_t getSibId()             const   { return m_sibId;}
     uint32_t getSibPos()            const   { return m_sibPos;}
-    size_t   getNumAcks()           const   { return m_acks.size(); }
+    uint32_t getNumAcks()           const   { return (uint32_t)m_acks.size(); }
 
     void ByteAlign();
     void SetStream(BitStream *stream)       { m_stream = stream; }

--- a/Common/CRUDP_Protocol/CRUDP_Protocol.cpp
+++ b/Common/CRUDP_Protocol/CRUDP_Protocol.cpp
@@ -185,7 +185,7 @@ void CrudP_Protocol::storeAcks(BitStream &bs)
     recv_acks.sort();
     recv_acks.unique();
     std::list<uint32_t>::iterator iter = recv_acks.begin();
-    uint32_t num_acks = std::min<uint32_t>(recv_acks.size(),16); // store up to 16 acks
+    uint32_t num_acks = std::min<uint32_t>((uint32_t)recv_acks.size(),16); // store up to 16 acks
     bs.StorePackedBits(1,num_acks);
 
     uint32_t last_ack = *iter;
@@ -346,7 +346,7 @@ void CrudP_Protocol::PacketAck(uint32_t id)
     // reliable_packets
 }
 
-vCrudP_Packet packetSplit(CrudP_Packet &src,size_t block_size)
+vCrudP_Packet packetSplit(CrudP_Packet &src,uint32_t block_size)
 {
     vCrudP_Packet res;
     CrudP_Packet *act;

--- a/Common/CRUDP_Protocol/CRUDP_Protocol.cpp
+++ b/Common/CRUDP_Protocol/CRUDP_Protocol.cpp
@@ -147,7 +147,7 @@ void CrudP_Protocol::ReceivedBlock(BitStream &src)
     res->SetIsCompressed(src.GetBits(1));
     src.ByteAlign(true,false);
     // how much data did we actually read
-    size_t bits_left=(bitlength-src.GetReadPos());
+    uint32_t bits_left=(bitlength-src.GetReadPos());
     res->StoreBitArray(src.read_ptr(),bits_left);
     PushRecvPacket(res);
 }

--- a/Common/GameData/Character.cpp
+++ b/Common/GameData/Character.cpp
@@ -232,7 +232,7 @@ void Character::GetCharBuildInfo(BitStream &src)
 
 void Character::sendEnhancements(BitStream &bs) const
 {
-    bs.StorePackedBits(5, m_char_data.m_enhancements.size()); // count
+    bs.StorePackedBits(5, (uint32_t)m_char_data.m_enhancements.size()); // count
     for(size_t i = 0; i < m_char_data.m_enhancements.size(); ++i)
     {
         bs.StorePackedBits(3, m_char_data.m_enhancements[i].m_slot_idx); // boost idx, maybe use m_enhancement_idx
@@ -268,11 +268,11 @@ void Character::sendInspirations(BitStream &bs) const
 
 void Character::sendOwnedPowers(BitStream &bs) const
 {
-    bs.StorePackedBits(4, m_char_data.m_powersets.size()); // count
+    bs.StorePackedBits(4, (uint32_t)m_char_data.m_powersets.size()); // count
     for(const CharacterPowerSet &pset : m_char_data.m_powersets)
     {
         bs.StorePackedBits(5, pset.m_level_bought);
-        bs.StorePackedBits(4, pset.m_powers.size());
+        bs.StorePackedBits(4, (uint32_t)pset.m_powers.size());
         for(const CharacterPower &power : pset.m_powers)
         {
             power.m_power_info.serializeto(bs);
@@ -282,7 +282,7 @@ void Character::sendOwnedPowers(BitStream &bs) const
             if(power.m_total_eh_slots > power.m_enhancements.size())
                 qCWarning(logPowers) << "sendOwnedPowers: Total EH Slots larger than vector!";
 
-            bs.StorePackedBits(4, power.m_enhancements.size());
+            bs.StorePackedBits(4, (uint32_t)power.m_enhancements.size());
             for(const CharacterEnhancement &eh : power.m_enhancements)
             {
                 bs.StoreBits(1, eh.m_slot_used); // slot has enhancement

--- a/Common/GameData/CoXHash.h
+++ b/Common/GameData/CoXHash.h
@@ -129,7 +129,8 @@ public:
             uint32_t factor=1;
             if( in_use >= watermark || in_use >= m_storage.size() - 1 )
                 factor=2;
-            resize(factor*m_storage.size());
+            //TODO: verify factor*m_storage.size() is less than uint32_t max
+            resize(uint32_t(factor*m_storage.size()));
         }
         if(this->find_index(k,entry_idx,prev_val,true))
         {

--- a/Common/GameData/Costume.cpp
+++ b/Common/GameData/Costume.cpp
@@ -94,7 +94,7 @@ void serializefrom(CostumePart &part,BitStream &bs,const ColorAndPartPacker *pac
 Costume Costume::NullCostume;
 void Costume::storeCharselParts( BitStream &bs ) const
 {
-    bs.StorePackedBits(1,m_parts.size());
+    bs.StorePackedBits(1,(uint32_t)m_parts.size());
     for(const CostumePart & part : m_parts)
         serializeto_charsel(part,bs);
 }
@@ -220,7 +220,7 @@ void serializeto(const Costume &costume,BitStream &bs, const ColorAndPartPacker 
 
     bs.StoreBits(1, costume.m_send_full_costume);
     assert(!costume.m_parts.empty());
-    bs.StorePackedBits(4, costume.m_parts.size());
+    bs.StorePackedBits(4, (uint32_t)costume.m_parts.size());
     try
     {
         for(uint32_t costume_part = 0; costume_part < costume.m_parts.size(); costume_part++)

--- a/Common/GameData/Friend.cpp
+++ b/Common/GameData/Friend.cpp
@@ -120,7 +120,7 @@ FriendListChangeStatus removeFriend(Entity &src, const QString& friend_name)
     if(src_data.m_friends.empty())
         src_data.m_has_friends = false;
 
-    src_data.m_friends_count = src_data.m_friends.size();
+    src_data.m_friends_count = (uint32_t)src_data.m_friends.size();
 
     qCDebug(logFriends).noquote() << msg;
     return FriendListChangeStatus::FRIEND_REMOVED;

--- a/Common/GameData/GameDataStore.cpp
+++ b/Common/GameData/GameDataStore.cpp
@@ -73,7 +73,7 @@ public:
             return;
         }
         m_known_strings.push_back(str.toLower());
-        m_string_to_index[str.toLower()] = m_known_strings.size();
+        m_string_to_index[str.toLower()] = (uint32_t)m_known_strings.size();
     }
     int getIndex(const QString &str) const
     {
@@ -101,31 +101,31 @@ public:
         m_strings.init(4096,0x3D);
         add_colors(data.m_supergroup_colors.m_Colors);
         //TODO: Use reverse iterators here ?
-        for(int idx=data.m_costume_store.size()-1; idx>=0; --idx)
+        for(int idx=(int)data.m_costume_store.size()-1; idx>=0; --idx)
         {
             const Costume2_Data &ce(data.m_costume_store[idx]);
             m_strings.insert_entry(ce.m_Name,"");
-            for(int orign_idx=ce.m_Origins.size()-1; orign_idx>=0; --orign_idx)
+            for(int orign_idx=(int)ce.m_Origins.size()-1; orign_idx>=0; --orign_idx)
             {
                 const CostumeOrigin_Data &orig(ce.m_Origins[orign_idx]);
                 add_colors(orig.m_BodyPalette[0].m_Colors);
                 add_colors(orig.m_SkinPalette[0].m_Colors);
-                for(int region_idx=orig.m_Region.size()-1; region_idx>=0; --region_idx)
+                for(int region_idx=(int)orig.m_Region.size()-1; region_idx>=0; --region_idx)
                 {
                     const Region_Data &region(orig.m_Region[region_idx]);
                     m_strings.insert_entry(region.m_Name,"");
-                    for(int bone_idx=region.m_BoneSets.size()-1; bone_idx>=0; --bone_idx)
+                    for(int bone_idx=(int)region.m_BoneSets.size()-1; bone_idx>=0; --bone_idx)
                     {
                         const BoneSet_Data &bset(region.m_BoneSets[bone_idx]);
                         m_strings.insert_entry(bset.m_Name,"");
                         m_strings.insert_entry(bset.m_Displayname,"");
 
-                        for(int geo_idx=bset.m_GeoSets.size()-1; geo_idx>=0; --geo_idx)
+                        for(int geo_idx=(int)bset.m_GeoSets.size()-1; geo_idx>=0; --geo_idx)
                         {
                             const GeoSet_Data &geo_set(bset.m_GeoSets[geo_idx]);
                             m_strings.insert_entry(geo_set.m_Displayname,"");
                             m_strings.insert_entry(geo_set.m_BodyPart,"");
-                            for(int info_idx=geo_set.m_Infos.size()-1; info_idx>=0; --info_idx)
+                            for(int info_idx=(int)geo_set.m_Infos.size()-1; info_idx>=0; --info_idx)
                             {
                                 const GeoSet_Info_Data &info(geo_set.m_Infos[info_idx]);
                                 m_strings.insert_entry(info.m_DisplayName,"");
@@ -134,15 +134,15 @@ public:
                                 m_strings.insert_entry(info.m_Tex1,"");
                                 m_strings.insert_entry(info.m_Tex2,"");
                             }
-                            for(int name_idx=geo_set.m_MaskNames.size()-1; name_idx>=0; --name_idx)
+                            for(int name_idx=(int)geo_set.m_MaskNames.size()-1; name_idx>=0; --name_idx)
                             {
                                 m_strings.insert_entry(geo_set.m_MaskNames[name_idx],"");
                             }
-                            for(int name_idx=int(geo_set.m_MaskStrings.size())-1; name_idx>=0; --name_idx)
+                            for(int name_idx=(int)geo_set.m_MaskStrings.size()-1; name_idx>=0; --name_idx)
                             {
                                 m_strings.insert_entry(geo_set.m_MaskStrings[name_idx],"");
                             }
-                            for(int mask_idx=geo_set.m_Masks.size()-1; mask_idx>=0; --mask_idx)
+                            for(int mask_idx=(int)geo_set.m_Masks.size()-1; mask_idx>=0; --mask_idx)
                             {
                                 const GeoSet_Mask_Data &mask(geo_set.m_Masks[mask_idx]);
                                 m_strings.insert_entry(mask.m_Name,"");

--- a/Common/GameData/Movement.cpp
+++ b/Common/GameData/Movement.cpp
@@ -888,8 +888,8 @@ void processNewInputs(Entity &e)
                 // assuming that the client never sends a partial tick, if that's not the case 
                 // then tick_state needs to move into the entity somewhere
                 assert(tick_state.length_ms == 0);
-
-                uint16_t new_csc_count = input_change.m_control_state_changes.size() - csc_id_delta;
+                //TODO: check for cases where csc_id_delta > input_change.m_control_state_changes.size()
+                uint16_t new_csc_count = uint16_t((int32_t)input_change.m_control_state_changes.size() - csc_id_delta);
 
                 if (logInput().isDebugEnabled() && e.m_input_state.m_debug)
                 {

--- a/Common/GameData/NpcStore.cpp
+++ b/Common/GameData/NpcStore.cpp
@@ -32,7 +32,7 @@ void NPCStorage::prepare_dictionaries()
                 pcp.m_Color1.rgba.a = 255;
                 pcp.m_Color2.rgba.a = 255;
             }
-            pc.m_NumParts = pc.m_CostumeParts.size();
+            pc.m_NumParts = (uint32_t)pc.m_CostumeParts.size();
         }
     }
     for(Parse_NPC &npc : m_all_npcs)

--- a/Common/GameData/Powers.cpp
+++ b/Common/GameData/Powers.cpp
@@ -471,7 +471,7 @@ uint32_t countAllOwnedPowers(CharacterData &cd, bool include_temps)
         if(pset.m_index == 0 && !include_temps) // don't count temporary_powers
             continue;
 
-        count += pset.m_powers.size(); // total up all powers
+        count += (uint32_t)pset.m_powers.size(); // total up all powers
     }
 
     qCDebug(logPowers) << "Total Owned Powers:" << include_temps << count;
@@ -834,7 +834,7 @@ uint32_t getNumberEnhancements(const CharacterData &cd)
 
 uint32_t getMaxNumberEnhancements(const CharacterData &cd)
 {
-    return cd.m_enhancements.size();
+    return (uint32_t)cd.m_enhancements.size();
 }
 
 void moveEnhancement(CharacterData &cd, uint32_t src_idx, uint32_t dest_idx)
@@ -913,9 +913,9 @@ void reserveEnhancementSlot(CharacterPower *pow, uint32_t level_purchased)
     {
         CharacterEnhancement eh;
         eh.m_enhance_info = pow->m_power_info;
-        eh.m_slot_idx = pow->m_enhancements.size();
+        eh.m_slot_idx = (uint32_t)pow->m_enhancements.size();
         pow->m_enhancements.push_back(eh);
-        pow->m_total_eh_slots = pow->m_enhancements.size();
+        pow->m_total_eh_slots = (uint32_t)pow->m_enhancements.size();
 
         qCDebug(logPowers) << "Adding empty EH Slot" << eh.m_slot_idx
                            << eh.m_enhance_info.m_pset_idx
@@ -950,14 +950,8 @@ void buyEnhancementSlots(Entity &ent, uint32_t available_slots, std::vector<int>
 float enhancementCombineChances(CharacterEnhancement *eh1, CharacterEnhancement *eh2)
 {
     const std::vector<float> *combine_chances;
-    int chance_idx = 0;
-    int eh_delta = 0;
-
-    eh_delta = eh1->m_num_combines + eh1->m_level - (eh2->m_num_combines + eh2->m_level);
-    if(eh_delta >= 0)
-        chance_idx = eh_delta;
-    else
-        chance_idx = -eh_delta;
+    int eh_delta = eh1->m_num_combines + eh1->m_level - (eh2->m_num_combines + eh2->m_level);
+    uint32_t chance_idx = std::abs(eh_delta);
 
     qCDebug(logPowers) << "eh_delta" << eh_delta;
     qCDebug(logPowers) << "chance_idx" << chance_idx;
@@ -967,13 +961,13 @@ float enhancementCombineChances(CharacterEnhancement *eh1, CharacterEnhancement 
     else
         combine_chances = &getGameData().m_combine_chances.CombineChances;
 
-    int chance_count = combine_chances->size();
+    uint32_t chance_count = (uint32_t)combine_chances->size();
     qCDebug(logPowers) << "combine_chances size" << chance_count;
-
+    // if we've got chance index larger then our array size, just return the last one
     if( chance_idx >= chance_count )
     {
         if( chance_count > 0 )
-            return combine_chances->at(chance_count - 1);
+            return combine_chances->back();
 
         return 0.0f;
     }

--- a/Common/GameData/Powers.h
+++ b/Common/GameData/Powers.h
@@ -139,9 +139,9 @@ struct vInspirations
     std::vector<std::vector<CharacterInspiration>> m_inspirations;
 
     // although in some cases people prefer [row][col], i'll be using x -> col and y -> row
-    size_t m_rows, m_cols;
+    uint32_t m_rows, m_cols;
 
-    vInspirations(size_t cols = 5, size_t rows = 4)
+    vInspirations(uint32_t cols = 5, uint32_t rows = 4)
     {
         if(cols > 5)
             qCritical() << "vInspirations has more than 5 columns!";
@@ -165,7 +165,7 @@ struct vInspirations
         return m_cols * m_rows;
     }
 
-    CharacterInspiration& at (const size_t col, const size_t row)
+    CharacterInspiration& at (uint32_t col, uint32_t row)
     {
         if(col >= m_cols || row >= m_rows)
             qCritical() << QString("Trying to access vInspirations of %1 rows %2 cols using params %3 rows %4 cols");
@@ -173,7 +173,7 @@ struct vInspirations
         return m_inspirations[col][row];
     }
 
-    const CharacterInspiration& at (const size_t col, const size_t row) const
+    const CharacterInspiration& at (uint32_t col, uint32_t row) const
     {
         if(col >= m_cols || row >= m_rows)
             qCritical() << QString("Trying to access vInspirations of %1 rows %2 cols using params %3 rows %4 cols");
@@ -181,7 +181,7 @@ struct vInspirations
         return m_inspirations[col][row];
     }
 
-    CharacterInspiration& from_first_row (const size_t col)
+    CharacterInspiration& from_first_row (uint32_t col)
     {
         if(!m_inspirations[col][0].m_has_insp)
             push_to_first_row(col);
@@ -189,12 +189,12 @@ struct vInspirations
         return m_inspirations[col][0];
     }
 
-    CharacterInspiration value(const size_t col, const size_t row) const
+    CharacterInspiration value(uint32_t col, uint32_t row) const
     {
         return m_inspirations[col][row];
     }
 
-    void resize (const size_t newCol, const size_t newRow)
+    void resize (uint32_t newCol, uint32_t newRow)
     {
         m_inspirations.resize(newCol);
         for (size_t i = 0; i < m_cols; ++i)
@@ -204,7 +204,7 @@ struct vInspirations
         m_rows = newRow;
     }
 
-    void push_to_first_row (const size_t col)
+    void push_to_first_row (uint32_t col)
     {
         size_t i = 1;
         while (m_inspirations[col][0].m_has_insp && i < m_rows)

--- a/Common/GameData/StateInterpolator.cpp
+++ b/Common/GameData/StateInterpolator.cpp
@@ -250,7 +250,7 @@ std::array<BinTreeEntry,7> interpolateBinTree(std::array<PosUpdate, 64> vals, fl
     // Enc 2 -> needs 1, marks it, 1 needs 3, marks it -> whole path to tree root marked
     //3, 1, 5, 0, 2, 4, 6
     int required_value_order[] = {2,2,1,1,0,0,0};
-    for(int to_check=enc.size()-1; to_check>0; --to_check) {
+    for(int to_check=int(enc.size())-1; to_check>0; --to_check) {
         BinTreeEntry &checked_parent(enc[required_value_order[to_check]]);
         if(enc[to_check].x && !checked_parent.x) {
             checked_parent.x=1;

--- a/Common/GameData/seq_definitions.cpp
+++ b/Common/GameData/seq_definitions.cpp
@@ -9,7 +9,7 @@
 
 int16_t getSeqMoveIdxByName(const QByteArray &name, const SequencerData &seq)
 {
-    int cnt = seq.m_Move.size();
+    int cnt = (int)seq.m_Move.size();
     QByteArray compare_against=name.toLower();
     for (int i = 0; i < cnt; ++i )
     {
@@ -27,7 +27,7 @@ void cleanSeqFileName(QByteArray &filename)
 
     if(loc!=-1)
     {
-        filename = filename.mid(loc+strlen("SEQUENCERS/"));
+        filename = filename.mid(loc+(int)strlen("SEQUENCERS/"));
     }
 }
 SequencerData *SequencerList::getSequencerData(const QByteArray &seq_name)

--- a/Common/GameData/seq_serializers.cpp
+++ b/Common/GameData/seq_serializers.cpp
@@ -253,7 +253,7 @@ bool loadFrom(BinStore *s, SequencerList &target)
             ok &= loadFrom(s,&nt);
             cleanSeqFileName(nt.name);       // this was done after reading, no reason to not do this now.
             target.sq_list.push_back(nt);
-            target.m_Sequencers[nt.name.toLower()] = target.sq_list.size()-1;
+            target.m_Sequencers[nt.name.toLower()] = (int)target.sq_list.size()-1;
             s->nest_out();
         }
         else

--- a/Common/Messages/Auth/AuthEvents.h
+++ b/Common/Messages/Auth/AuthEvents.h
@@ -20,7 +20,7 @@ class AuthLinkEvent : public Event
 protected:
         ~AuthLinkEvent() override = default;
 public:
-        AuthLinkEvent(size_t evtype,EventSrc *ev_src=nullptr) : Event(evtype,ev_src)
+        AuthLinkEvent(uint32_t evtype,EventSrc *ev_src=nullptr) : Event(evtype,ev_src)
         {}
         virtual void serializeto(GrowingBuffer &) const=0;
         virtual void serializefrom(GrowingBuffer &)=0;

--- a/Common/Messages/Auth/LoginRequest.h
+++ b/Common/Messages/Auth/LoginRequest.h
@@ -32,8 +32,8 @@ public:
     void serializeto(GrowingBuffer &buf) const override
     {
         buf.uPut(uint8_t(0));
-        buf.uPutBytes((uint8_t*)m_data.login.data(), m_data.login.size());
-        buf.uPutBytes((uint8_t*)m_data.password.data(), m_data.password.size());
+        buf.uPutBytes((uint8_t*)m_data.login.data(), (uint32_t)m_data.login.size());
+        buf.uPutBytes((uint8_t*)m_data.password.data(), (uint32_t)m_data.password.size());
         buf.uPut(m_data.unkval1);
         buf.uPut(m_data.unkval2);
         //assert(!"Not implemented");
@@ -46,8 +46,8 @@ public:
         {
             //assert(packet_code==0);
         }
-        buf.uGetBytes((uint8_t *)m_data.login.data(), m_data.login.size());
-        buf.uGetBytes((uint8_t *)m_data.password.data(), m_data.password.size());
+        buf.uGetBytes((uint8_t *)m_data.login.data(), (uint32_t)m_data.login.size());
+        buf.uGetBytes((uint8_t *)m_data.password.data(), (uint32_t)m_data.password.size());
         buf.uGet(m_data.unkval1);
         buf.uGet(m_data.unkval2);
     }

--- a/Common/Messages/Game/GameEvents.cpp
+++ b/Common/Messages/Game/GameEvents.cpp
@@ -51,7 +51,7 @@ void UpdateServer::serializeto( BitStream &tgt ) const
     tgt.StorePackedBits(1, m_build_date);
     tgt.StorePackedBits(1, 0); // flags
     tgt.StoreString(currentVersion);
-    tgt.StoreBitArray(clientInfo.data(),clientInfo.size()*8);
+    tgt.StoreBitArray(clientInfo.data(),(uint32_t)clientInfo.size()*8);
     tgt.StorePackedBits(1, authID);
     tgt.StoreBits(32, authCookie);
     tgt.StoreString(accountName);
@@ -62,7 +62,7 @@ void UpdateServer::serializefrom( BitStream &src )
     m_build_date = src.GetPackedBits(1);
     /*uint32_t t =*/ src.GetPackedBits(1);
     src.GetString(currentVersion);
-    src.GetBitArray(clientInfo.data(),clientInfo.size()*8);
+    src.GetBitArray(clientInfo.data(),(uint32_t)clientInfo.size()*8);
     authID = src.GetPackedBits(1);
     authCookie = src.GetBits(32);
     src.GetString(accountName);

--- a/Common/Messages/Map/ClueList.h
+++ b/Common/Messages/Map/ClueList.h
@@ -32,7 +32,7 @@ class ClueList final : public GameCommandEvent
     {
         bs.StorePackedBits(1, type()-evFirstServerToClient); // packet 70
 
-        bs.StorePackedBits(1, m_clue_list.size());
+        bs.StorePackedBits(1, (uint32_t)m_clue_list.size());
         for (const Clue &clue : m_clue_list)
         {
             bs.StoreString(clue.m_name);
@@ -62,7 +62,7 @@ class SouvenirListHeaders final : public GameCommandEvent
     {
         bs.StorePackedBits(1, type()-evFirstServerToClient); // packet 71
 
-        bs.StorePackedBits(1, m_souvenir_list.size());
+        bs.StorePackedBits(1, (uint32_t)m_souvenir_list.size());
         for (const Souvenir &souvenir : m_souvenir_list)
         {
             bs.StorePackedBits(1, souvenir.m_idx);

--- a/Common/Messages/Map/ContactDialogs.h
+++ b/Common/Messages/Map/ContactDialogs.h
@@ -37,7 +37,7 @@ public:
                     bs.StorePackedBits(1, type()-evFirstServerToClient); // 39
 
                     bs.StoreString(m_msgbody);
-                    bs.StorePackedBits(1, m_active_contacts.size());
+                    bs.StorePackedBits(1, (uint32_t)m_active_contacts.size());
 
                     for(const ContactEntry &contact : m_active_contacts)
                     {

--- a/Common/Messages/Map/ContactList.h
+++ b/Common/Messages/Map/ContactList.h
@@ -29,8 +29,8 @@ namespace SEGSEvents
         void serializeto(BitStream &bs) const override
         {
             bs.StorePackedBits(1, type()-evFirstServerToClient); // packet 43
-            bs.StorePackedBits(1, m_contact_list.size() - 1); // svr_contacts_total_also_maybe
-            bs.StorePackedBits(1, m_contact_list.size()); // svr_contacts_total
+            bs.StorePackedBits(1, (uint32_t)m_contact_list.size() - 1); // svr_contacts_total_also_maybe
+            bs.StorePackedBits(1, (uint32_t)m_contact_list.size()); // svr_contacts_total
 
             int count = 0;
             for(const Contact &contact : m_contact_list)

--- a/Common/Messages/Map/EmailHeaders.h
+++ b/Common/Messages/Map/EmailHeaders.h
@@ -49,7 +49,7 @@ public:
     {
         bs.StorePackedBits(1, type()-evFirstServerToClient);
         bs.StorePackedBits(1, m_fullupdate);
-        bs.StorePackedBits(1, m_emails.size());
+        bs.StorePackedBits(1, (uint32_t)m_emails.size());
 
         for(const EmailHeader &hdr : m_emails)
         {

--- a/Common/Messages/Map/SceneEvent.cpp
+++ b/Common/Messages/Map/SceneEvent.cpp
@@ -76,7 +76,7 @@ void Scene::serializefrom(BitStream &src)
     num_base_elems = src.GetPackedBits(1);
     m_crc.resize(num_base_elems);
     m_trays.resize(num_base_elems);
-    for(size_t i=1; i<num_base_elems; i++)
+    for(uint32_t i=1; i<num_base_elems; i++)
     {
         getGrpElem(src,i);
     }

--- a/Common/Messages/Map/SendVisitLocation.h
+++ b/Common/Messages/Map/SendVisitLocation.h
@@ -32,7 +32,7 @@ namespace SEGSEvents
             //Could be tied to glowies or plagues/location/early badges
             bs.StorePackedBits(1, type()-evFirstServerToClient); // packet 63
             qCDebug(logMapEvents) << "SendLocations Event serializeTo. m_locations.size(): " << m_locations.size();
-            bs.StorePackedBits(1, m_locations.size());
+            bs.StorePackedBits(1, (uint32_t)m_locations.size());
 
             for(const VisitLocation &location : m_locations)
             {

--- a/Common/Messages/Map/Shortcuts.h
+++ b/Common/Messages/Map/Shortcuts.h
@@ -39,7 +39,7 @@ explicit Shortcuts():MapLinkEvent(MapEventTypes::evShortcuts) {}
         {
             int cmd_idx = bs.GetPackedBits(1);
             assert(cmd_idx>0 && cmd_idx<200);
-            m_commands.resize(std::max<int>(m_commands.size(),cmd_idx));
+            m_commands.resize(std::max<int>((uint32_t)m_commands.size(),cmd_idx));
             bs.GetString(m_commands[cmd_idx-1]);
         }
     }

--- a/Common/Messages/Map/StoresEvents.h
+++ b/Common/Messages/Map/StoresEvents.h
@@ -30,7 +30,7 @@ namespace SEGSEvents
         {
             bs.StorePackedBits(1, type()-evFirstServerToClient); // packet 78
             bs.StorePackedBits(12, m_store.m_npc_idx);
-            bs.StorePackedBits(2, m_store.m_store_Items.size());
+            bs.StorePackedBits(2, (uint32_t)m_store.m_store_Items.size());
 
             for(const StoreItem &store_item: m_store.m_store_Items)
             {

--- a/Common/Messages/Map/Tasks.h
+++ b/Common/Messages/Map/Tasks.h
@@ -28,7 +28,7 @@ namespace SEGSEvents
         void serializeto(BitStream &bs) const override
         {
             bs.StorePackedBits(1, type()-evFirstServerToClient); // packet 45
-            bs.StorePackedBits(1, m_task_entry_list.size());
+            bs.StorePackedBits(1, (uint32_t)m_task_entry_list.size());
 
             uint32_t loop_count_2 = 0;
             for(const TaskEntry &task_entry: m_task_entry_list)
@@ -36,8 +36,8 @@ namespace SEGSEvents
 
                 bs.StorePackedBits(1, task_entry.m_db_id); // Player m_db_id?
                 bs.StoreBits(1, task_entry.m_reset_selected_task);
-                bs.StorePackedBits(1,  task_entry.m_task_list.size());
-                bs.StorePackedBits(1,  task_entry.m_task_list.size());
+                bs.StorePackedBits(1,  (uint32_t)task_entry.m_task_list.size());
+                bs.StorePackedBits(1,  (uint32_t)task_entry.m_task_list.size());
 
                 for(const Task &task : task_entry.m_task_list)
                 {

--- a/Common/Messages/Map/TeamLooking.h
+++ b/Common/Messages/Map/TeamLooking.h
@@ -24,7 +24,7 @@ public:
     std::vector<LFGMember> m_list;
     explicit TeamLooking() : GameCommandEvent(MapEventTypes::evTeamLooking) {}
     TeamLooking(const std::vector<LFGMember> &list) : GameCommandEvent(MapEventTypes::evTeamLooking),
-        m_num(list.size()),
+        m_num((uint32_t)list.size()),
         m_list(list)
     {
     }

--- a/Common/Messages/Map/TradeUpdate.cpp
+++ b/Common/Messages/Map/TradeUpdate.cpp
@@ -95,8 +95,8 @@ void TradeUpdate::serializeto(BitStream& bs) const {
     bs.StorePackedBits(1, info_self.m_influence);
     bs.StorePackedBits(1, info_other.m_influence);
 
-    bs.StorePackedBits(1, info_other.m_enhancements.size());
-    bs.StorePackedBits(1, info_other.m_inspirations.size());
+    bs.StorePackedBits(1, (uint32_t)info_other.m_enhancements.size());
+    bs.StorePackedBits(1, (uint32_t)info_other.m_inspirations.size());
 
     for (const CharacterEnhancement& enh : m_enhancements)
     {

--- a/Common/Messages/Map/VisitMapCells.h
+++ b/Common/Messages/Map/VisitMapCells.h
@@ -31,7 +31,7 @@ public:
         bs.StorePackedBits(1, type() - evFirstServerToClient); // Packet 22
         bs.StorePackedBits(1, 1);
         bs.StoreBits(1, m_is_opaque);
-        uint32_t num_cells = m_visible_map_cells.size();
+        uint32_t num_cells = (uint32_t)m_visible_map_cells.size();
         bs.StorePackedBits(1, num_cells);
 
         std::vector<uint8_t> cells_arr;

--- a/Common/Runtime/HandleBasedStorage.h
+++ b/Common/Runtime/HandleBasedStorage.h
@@ -102,7 +102,7 @@ private:
         if(m_free_list_head != HType::FREE_LIST_TERMINATOR)
             return m_free_list_head;
         //NOTE: we allocate 256 new 'nodes' each time
-        uint32_t start_idx = m_sparse_array.size();
+        uint32_t start_idx = (uint32_t)m_sparse_array.size();
         assert(start_idx + 256 < HType::FREE_LIST_TERMINATOR);
         m_free_list_head = start_idx;
         m_sparse_array.resize(start_idx + 256);

--- a/Common/Runtime/SceneGraph.cpp
+++ b/Common/Runtime/SceneGraph.cpp
@@ -200,14 +200,14 @@ QByteArray mapNameToPath(const QByteArray &name,LoadingContext &ctx)
 
 RootNode *newRef(SceneGraph &scene)
 {
-    size_t idx;
-    for(idx=0; idx<scene.roots.size(); ++idx)
+    uint32_t idx;
+    for(idx=0; idx<(uint32_t)scene.roots.size(); ++idx)
         if(!scene.roots[idx])
             break;
 
-    if(idx>=scene.roots.size())
+    if(idx>=(uint32_t)scene.roots.size())
     {
-        idx = scene.roots.size();
+        idx = (uint32_t)scene.roots.size();
         scene.roots.emplace_back();
     }
 
@@ -253,7 +253,7 @@ void addRoot(const SceneRootNode_Data &refload, LoadingContext &ctx, PrefabStore
 SceneNode *newDef(SceneGraph &scene,int level)
 {
     SceneNode *res = new SceneNode(level);
-    res->m_index_in_scenegraph = scene.all_converted_defs.size();
+    res->m_index_in_scenegraph = (uint32_t)scene.all_converted_defs.size();
     scene.all_converted_defs.emplace_back(res);
     res->in_use = true;
     return res;
@@ -262,7 +262,7 @@ SceneNode *newDef(SceneGraph &scene,int level)
 void setNodeNameAndPath(SceneGraph &scene,SceneNode *node, QString obj_path)
 {
     QString result;
-    size_t strlenobjec = strlen("object_library");
+    const uint32_t strlenobjec = (uint32_t)strlen("object_library");
     if( obj_path.startsWith("object_library", Qt::CaseInsensitive) )
         obj_path.remove(0, strlenobjec + 1);
     if( groupInLibSub(obj_path) )
@@ -322,7 +322,7 @@ void addChildNodes(const SceneGraphNode_Data &inp_data, SceneNode *node, Loading
                 qDebug() << "Cannot find the source for requested:"<<new_name;
                 continue;
             }
-            int child_idx = node->m_children.size();
+            int child_idx = (int)node->m_children.size();
             node->m_children.emplace_back(child);
             ctx.m_target->node_request_instantiation(NodeLoadTarget{node,child_idx},request);
         }
@@ -578,12 +578,14 @@ void  groupApplyModifiers(SceneNode *node)
 
     if(mods->LodNear != 0.0f || mods->LodFar != 0.0f || mods->LodNearFade != 0.0f || mods->LodFarFade != 0.0f || mods->LodScale != 0.0f)
         node->lod_fromtrick = 1;
+#ifdef WIP
     if( mods->node._TrickFlags & NoColl )
         ; //TODO: disable collisions for this node
     if( mods->node._TrickFlags & SelectOnly )
         ; // set the model's triangles as only selectable ?? ( selection mesh ? )
     if( mods->node._TrickFlags & NotSelectable )
         ; //
+#endif
 }
 bool addNode(const SceneGraphNode_Data &defload, LoadingContext &ctx,PrefabStore &prefabs)
 {

--- a/Common/Runtime/Sequencer.cpp
+++ b/Common/Runtime/Sequencer.cpp
@@ -1003,7 +1003,7 @@ int seqProcessClientInst(HSequencerInstance seq, float step_size, int idx, bool 
     float          adv = getAnimScaleFromSeq(seq) * step_size;
     if (changed)
     {
-        num_moves_in_arr = tpl->m_Move.size();
+        num_moves_in_arr = (int)tpl->m_Move.size();
         if (idx >= num_moves_in_arr)
             idx = 0;
         move  = &tpl->m_Move[idx];

--- a/Common/Servers/MessageBus.cpp
+++ b/Common/Servers/MessageBus.cpp
@@ -29,7 +29,7 @@ namespace
 
     void removeEndpointFromUnorderedVector(std::vector<MessageBusEndpoint *> &vec,const MessageBusEndpoint *to_remove)
     {
-        for(int i=0,total=vec.size(); i<total; ++i)
+        for(int i=0,total=(int)vec.size(); i<total; ++i)
         {
             if(vec[i]==to_remove)
             {

--- a/Components/BitStream.cpp
+++ b/Components/BitStream.cpp
@@ -36,7 +36,7 @@ Function:   BitStream
 Description: BitStream's main constructor, initializes various internal
 values and buffers
 ************************************************************************/
-BitStream::BitStream(size_t size) : GrowingBuffer(0xFFFFFFFF,7,size)
+BitStream::BitStream(uint32_t size) : GrowingBuffer(0xFFFFFFFF,7,size)
 {
     m_byteAligned    = false;
     ResetOffsets();
@@ -62,7 +62,7 @@ Function:     BitStream
 Description: BitStream's constructor, initializes various internal
                          values and buffers
 ************************************************************************/
-BitStream::BitStream(uint8_t *arr,size_t size) : GrowingBuffer(arr,size,false)
+BitStream::BitStream(uint8_t *arr, uint32_t size) : GrowingBuffer(arr,size,false)
 {
     m_byteAligned   = false;
     m_read_bit_off  = 0;
@@ -117,7 +117,7 @@ void BitStream::StoreBits(uint32_t nBits, uint32_t dataBits)
 
     if(nBits>GetWritableBits())
     {
-        size_t new_size = m_size+(nBits>>3);
+        uint32_t new_size = m_size+(nBits>>3);
         // growing to accommodate !
         if(resize(new_size+7)==-1)
         {
@@ -180,9 +180,9 @@ void BitStream::StorePackedBits(uint32_t nBits, uint32_t dataBits)
  * @param src
  * @param nBits
  */
-void BitStream::StoreBitArray(const uint8_t *src,size_t nBits)
+void BitStream::StoreBitArray(const uint8_t *src, uint32_t nBits)
 {
-    size_t nBytes = BITS_TO_BYTES(nBits);
+    uint32_t nBytes = BITS_TO_BYTES(nBits);
     assert(src);
     ByteAlign(false,true);
     PutBytes(src,nBytes);
@@ -213,7 +213,7 @@ void BitStream::StoreString(const char *str)
         PutString(str);
         return;
     }
-    size_t len = strlen(str)+1;
+    uint32_t len = (uint32_t)strlen(str)+1;
     uint32_t idx;
     uint8_t rshift = 8-m_write_bit_off;
     if(len>GetAvailSize())
@@ -435,7 +435,7 @@ void BitStream::ByteAlign( bool read_part,bool write_part )
 
 void BitStream::CompressAndStoreString(const char *str)
 {
-    uint32_t decompLen = strlen(str) + 1;
+    uint32_t decompLen = (uint32_t)strlen(str) + 1;
     QByteArray ba = qCompress(reinterpret_cast<const uint8_t *>(str),decompLen,5);
     ba.remove(0,sizeof(uint32_t)); // qt includes uncompressed size as a first 4 bytes of QByteArray
     uint32_t len = ba.size();

--- a/Components/BitStream.h
+++ b/Components/BitStream.h
@@ -40,8 +40,8 @@ class BitStream : public GrowingBuffer
 
 public:
 
-explicit        BitStream(size_t size);
-                BitStream(uint8_t *from,size_t bitsize);
+explicit        BitStream(uint32_t size);
+                BitStream(uint8_t *from,uint32_t bitsize);
                 BitStream(const BitStream &bs);
                 BitStream(BitStream &&bs) noexcept : GrowingBuffer(std::move(bs)) {
                     m_read_bit_off = bs.m_read_bit_off;
@@ -66,7 +66,7 @@ explicit        BitStream(size_t size);
             }
             StoreBits(bits_to_store,src.uGetBits(bits_to_store));
         }
-        void    StoreBitArray(const uint8_t *array,size_t nBits);
+        void    StoreBitArray(const uint8_t *array,uint32_t nBits);
         void    StoreString(const char *str);
         void    StoreString(const QByteArray &str);
         void    StoreString(const QString &str);

--- a/Servers/GameServer/FriendshipService/FriendHandler.cpp
+++ b/Servers/GameServer/FriendshipService/FriendHandler.cpp
@@ -161,7 +161,7 @@ void on_friend_removed(FriendHandlerState &state,FriendRemovedMessage *msg)
     if(list->m_friends.empty())
         list->m_has_friends = false;
 
-    list->m_friends_count = list->m_friends.size();
+    list->m_friends_count = (uint32_t)list->m_friends.size();
     send_update_friends_list(state,msg->m_data.m_char_db_id);
 }
 } // end of anonymous namespace.

--- a/Servers/GameServer/GameEventFactory.cpp
+++ b/Servers/GameServer/GameEventFactory.cpp
@@ -17,7 +17,7 @@ using namespace SEGSEvents;
 
 GameLinkEvent *GameEventFactory::EventFromStream(BitStream &bs)
 {
-    size_t read_pos = bs.GetReadPos();
+    uint32_t read_pos = bs.GetReadPos();
     //size_t bits_avail = bs.GetReadableBits();
     GameLinkEvent *ev = CRUD_EventFactory::EventFromStream(bs);
     if(ev) // base class created the event

--- a/Servers/GameServer/TeamService/TeamHandler.cpp
+++ b/Servers/GameServer/TeamService/TeamHandler.cpp
@@ -114,7 +114,7 @@ bool TeamHandler::db_id_is_lfg(const uint32_t db_id)
 
 void TeamHandler::add_lfg(LFGMember m)
 {
-	m_state.m_lfg_list.emplace_back(m);
+    m_state.m_lfg_list.emplace_back(std::move(m));
 }
 
 void TeamHandler::remove_lfg(const uint32_t db_id)
@@ -154,8 +154,10 @@ Team* TeamHandler::team_for_name(const QString &name)
 uint32_t TeamHandler::id_for_name(const QString &name)
 {
     for (const auto &e : m_state.m_id_to_name)
+    {
         if (e.second == name)
             return e.first;
+    }
 
     qCCritical(logTeams) << "Couldn't find id for name:" << name;
 
@@ -165,8 +167,10 @@ uint32_t TeamHandler::id_for_name(const QString &name)
 bool TeamHandler::name_known(const QString &name)
 {
     for (const auto &e : m_state.m_id_to_name)
+    {
         if (e.second == name)
             return true;
+    }
 
     return false;
 }

--- a/Servers/MapServer/DataHelpers.cpp
+++ b/Servers/MapServer/DataHelpers.cpp
@@ -1542,7 +1542,7 @@ void sendUpdateTaskStatusList(MapClientSession &src, Task task)
     if(!found)
     {
         qCDebug(logScripts) << "SendUpdateTaskStatusList Creating new task";
-        uint32_t listSize = task_entry_list.size();
+        uint32_t listSize = (uint32_t)task_entry_list.size();
         if(task_entry_list.size() > 0)
         {
             qCDebug(logScripts) << "SendUpdateTaskStatusList task list not empty";

--- a/Servers/MapServer/EntityStorage.cpp
+++ b/Servers/MapServer/EntityStorage.cpp
@@ -93,7 +93,7 @@ void EntityManager::sendDeletes( BitStream &tgt,MapClientSession &client ) const
         if(m_live_entlist.end()==m_live_entlist.find((Entity *)entry.second.m_entity))
             entities_to_remove.push_back(entry.first);
     }
-    tgt.StorePackedBits(1,entities_to_remove.size());
+    tgt.StorePackedBits(1,(uint32_t)entities_to_remove.size());
     for(int idx : entities_to_remove)
     {
         tgt.StorePackedBits(12,idx);//index

--- a/Servers/MapServer/EntityUpdateCodec.cpp
+++ b/Servers/MapServer/EntityUpdateCodec.cpp
@@ -197,7 +197,7 @@ void sendSeqTriggeredMoves(const Entity &src,BitStream &bs)
         qCDebug(logAnimations, "Sending seq triggered moves %" PRIu64, src.m_triggered_moves.size());
 
     // client appears to process only the last 20 triggered moves
-    bs.StorePackedBits(1, src.m_triggered_moves.size()); // num moves
+    bs.StorePackedBits(1, (uint32_t)src.m_triggered_moves.size()); // num moves
     for(const TriggeredMove &move : src.m_triggered_moves)
     {
         bs.StorePackedBits(10, move.m_move_idx);                   // 2  triggeredMoveIDX
@@ -208,7 +208,7 @@ void sendSeqTriggeredMoves(const Entity &src,BitStream &bs)
 
 void sendNetFx(const Entity &src, BitStream &bs)
 {
-    bs.StorePackedBits(1, src.m_net_fx.size()); // num fx
+    bs.StorePackedBits(1, (uint32_t)src.m_net_fx.size()); // num fx
     for(NetFxHandle fxh : src.m_net_fx)
     {
         const NetFx &fx(lookup(fxh));
@@ -403,7 +403,7 @@ void sendLogoutUpdate(const Entity &src,ClientEntityStateBelief &belief,BitStrea
 } // end of anonoymous namespace
 void sendBuffs(const Entity &src, BitStream &bs)
 {
-    bs.StorePackedBits(5, src.m_buffs.size());
+    bs.StorePackedBits(5, (uint32_t)src.m_buffs.size());
     for(const Buffs &buff : src.m_buffs)
         buff.m_buff_info.serializeto(bs);
 }

--- a/Servers/MapServer/MapEventFactory.cpp
+++ b/Servers/MapServer/MapEventFactory.cpp
@@ -23,7 +23,7 @@ using namespace SEGSEvents;
 
 MapLinkEvent *MapEventFactory::EventFromStream(BitStream &bs)
 {
-    size_t read_pos = bs.GetReadPos();
+    uint32_t read_pos = bs.GetReadPos();
 
     MapLinkEvent *ev = CRUD_EventFactory::EventFromStream(bs);
     if(ev) // base class created the event

--- a/Servers/MapServer/MessageHelpers.cpp
+++ b/Servers/MapServer/MessageHelpers.cpp
@@ -217,7 +217,7 @@ void storeTeamList(BitStream &bs, Entity *self)
         team_idx        = self->m_team->m_data.m_team_idx;
         has_taskforce   = self->m_team->m_data.m_has_taskforce;
         tm_leader_id    = self->m_team->m_data.m_team_leader_idx;
-        tm_size         = self->m_team->m_data.m_team_members.size();
+        tm_size         = (uint32_t)self->m_team->m_data.m_team_members.size();
     }
 
     storePackedBitsConditional(bs,20,team_idx);
@@ -321,7 +321,7 @@ static void sendTrayMode(const GUISettings &gui, BitStream &bs)
 static void sendKeybinds(const KeybindSettings &keybinds,BitStream &bs)
 {
     const CurrentKeybinds &cur_keybinds = keybinds.getCurrentKeybinds();
-    int total_keybinds = cur_keybinds.size();
+    int total_keybinds = (int)cur_keybinds.size();
 
     qCDebug(logKeybinds) << "total keybinds:" << total_keybinds;
 
@@ -527,7 +527,7 @@ void storePowerInfoUpdate(BitStream &bs,Entity *e)
             if(power.m_total_eh_slots > power.m_enhancements.size())
                 qCWarning(logPowers) << "storePowerInfoUpdate: Total EH Slots larger than vector!";
 
-            bs.StorePackedBits(4, power.m_enhancements.size()); // power.m_total_eh_slots; total owned enhancement slots
+            bs.StorePackedBits(4, (uint32_t)power.m_enhancements.size()); // power.m_total_eh_slots; total owned enhancement slots
             for(const auto & enhancement : power.m_enhancements)
             {
                 qCDebug(logPowers) << "  Enhancement:" << enhancement.m_name
@@ -574,7 +574,7 @@ void storePowerInfoUpdate(BitStream &bs,Entity *e)
             rpow_idx++;
     }
     qCDebug(logPowers) << "NumRechargingTimers:" << e->m_recharging_powers.size();
-    bs.StorePackedBits(1, e->m_recharging_powers.size());
+    bs.StorePackedBits(1, (uint32_t)e->m_recharging_powers.size());
     for(const QueuedPowers &rpow : e->m_recharging_powers)
     {
         qCDebug(logPowers) << "  RechargeCountdown:" << rpow.m_timer_updated << rpow.m_recharge_time;
@@ -611,7 +611,7 @@ void storePowerInfoUpdate(BitStream &bs,Entity *e)
     // All Owned Enhancements
     qCDebug(logPowers) << "Enhancement Slots:" << cd->m_enhancements.size();
 
-    bs.StorePackedBits(1, cd->m_enhancements.size());
+    bs.StorePackedBits(1, (uint32_t)cd->m_enhancements.size());
     for(CharacterEnhancement &eh : cd->m_enhancements)
     {
         if(cd->m_enhancements.empty() || eh.m_name.isEmpty())

--- a/Servers/MapServer/NetCommandManager.cpp
+++ b/Servers/MapServer/NetCommandManager.cpp
@@ -140,7 +140,7 @@ void NetCommandManager::UpdateCommandShortcuts(MapClientSession *client, std::ve
     // add shortcuts to client's shortcut map.
     //TODO: differentiate the commands based on access level ?
     commands.reserve(m_commands_level0.size());
-    for(size_t i=0, total = m_commands_level0.size(); i<total; ++i)
+    for(uint32_t i=0, total = (uint32_t)m_commands_level0.size(); i<total; ++i)
     {
         client->AddShortcut(i,m_commands_level0[i]);
         commands.push_back(m_commands_level0[i]->m_name);

--- a/Servers/MapServer/ScriptingEngine/ScriptingEngine_SpawnerTypes.cpp
+++ b/Servers/MapServer/ScriptingEngine/ScriptingEngine_SpawnerTypes.cpp
@@ -28,7 +28,7 @@ void ScriptingEngine::register_SpawnerTypes()
     m_private->m_lua["MapInstance"]["GetSpawnerCount"] = [this]()
     {
         auto sg = &mi->m_map_scenegraph->m_csNodes;
-        uint sCount = sg->size();
+        uint32_t sCount = (uint32_t)sg->size();
         return sCount;
     };
 
@@ -36,7 +36,7 @@ void ScriptingEngine::register_SpawnerTypes()
     m_private->m_lua["MapInstance"]["GetSpawnerChildCount"] = [this](uint index)
     {
         auto sg = &mi->m_map_scenegraph->m_csNodes;
-        uint sChildCount = sg->at(index).m_markers.size();
+        uint32_t sChildCount = (uint32_t)sg->at(index).m_markers.size();
         return sChildCount;
     };
 
@@ -92,7 +92,7 @@ void ScriptingEngine::register_SpawnerTypes()
     m_private->m_lua["MapInstance"]["GetPersistentCount"] = [this]()
     {
         auto sg = &mi->m_map_scenegraph->m_persNodes;
-        uint pCount = sg->size();
+        uint32_t pCount = (uint32_t)sg->size();
         return pCount;
     };
 
@@ -138,7 +138,7 @@ void ScriptingEngine::register_SpawnerTypes()
     m_private->m_lua["MapInstance"]["GetCarCount"] = [this]()
     {
         auto sg = &mi->m_map_scenegraph->m_carNodes;
-        uint cCount = sg->size();
+        uint32_t cCount = (uint32_t)sg->size();
         return cCount;
     };
 
@@ -162,7 +162,7 @@ void ScriptingEngine::register_SpawnerTypes()
     m_private->m_lua["MapInstance"]["GetCivCount"] = [this]()
     {
         auto sg = &mi->m_map_scenegraph->m_npcNodes;
-        uint nCount = sg->size();
+        uint32_t nCount = (uint32_t)sg->size();
         return nCount;
     };
 

--- a/Servers/MapServer/SlashCommands/SlashCommand_Teams.cpp
+++ b/Servers/MapServer/SlashCommands/SlashCommand_Teams.cpp
@@ -151,7 +151,7 @@ void cmdHandler_Sidekick(const QStringList &params, MapClientSession &sess)
         return;
 
     auto res=inviteSidekick(*sess.m_ent, *tgt);
-    static const QLatin1Literal possible_messages[] = {
+    static const QLatin1String possible_messages[] = {
         QLatin1String("Unable to add sidekick."),
         QLatin1String("To Mentor another player, you must be at least 3 levels higher than them."),
         QLatin1String("To Mentor another player, you must be at least level 10."),

--- a/Utilities/TextureConverter/main.cpp
+++ b/Utilities/TextureConverter/main.cpp
@@ -65,7 +65,7 @@ QString saveTo(const CohTextureInfo &tgt)
         input_arc(cereal::make_nvp("CohTextureInfo",tgt));
     }
     catch(std::runtime_error &e) {
-        qDebug() << "Exception throw while reading scenedef";
+        qDebug() << "Exception throw while reading scenedef:"<<e.what();
         return "";
     }
     return QString::fromStdString(str_dat.str());

--- a/Utilities/slav/CMakeLists.txt
+++ b/Utilities/slav/CMakeLists.txt
@@ -6,14 +6,12 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
 set(SLAV_SOURCES
-    SLAVLogic
-    ServerConnection
-    UpdaterDlg.cpp
-    UpdaterDlg.h
-    UpdaterDlg.ui
-    ProjectDescriptor
-    ProjectManifest
-    FileSignatureWorker
+    SLAVLogic.cpp SLAVLogic.h
+    ServerConnection.cpp ServerConnection.h
+    UpdaterDlg.cpp UpdaterDlg.h UpdaterDlg.ui
+    ProjectDescriptor.cpp ProjectDescriptor.h
+    ProjectManifest.cpp ProjectManifest.h
+    FileSignatureWorker.cpp FileSignatureWorker.h
     main.cpp
 )
 

--- a/Utilities/slav/FileSignatureWorker.cpp
+++ b/Utilities/slav/FileSignatureWorker.cpp
@@ -26,7 +26,7 @@ void FileSignatureWorker::process()
     {
       float prev_percentage=-1.0f;
       int current_idx=0;
-      int count = m_manifest->m_files.size();
+      int count = (int)m_manifest->m_files.size();
       for(auto &fileentry : m_manifest->m_files) {
           QCryptographicHash crypto(QCryptographicHash::Sha1);
           QFile file(fileentry.m_relativePath);


### PR DESCRIPTION
## Summary
1. Wanted to see what MSVC2022 thinks about the codebase, so compiled it in the default configuration.
2. Enabled 3rd level of warnings
3. Fixed most of them ( used a recent qt5, but skipped fixing deprecated functionality from there, until the required qt version is changed )


